### PR TITLE
portal bug due to orphaned notificaitons

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -25,7 +25,7 @@ class Notification < ActiveRecord::Base
   belongs_to :sub_service_request
 
   has_many :messages
-  has_many :user_notifications
+  has_many :user_notifications, :dependent => :destroy
 
   attr_accessible :sub_service_request_id
   attr_accessible :originator_id

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -35,6 +35,7 @@ class SubServiceRequest < ActiveRecord::Base
   has_many :cover_letters, :dependent => :destroy
   has_one :subsidy, :dependent => :destroy
   has_many :reports, :dependent => :destroy
+  has_many :notification, :dependent => :destroy
 
   # These two ids together form a unique id for the sub service request
   attr_accessible :service_request_id


### PR DESCRIPTION
null reference exception occurs on portal page when a service request with notifications was  deleted. 