### PR TITLE
WTH - Error clicking 'edit original'

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,7 +102,7 @@ class ApplicationController < ActionController::Base
     error += "<br />If you believe this is in error please contact, #{I18n.t 'error_contact'}, and provide the following information:"
     error += "<br /> Reference #: "
     error += ref
-    render 'service_requests/authorization_error', error: error
+    render partial: 'service_requests/authorization_error', locals: { error: error }
   end
 
   def clean_errors errors

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -628,7 +628,8 @@ class ServiceRequestsController < ApplicationController
       unless authorized
         @service_request     = nil
         @sub_service_request = nil
-        render 'service_requests/authorization_error', error: 'You are not allowed to edit this Request.'
+        render partial: 'service_requests/authorization_error',
+          locals: { error: 'You are not allowed to edit this Request.' }
       end
     end
   end

--- a/app/views/service_requests/_authorization_error.html.haml
+++ b/app/views/service_requests/_authorization_error.html.haml
@@ -25,7 +25,7 @@
     = stylesheet_link_tag '960', "#{CUSTOM_ASSET_PATH}application", 'jquery-ui', :media => 'all'
   %body
     #container.container
-      = render :partial => 'shared/header_logos'
+      = render 'shared/header_logos', in_dashboard: false
       #title
         %h1= t 'application_title'
       #content.container_12


### PR DESCRIPTION
Correctly passed in error message from Application controller to
authorization error partial. Set 'in_dashboard' variable in
shared/header_logos to false as authorization error partial will never
be in the dashboard section.

set in_dashboard variable to false