### PR TITLE
fixing get a quote welcom text in notification to service providers

### DIFF
--- a/app/views/notifier/_notification_email.html.haml
+++ b/app/views/notifier/_notification_email.html.haml
@@ -27,7 +27,7 @@
     %title= t(:notifier)[:service_request]
 
   %body
-    - welcome_text = @service_request.status == "obtain_research_pricing" ? I18n.t('notifier.welcome_obtain_research_pricing') : I18n.t('notifier.welcome_submit')
+    - welcome_text = @service_request.status == "get_a_quote" ? I18n.t('notifier.welcome_obtain_research_pricing') : I18n.t('notifier.welcome_submit')
     - if @role == 'pi' || @role == 'primary-pi'
       %p= I18n.t('notifier.body1', :full_name => @identity.full_name)
       %p= I18n.t('notifier.body2_pi', :welcome => welcome_text, :application_title => I18n.t('application_title'), :root_url => ROOT_URL, :protocol_type => @protocol.type.downcase)


### PR DESCRIPTION
The opening text in the email notification to service providers for Get a quote request is the same as those of Submitted status. In app/views/notifier/_notification_email.html.haml, line 30:

>    - welcome_text = @service_request.status == "obtain_research_pricing" ? I18n.t('notifier.welcome_obtain_research_pricing') : 