### PR TITLE
WTH - SLA qty requested not saving

### DIFF
--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -301,7 +301,7 @@ class ServiceRequest < ActiveRecord::Base
   end
 
   def create_line_item(args)
-    quantity = args.delete(:quantity) || 1
+    quantity = args.delete('quantity') || args.delete(:quantity) || 1
     if line_item = self.line_items.create(args)
 
       if line_item.service.one_time_fee


### PR DESCRIPTION
Fixed validation error on creating a line item. Was defaulting to 1,
because it could not find method parameter due to improper format.

checking for different formats when line items are created