### PR TITLE
WTH - Fix Review Submit Spec

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,10 +32,10 @@ module ApplicationHelper
   end
 
   def protocol_id_display(sub_service_request, service_request)
-    if sub_service_request
+    if sub_service_request && sub_service_request.service_request.protocol.present?
       "SRID: #{sub_service_request.service_request.protocol.id}"
-    elsif protocol = service_request.protocol
-      "SRID: #{protocol.id}"
+    elsif service_request && service_request.protocol.present?
+      "SRID: #{service_request.protocol.id}"
     else
       ""
     end


### PR DESCRIPTION
Removed assignment of protocol, simply checking if a service_request
and associated protocol exists and if so assign string to the protocol of the service_request.

Also checking if service request associated to sub_service_request
indeed has a protocol. If those cases fail, return empty string.

added check for protocol associated to service_request

added check to see if service_request associated to ssr has protocol