### PR TITLE
added SRID to the notification message display

### DIFF
--- a/app/assets/stylesheets/portal/layout.css.sass
+++ b/app/assets/stylesheets/portal/layout.css.sass
@@ -466,11 +466,13 @@ div.rsr_dialog
     th
       text-align: left
     td
-      padding: 20px 0
+      padding: 10px 0
     td.sender div
-      width: 130px
+      width: 90px
+    td.srid div
+      width: 50px
     td.subject div
-      width: 170px
+      width: 160px
     .image_placeholder
       padding: 0px
       div

--- a/app/views/portal/home/_user_information.html.haml
+++ b/app/views/portal/home/_user_information.html.haml
@@ -34,6 +34,7 @@
       %thead
         %tr
           %th
+          %th SRID:
           %th From:
           %th Subject:
           %th Time:
@@ -42,6 +43,8 @@
           %tr{:'data-notification_id' => notification.id, :'data-sub_service_request_id' => @sub_service_request.try(:id), :class => notification.try(:user_notifications_for_current_user, @user).try(:last).try(:read) ? "read_notification" : "unread_notification"}
             %td.image_placeholder
               %div
+            %td.srid
+              %div= notification.sub_service_request.display_id
             %td.sender
               %div= notification.try(:messages).try(:last).try(:sender).try(:full_name)
             %td.subject

--- a/app/views/portal/notifications/_notifications.html.haml
+++ b/app/views/portal/notifications/_notifications.html.haml
@@ -35,6 +35,7 @@
           %tr
             %th.notification_icon
             %th.from_column= t(:notifications)[:from]
+            %th.srid_column= t(:notifications)[:srid]
             %th.subject_column= t(:notifications)[:about]
             %th.body_column= t(:notifications)[:preview]
             %th.received_column= t(:notifications)[:received]
@@ -48,6 +49,7 @@
                 - else
                   = image_tag("portal/notification_red_small.png")
               %td.from_column{:'data-notification_id' => notification.id, :'data-sub_service_request_id' => @sub_service_request.try(:id)}= notification.try(:messages).try(:last).try(:sender).try(:full_name)
+              %td.subject_column{:'data-notification_id' => notification.id, :'data-sub_service_request_id' => @sub_service_request.try(:id)}= notification.sub_service_request.display_id
               %td.subject_column{:'data-notification_id' => notification.id, :'data-sub_service_request_id' => @sub_service_request.try(:id)}= notification.try(:messages).try(:last).try(:subject)
               %td.body_column{:'data-notification_id' => notification.id, :'data-sub_service_request_id' => @sub_service_request.try(:id)}= notification.try(:messages).try(:last).try(:body)
               %td.received_column{:'data-notification_id' => notification.id, :'data-sub_service_request_id' => @sub_service_request.try(:id)}= received_at(notification)

--- a/app/views/portal/notifications/_show_notification.html.haml
+++ b/app/views/portal/notifications/_show_notification.html.haml
@@ -19,6 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .notifications{:style => 'border-right:0px;'}
+  %strong="SRID: " + @notification.sub_service_request.display_id
   %ul.message-list{:style => 'list-style:none;margin-top:5px'}
     - @notification.messages.each_with_index do |message, i|
       - style_class = i == 0 ? 'first_message' : ''

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -791,6 +791,7 @@ en:
     ask_a_question_email: "Enter Your Email"
     ask_a_question_email_error: "Valid email address required."
     ask_a_question: "Please ask your question here"
+    srid: "SRID:"
 
   # Mailer
   mailer:


### PR DESCRIPTION
This commit includes changes made to notification screens/popups on dashboard to display the SRID.

Currently, Notifications only display From, Subject (Preview), and Time of the message. It is somewhat difficult to tell which study and service the message is about without the reference of the Service Request ID
especially when an investigator has multiple studies and service requests to the same provider.
