### PR TITLE
suppress hidden field for is_one_time_fee when its value is true

### DIFF
--- a/app/views/catalog_manager/services/_pricing_map.html.haml
+++ b/app/views/catalog_manager/services/_pricing_map.html.haml
@@ -95,7 +95,7 @@
         %tr.otf
           %th= t(:pricing_map_form)[:is_one_time_fee]
           %td.is_one_time_fee{colspan: 2}
-            = hidden_field_tag "pricing_maps[#{pricing_map.try(:[], 'id') || 'blank_pricing_map'}][is_one_time_fee]", 0
+            = hidden_field_tag "pricing_maps[#{pricing_map.try(:[], 'id') || 'blank_pricing_map'}][is_one_time_fee]", 0 unless pricing_map.try(:[], 'is_one_time_fee')
             = check_box_tag "pricing_maps[#{pricing_map.try(:[], 'id') || 'blank_pricing_map'}][is_one_time_fee]", true, pricing_map.try(:[], 'is_one_time_fee'), :disabled => pricing_map_disabled, :readonly => pricing_map_disabled, :class => 'otf_checkbox', :'data-pricing_map_id' => pricing_map.try(:id), :'data-pricing_map_clinical_quantity_type' => pricing_map.try(:unit_type), :id => "otf_checkbox_#{pricing_map.try(:id)}"
         %table{:style => pricing_map.try(:is_one_time_fee) ? "" : "display:none;", :id => "otf_fields_#{pricing_map.try(:id)}"}
           %tbody


### PR DESCRIPTION
Since last Fall in all of our environments, a service with Pricing Maps that have is_one_time_fee = true has them set to false on any "Save" call within Catalog manager for that service. The issue appears to be that a hidden field with a value of 0 is always present whereas the disabled checkbox's "true" value is not present:
http://stackoverflow.com/questions/7730695/whats-the-difference-between-disabled-disabled-and-readonly-readonly-for-ht

Since, readonly checkboxes won't work for us in this scenario: http://stackoverflow.com/questions/155291/can-html-checkboxes-be-set-to-readonly?page=1&tab=votes#tab-top , I've removed the hidden field when is_one_time_fee = true.

Please let me know if this fix (for us) causes issues for your institution.