### PR TITLE
WTH - Remove duplicate header logo on SPARC Report Module

### DIFF
--- a/app/views/layouts/reporting.html.haml
+++ b/app/views/layouts/reporting.html.haml
@@ -36,9 +36,6 @@
     #container.container
       = render 'shared/header_logos', in_dashboard: false
       #welcome_msg= show_welcome_message(current_user)
-      #sparc_logo_header
-        = image_tag('sparc_request_header.jpg')
-        #right_header
       #content.container_12
         - flash.each do |name, msg|
           = content_tag :div, msg, :id => "flash_#{name}" if msg.is_a?(String)


### PR DESCRIPTION
I removed duplicate sparc header logo on the SPARC Report Module by
simply removing lines from the 'reporting' layout