### PR TITLE
Suppressing 'Advanced User Search' by default

### DIFF
--- a/app/views/shared/_user_search.html.haml
+++ b/app/views/shared/_user_search.html.haml
@@ -26,7 +26,7 @@
   %h3= t(:user_search)[:search_box_header]
   .search.form-group
     = text_field_tag 'user_search_term', nil, :placeholder => t(:user_search)[:search_placeholder], :class => "search-identities form-control",  :'data-protocol_use_epic' => protocol.selected_for_epic
-    - if USE_LDAP
+    - if USE_LDAP && SUPPRESS_LDAP_FOR_USER_SEARCH
       %br
       %br
       %span.help-block 


### PR DESCRIPTION
The 'Advanced User Search' help text and link will only display if USE_LDAP and SUPPRESS_LDAP_FOR_USER_SEARCH are both set to true since when the ldap is not suppressed, the user information will be overwritten by the ldap database 