### PR TITLE
fixing Add/Update Authorized User button

### DIFF
--- a/app/views/shared/_user_details_right.html.haml
+++ b/app/views/shared/_user_details_right.html.haml
@@ -63,3 +63,7 @@
       = select_tag "identity[subspecialty]", options_for_select((SUBSPECIALTIES.sort), identity.subspecialty), :prompt => t(:user_details)[:subspecialty_select], :class => 'form-control'
       %br
       %br
+
+    .add-user
+      %div{:style => 'padding-left:185px;'}
+        = button_tag @can_edit ? t(:user_details)[:update_button] : t(:user_details)[:add_button], :class => 'dark-blue-button add-authorized-user btn btn-primary', :style => 'border:none; width:180px;'

--- a/app/views/shared/_user_list.html.haml
+++ b/app/views/shared/_user_list.html.haml
@@ -18,9 +18,6 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-.add-user
-  %div{:style => 'padding-left:395px; padding-bottom: 55px; margin-top: -157px;'}
-    = button_tag @can_edit ? t(:user_details)[:update_button] : t(:user_details)[:add_button], :class => 'dark-blue-button add-authorized-user btn btn-primary', :style => 'border:none; width:150px;'
 %table.authorized-users
   %thead
     %tr


### PR DESCRIPTION
To correct myself, I found the problem was not due to any missing local variable, rather when updating an existing user, the user_list was not being reloaded. 

Is there any reason why the Add Authorized User button always sitting there? Doesn’t it flow better where it was? I don't want to spend too much time to reinvent the engine and break anything else. I only fixed the issue by simply moving the .add-user div back to the user_details_right and updating its css to dark-blue-button. 

