### PR TITLE
reduced :visit_count to prevent SQLite3::SQLException: too many terms in...

### DIFF
--- a/spec/controllers/service_requests_controller_spec.rb
+++ b/spec/controllers/service_requests_controller_spec.rb
@@ -391,7 +391,7 @@ describe ServiceRequestsController do
     let!(:one_time_fee_line_item) { FactoryGirl.create(:line_item, service_id: service.id, service_request_id: service_request.id) }
 
     it "should set the page if page is passed in" do
-      arm1.update_attribute(:visit_count, 500)
+      arm1.update_attribute(:visit_count, 200)
 
       session[:service_request_id] = service_request.id
       get :service_calendar, { :id => service_request.id, :pages => { arm1.id.to_s => 42 } }.with_indifferent_access


### PR DESCRIPTION
... compound SELECT

1) ServiceRequestsController GET service_calendar should set the page if page is passed in
     Failure/Error: get :service_calendar, { :id => service_request.id, :pages => { arm1.id.to_s => 42 } }.with_indifferent_access
     ActiveRecord::StatementInvalid:
       SQLite3::SQLException: too many terms in compound SELECT: INSERT INTO visits (`line_items_visit_id`, `visit_group_id`, `created_at`, `updated_at`) VALUES (1, 16, '2014-09-17 19:25:30', '2014-09-17 19:25:30'),
