### PR TITLE
fixing Dashboard authorized user bugs

### DIFF
--- a/app/views/portal/associated_users/_form.html.haml
+++ b/app/views/portal/associated_users/_form.html.haml
@@ -45,7 +45,7 @@
         %strong
           = label_tag "identity[phone]", t(:portal_user_form)[:phone]
         %br
-        = text_field_tag "identity[phone]", identity.phone
+        = text_field_tag "identity[phone]", identity.phone, {:disabled => true}
         %br
       .user_role
         %strong


### PR DESCRIPTION
Fixed the following bugs on Dashboard Authorized User popup:
1. user's Phone textbox was disabled 
2. Incorrect Subspecialty dropdown label and missing the 'Select a Subspecialty' default selection. 
