### PR TITLE
fixing dashboard user credential dropdown select

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,7 +674,7 @@ en:
     role_prompt: "Select a Role"
     era: "ERA Commons Name:"
     credentials: "Credentials:"
-    credentials_prompt: "Select a Credential"
+    credential_prompt: "Select a Credential"
     institution: "Institution:"
     institution_prompt: "Select an Institution"
     college: "College:"


### PR DESCRIPTION
missing 'Select a Credential' default value from Credentials dropdown - Portal Add/Edit an Authorized User