### PR TITLE
Added a set_callback for each skip_callback

### DIFF
--- a/spec/api/v1/line_items_visits/get_line_items_visit_spec.rb
+++ b/spec/api/v1/line_items_visits/get_line_items_visit_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
 
       @line_items_visit = build(:line_items_visit)
       @line_items_visit.save validate: false
+      
+      LineItemsVisit.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
     context 'response params' do

--- a/spec/api/v1/line_items_visits/get_line_items_visits_spec.rb
+++ b/spec/api/v1/line_items_visits/get_line_items_visits_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         line_items_visit = build(:line_items_visit)
         line_items_visit.save validate: false
       end
+      
+      LineItemsVisit.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
 

--- a/spec/api/v1/line_items_visits/get_line_items_visits_with_ids_spec.rb
+++ b/spec/api/v1/line_items_visits/get_line_items_visits_with_ids_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
       end
 
       @line_items_visits_ids = LineItemsVisit.pluck(:id)
+      
+      LineItemsVisit.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
     context 'with ids' do

--- a/spec/api/v1/visit_groups/get_visit_group_spec.rb
+++ b/spec/api/v1/visit_groups/get_visit_group_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
 
       @visit_group = build(:visit_group)
       @visit_group.save validate: false
+      
+      VisitGroup.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
     context 'response params' do

--- a/spec/api/v1/visit_groups/get_visit_groups_spec.rb
+++ b/spec/api/v1/visit_groups/get_visit_groups_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         visit_group = build(:visit_group)
         visit_group.save validate: false
       end
+      
+      VisitGroup.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
 

--- a/spec/api/v1/visit_groups/get_visit_groups_with_ids_spec.rb
+++ b/spec/api/v1/visit_groups/get_visit_groups_with_ids_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
       end
 
       @visit_group_ids = VisitGroup.pluck(:id)
+      
+      VisitGroup.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
     context 'with ids' do

--- a/spec/api/v1/visits/get_visit_spec.rb
+++ b/spec/api/v1/visits/get_visit_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
 
       @visit = build(:visit)
       @visit.save validate: false
+      
+      Visit.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
     context 'response params' do

--- a/spec/api/v1/visits/get_visits_spec.rb
+++ b/spec/api/v1/visits/get_visits_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         visit = build(:visit)
         visit.save validate: false
       end
+      
+      Visit.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
 

--- a/spec/api/v1/visits/get_visits_with_ids_spec.rb
+++ b/spec/api/v1/visits/get_visits_with_ids_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
       end
 
       @visit_ids = Visit.pluck(:id)
+      
+      Visit.set_callback(:save, :after, :set_arm_edited_flag_on_subjects)
     end
 
     context 'with ids' do

--- a/spec/factories/protocol.rb
+++ b/spec/factories/protocol.rb
@@ -64,6 +64,7 @@ FactoryGirl.define do
         SubServiceRequest.skip_callback(:save, :after, :update_org_tree)
         sub_service_request = build(:sub_service_request_in_cwf, service_request: service_request)
         sub_service_request.save validate: false
+        SubServiceRequest.set_callback(:save, :after, :update_org_tree)
       end
     end
 

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
 
      trait :without_callback_notify_remote_service_after_create do
        before(:create) { |service| service.class.skip_callback(:create, :after, :notify_remote_service_after_create) }
-       after(:create) { Service.set_callback(:create, :after, :notify_remote_service_after_create) }
+     #  after(:create) { Service.set_callback(:create, :after, :notify_remote_service_after_create) }
      end
 
     trait :with_ctrc_organization do

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -31,6 +31,7 @@ FactoryGirl.define do
 
      trait :without_callback_notify_remote_service_after_create do
        before(:create) { |service| service.class.skip_callback(:create, :after, :notify_remote_service_after_create) }
+       after(:create) { |service| service.class.set_callback(:create, :after, :notify_remote_service_after_create) }
      end
 
     trait :with_ctrc_organization do

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
 
      trait :without_callback_notify_remote_service_after_create do
        before(:create) { |service| service.class.skip_callback(:create, :after, :notify_remote_service_after_create) }
-       after(:create) { |service| service.class.set_callback(:create, :after, :notify_remote_service_after_create) }
+       after(:create) { Service.set_callback(:create, :after, :notify_remote_service_after_create) }
      end
 
     trait :with_ctrc_organization do

--- a/spec/models/sub_service_request/formatted_status_spec.rb
+++ b/spec/models/sub_service_request/formatted_status_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe SubServiceRequest, type: :model do
   describe ".formatted_status" do
 
     before { SubServiceRequest.skip_callback(:save, :after, :update_org_tree) }
-
+    after { SubServiceRequest.set_callback(:save, :after, :update_org_tree) }
+      
     context "constants.yml mapping present" do
 
       it "should return the value from constants.yml" do

--- a/spec/models/sub_service_request/notify_remote_around_update_spec.rb
+++ b/spec/models/sub_service_request/notify_remote_around_update_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'SubServiceRequest' do
   describe '#notify_remote_around_update', delay: true do
 
     before { SubServiceRequest.skip_callback(:save, :after, :update_org_tree) }
-
+    after { SubServiceRequest.set_callback(:save, :after, :update_org_tree) }
+      
     context '.in_work_fulfillment changed' do
 
       it 'should create a RemoteServiceNotifierJob' do

--- a/spec/models/sub_service_request/stored_percent_subsidy_spec.rb
+++ b/spec/models/sub_service_request/stored_percent_subsidy_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe SubServiceRequest, type: :model do
   describe '.stored_percent_subsidy' do
 
     before { SubServiceRequest.skip_callback(:save, :after, :update_org_tree) }
-
+    after { SubServiceRequest.set_callback(:save, :after, :update_org_tree) }
+      
     context 'subsidy present' do
 
       it 'should return the Subsidy.stored_percent_subsidy' do


### PR DESCRIPTION
skip_callback will persist across tests. I added a set_callback for each skip_callback to prevent unexpected test failures. For me, this update didn't affect the # of failing tests so it's a preventative change. 