### PR TITLE
SAW-Hid export buttons from dashboard

### DIFF
--- a/app/views/dashboard/documents/_documents_table.html.haml
+++ b/app/views/dashboard/documents/_documents_table.html.haml
@@ -22,7 +22,7 @@
   #documents-custom-toolbar
     %button.btn.btn-success#document_new{ data: {sub_service_request_id: sub_service_request.id }}
       = t(:dashboard)[:documents][:add]
-  %table.documents_table{id: "documents-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_documents_path(format: :json, sub_service_request_id: sub_service_request.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "true", "export-types" => ['excel']}}
+  %table.documents_table{id: "documents-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_documents_path(format: :json, sub_service_request_id: sub_service_request.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel']}}
     %thead.primary-header
       %tr
         %th{data: {class: 'type', align: "left", sortable: "true", field: "type"}}

--- a/app/views/dashboard/study_level_activities/_fulfillments_table.html.haml
+++ b/app/views/dashboard/study_level_activities/_fulfillments_table.html.haml
@@ -23,7 +23,7 @@
     #fulfillment-custom-toolbar
       %button.btn.btn-success.otf_fulfillment_new{type: "button", "aria-label" => "Add Fulfillment", data: {line_item_id: line_item.id}}
         = t(:dashboard)[:fulfillments][:add]
-    %table.fulfillments{id: "fulfillments-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_fulfillments_path(format: :json, line_item_id: line_item.id), "sort-name" => "fulfillment_date", "sort-order" => 'asc', sorter: "dateSorter", striped: "true", toolbar: "#fulfillment-custom-toolbar", "show-export" => "true", "export-types" => ['excel']}}
+    %table.fulfillments{id: "fulfillments-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_fulfillments_path(format: :json, line_item_id: line_item.id), "sort-name" => "fulfillment_date", "sort-order" => 'asc', sorter: "dateSorter", striped: "true", toolbar: "#fulfillment-custom-toolbar", "show-export" => "false", "export-types" => ['excel']}}
       %thead.secondary-header
         %tr
           %th{data: {class: 'fulfillment_date', align: "left", field: "fulfillment_date"}}

--- a/app/views/dashboard/study_level_activities/_study_level_activities_table.html.haml
+++ b/app/views/dashboard/study_level_activities/_study_level_activities_table.html.haml
@@ -23,7 +23,7 @@
       #sla-custom-toolbar
         %button.btn.btn-success#otf_service_new{type: "button", aria: {label: "Add Line Item"}, data: {sub_service_request_id: sub_service_request.id}}
           = t(:dashboard)[:study_level_activities][:add]
-      %table.study_level_activities{id: "study-level-activities-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_line_items_path(format: :json, sub_service_request_id: sub_service_request.id), striped: "true", toolbar: "#sla-custom-toolbar", "show-export" => "true", "export-types" => ['excel']}}
+      %table.study_level_activities{id: "study-level-activities-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_line_items_path(format: :json, sub_service_request_id: sub_service_request.id), striped: "true", toolbar: "#sla-custom-toolbar", "show-export" => "false", "export-types" => ['excel']}}
         %thead.primary-header
           %tr
             %th{data: {class: 'fulfillments_button', align: "left", field: "fulfillments_button"}}

--- a/app/views/dashboard/sub_service_requests/history/_approval_changes.html.haml
+++ b/app/views/dashboard/sub_service_requests/history/_approval_changes.html.haml
@@ -24,7 +24,7 @@
       = t(:dashboard)[:sub_service_requests][:tabs][:history][:status][:header]
     %button.btn.btn-primary.history_button#approval_history_button{ disabled: "disabled", data: { table: "approval_changes", sub_service_request_id: sub_service_request_id }} 
       = t(:dashboard)[:sub_service_requests][:tabs][:history][:approval][:header]
-  %table.ssr_history_table{id: "approval-history-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: approval_history_dashboard_sub_service_request_path(format: :json, sub_service_request_id: sub_service_request_id), striped: "true", toolbar: "#history-custom-toolbar", "show-export" => "true", "export-types" => ['excel']}}
+  %table.ssr_history_table{id: "approval-history-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: approval_history_dashboard_sub_service_request_path(format: :json, sub_service_request_id: sub_service_request_id), striped: "true", toolbar: "#history-custom-toolbar", "show-export" => "false", "export-types" => ['excel']}}
     %thead.primary-header
       %tr
         %th{data: {class: 'date', align: "left", sortable: "true", field: "date"}}

--- a/app/views/dashboard/sub_service_requests/history/_status_changes.html.haml
+++ b/app/views/dashboard/sub_service_requests/history/_status_changes.html.haml
@@ -24,7 +24,7 @@
       = t(:dashboard)[:sub_service_requests][:tabs][:history][:status][:header]
     %button.btn.btn-default.history_button#approval_history_button{ data: { table: "approval_changes", sub_service_request_id: sub_service_request_id }} 
       = t(:dashboard)[:sub_service_requests][:tabs][:history][:approval][:header]
-  %table.ssr_history_table{id: "status-history-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: status_history_dashboard_sub_service_request_path(id: sub_service_request_id, format: :json), striped: "true", "show-export" => "true", toolbar: "#history-custom-toolbar", "export-types" => ['excel']}}
+  %table.ssr_history_table{id: "status-history-table", data: {toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: status_history_dashboard_sub_service_request_path(id: sub_service_request_id, format: :json), striped: "true", "show-export" => "false", toolbar: "#history-custom-toolbar", "export-types" => ['excel']}}
     %thead.primary-header
       %tr
         %th{data: {class: 'created_at', align: "left", sortable: "true", field: "created_at"}}


### PR DESCRIPTION
Hid export buttons from history, study level activities, and documents tab on dashboard