### PR TITLE
Turn Fulfillment "on" one Organization at a time

### DIFF
--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -264,7 +264,17 @@ class SubServiceRequest < ActiveRecord::Base
   ###############################################################################
   ######################## FULFILLMENT RELATED METHODS ##########################
   ###############################################################################
-
+  def ready_for_fulfillment? 
+    # return true if work fulfillment has already been turned "on" or global variable FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is set to false or nil
+    # otherwise, return true only if FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is true and the parent organization has tag 'clinical work fulfillment'
+    if self.in_work_fulfillment || !FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER ||
+        (FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER && self.organization.tag_list.include?('clinical work fulfillment'))
+      return true
+    else
+      return false
+    end
+  end
+   
   ########################
   ## SSR STATUS METHODS ##
   ########################

--- a/app/views/portal/sub_service_requests/_service_request_info.html.haml
+++ b/app/views/portal/sub_service_requests/_service_request_info.html.haml
@@ -26,9 +26,10 @@
   %h3= t(:service_requests)[:info][:text2]
   = select_tag "sub_service_request_owner_id", owners_for_select(@sub_service_request), :prompt => '---Please Select---', :'data-sub_service_request_id' => @sub_service_request.id, :class => 'fulfillment_data'
 %br
-#study_tracker_access
-  %h3{:style => "float:left; margin-right:10px;"}= t(:service_requests)[:info][:text3]
-  %td= check_box_tag "in_work_fulfillment", true, @sub_service_request.in_work_fulfillment, :'data-sub_service_request_id' => @sub_service_request.id, :class => "cwf_data", :disabled => @sub_service_request.in_work_fulfillment?
-  - if @user.clinical_provider_rights?
-    .ui-button.ui-state-default.ui-button-text-only{:style => "margin-top:5px; display: #{@sub_service_request.in_work_fulfillment? ? "inline-block" : "none"}"}
-      %span.ui-button-text= link_to t(:study_tracker)[:title], CLINICAL_WORK_FULFILLMENT_URL, :target => "_blank"
+- if @sub_service_request.ready_for_fulfillment?
+  #study_tracker_access
+    %h3{:style => "float:left; margin-right:10px;"}= t(:service_requests)[:info][:text3]
+    %td= check_box_tag "in_work_fulfillment", true, @sub_service_request.in_work_fulfillment, :'data-sub_service_request_id' => @sub_service_request.id, :class => "cwf_data", :disabled => @sub_service_request.in_work_fulfillment?
+    - if @user.clinical_provider_rights?
+      .ui-button.ui-state-default.ui-button-text-only{:style => "margin-top:5px; display: #{@sub_service_request.in_work_fulfillment? ? "inline-block" : "none"}"}
+        %span.ui-button-text= link_to t(:study_tracker)[:title], CLINICAL_WORK_FULFILLMENT_URL, :target => "_blank"

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -64,7 +64,9 @@ development:
   # end API
   bug_enhancement_url: "http://something.com"
   clinical_work_fulfillment_url: http://fulfillment-future-url.com
-
+  # allow catalog_manager to turn on work fulfillment one organization at a time
+  fulfillment_contingent_on_catalog_manager: true
+  
 test:
   default_mail_to: nobody@nowhere.com
   admin_mail_to: nobody@nowhere.com
@@ -109,3 +111,5 @@ test:
   # end API
   bug_enhancement_url: "http://something.com"
   clinical_work_fulfillment_url: http://fulfillment-future-url.com
+  # allow catalog_manager to turn on work fulfillment one organization at a time
+#  fulfillment_contingent_on_catalog_manager: true

--- a/config/initializers/obis_setup.rb
+++ b/config/initializers/obis_setup.rb
@@ -59,7 +59,8 @@ begin
   CURRENT_API_VERSION               = application_config['current_api_version']
   BUG_ENHANCEMENT_URL           = application_config['bug_enhancement_url'] || nil
   CLINICAL_WORK_FULFILLMENT_URL = application_config['clinical_work_fulfillment_url'] || nil
-
+  FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = application_config['fulfillment_contingent_on_catalog_manager'] || nil
+    
   if LOCALE_OVERRIDE
     I18n.available_locales = [:en, LOCALE_OVERRIDE]
     I18n.default_locale = LOCALE_OVERRIDE

--- a/spec/models/sub_service_request/ready_for_fulfillment_spec.rb
+++ b/spec/models/sub_service_request/ready_for_fulfillment_spec.rb
@@ -1,0 +1,113 @@
+# Copyright © 2011 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+require 'spec_helper'
+
+describe 'SubServiceRequest' do
+  before :each do
+    @institution = Institution.new
+    @institution.type = "Institution"
+    @institution.abbreviation = "TECHU"
+    @institution.save(validate: false)
+    
+    @provider = Provider.new
+    @provider.type = "Provider"
+    @provider.abbreviation = "ICTS"
+    @provider.parent_id = @institution.id
+    @provider.save(validate: false)
+    
+    @program = Program.new
+    @program.type = "Program"
+    @program.name = "BMI"
+    @program.parent_id = @provider.id
+    @program.save(validate: false)
+    
+    @core = Core.new
+    @core.type = "Core"
+    @core.name = "REDCap"
+    @core.parent_id = @program.id
+    @core.save(validate: false)
+    
+    @sub_service_request = SubServiceRequest.new
+    @sub_service_request.organization_id = @core.id
+    @sub_service_request.save(validate: false)
+  end
+  
+  it 'is ready for fulfillment if already in work fulfillment and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is true' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = true
+    @sub_service_request.in_work_fulfillment = true
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is ready for fulfillment if already in work fulfillment and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is false' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = false
+    @sub_service_request.in_work_fulfillment = true
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is ready for fulfillment if already in work fulfillment and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is nil' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = nil
+    @sub_service_request.in_work_fulfillment = true
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+ 
+  it 'is NOT ready for fulfillment if FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is true' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = true
+    @sub_service_request.ready_for_fulfillment?.should eq (false)
+  end
+       
+  it 'is ready for fulfillment if FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is false' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = false
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is ready for fulfillment if FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is nil' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = nil
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is ready for fulfillment if the service is directly under an organization with the tag "clinical work fulfillment" and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is true' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = true
+    @core.tag_list << "clinical work fulfillment"
+    @core.save(validate: false)
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is ready for fulfillment if the service is directly under an organization with the tag "clinical work fulfillment" and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is false' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = false
+    @core.tag_list << "clinical work fulfillment"
+    @core.save(validate: false)
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is ready for fulfillment if the service is directly under an organization with the tag "clinical work fulfillment" and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is nil' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = nil
+    @core.tag_list << "clinical work fulfillment"
+    @core.save(validate: false)
+    @sub_service_request.ready_for_fulfillment?.should eq (true)
+  end
+  
+  it 'is NOT ready for fulfillment if the service has a grandparent organization with the tag "clinical work fulfillment" and FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER is true' do
+    FULFILLMENT_CONTINGENT_ON_CATALOG_MANAGER = true
+    @program.tag_list << "clinical work fulfillment"
+    @program.save(validate: false)
+    @sub_service_request.ready_for_fulfillment?.should eq (false)
+  end
+ 
+end


### PR DESCRIPTION
We added a method to SubServiceRequest to answer the question: is a sub service request ready for fulfillment? This logic is backwards compatible such that all sub service requests will be ready if the configuration parameter fulfillment_contingent_on_catalog_manager is false or nil.