### PR TITLE
created configuration parameter to hide non-shibboleth registration and ...

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -24,35 +24,37 @@
       .info
         .center
           = link_to t(:signin)[:button1], identity_omniauth_authorize_path(:shibboleth), :class => 'blue-button devise_option_button btn btn-primary'
-  .clear
-  .sign_in_options
-    %br
-    \- OR -
-    %br
-    %br
-  .clear
-  .grid_6.prefix_3.suffix_3.box.sign_in_selection
-    .info
-      .center
-        = link_to t(:signin)[:button2], "javascript:void(0);", :class => 'toggle_outside_user_sign_in blue-button devise_option_button btn btn-primary'
+  - if USE_SHIBOLETH && !USE_SHIBBOLETH_ONLY
+    .clear
+    .sign_in_options
+      %br
+      \- OR -
+      %br
+      %br
+    .clear
+  - if !USE_SHIBBOLETH_ONLY
+    .grid_6.prefix_3.suffix_3.box.sign_in_selection
+      .info
+        .center
+          = link_to t(:signin)[:button2], "javascript:void(0);", :class => 'toggle_outside_user_sign_in blue-button devise_option_button btn btn-primary'
 
-      #outside_sign_in_form
-        = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
-          .field
-            = f.label(:ldap_uid, t(:login_name))
-            = f.text_field :ldap_uid, :size => '30', :style => 'width:auto'
-          .field
-            = f.label(:password, t(:login_password))
-            = f.password_field :password
-          - if devise_mapping.rememberable?
+        #outside_sign_in_form
+          = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
             .field
-              = f.label(:remember_me, t(:remember_user))
-              = f.check_box :remember_me
+              = f.label(:ldap_uid, t(:login_name))
+              = f.text_field :ldap_uid, :size => '30', :style => 'width:auto'
+            .field
+              = f.label(:password, t(:login_password))
+              = f.password_field :password
+            - if devise_mapping.rememberable?
+              .field
+                = f.label(:remember_me, t(:remember_user))
+                = f.check_box :remember_me
+            .clear
+            #button
+              = f.submit t(:signin)[:button3], :class => 'blue-button devise_submit_button btn btn-primary'
+              = link_to t(:devise)[:cancel], catalog_service_request_path(@service_request), :class => 'blue-button devise_cancel_button btn btn-primary'
           .clear
-          #button
-            = f.submit t(:signin)[:button3], :class => 'blue-button devise_submit_button btn btn-primary'
-            = link_to t(:devise)[:cancel], catalog_service_request_path(@service_request), :class => 'blue-button devise_cancel_button btn btn-primary'
-        .clear
-        .links
-          = render "devise/shared/links"
-        %br
+          .links
+            = render "devise/shared/links"
+          %br

--- a/app/views/service_requests/_catalog.html.haml
+++ b/app/views/service_requests/_catalog.html.haml
@@ -35,8 +35,9 @@
     = render :partial => 'catalogs/news_and_events'
 
 .grid_3.catalog-view-right.right.col-md-3
-  #account.create_new_account
-    = link_to(image_tag("/assets/#{CUSTOM_ASSET_PATH}account.png", width: '196'), new_identity_registration_path)
+  - if !USE_SHIBBOLETH_ONLY
+    #account.create_new_account
+      = link_to(image_tag("/assets/#{CUSTOM_ASSET_PATH}account.png", width: '196'), new_identity_registration_path)
   #services.ui-widget.ui-widget-content.cart-view
     %h3
       = t(:service_requests)[:catalog][:text1]

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -31,6 +31,7 @@ development:
   header_link_3: http://www.musc.edu
   use_indirect_cost: false
   use_shiboleth: true
+  use_shibboleth_only: false # set to true to turn off database authentication sign in options
   use_ldap: true
   wkhtmltopdf_location: '/usr/local/bin/wkhtmltopdf'
   approve_epic_rights_mail_to: "glennj@musc.edu, forney@musc.edu, crossoml@musc.edu"
@@ -64,6 +65,7 @@ test:
   header_link_3: http://www.musc.edu
   use_indirect_cost: false
   use_shiboleth: true
+  use_shibboleth_only: false # set to true to turn off database authentication sign in options
   use_ldap: true
   wkhtmltopdf_location: '/usr/local/bin/wkhtmltopdf'
   approve_epic_rights_mail_to: "glennj@musc.edu, forney@musc.edu, crossoml@musc.edu"

--- a/config/initializers/obis_setup.rb
+++ b/config/initializers/obis_setup.rb
@@ -34,6 +34,7 @@ begin
   HEADER_LINK_3                 = application_config['header_link_3']
   USE_INDIRECT_COST             = application_config['use_indirect_cost']
   USE_SHIBOLETH                 = application_config['use_shiboleth']
+  USE_SHIBBOLETH_ONLY           = application_config['use_shibboleth_only']
   USE_LDAP                      = application_config['use_ldap']
   USE_EPIC                      = application_config['use_epic']
   QUEUE_EPIC                    = application_config['queue_epic']


### PR DESCRIPTION
...sign-in. The USE_SHIBBOLETH_ONLY configuration parameter is optional and, thus, if it is not set then the database registration and sign in will continue to work as it currently does.