### PR TITLE
SAW - new method to not display in SPARC if parent is not displayed (1.7.5)

### DIFF
--- a/app/controllers/catalog_manager/institutions_controller.rb
+++ b/app/controllers/catalog_manager/institutions_controller.rb
@@ -43,6 +43,7 @@ class CatalogManager::InstitutionsController < CatalogManager::AppController
     
     params[:institution].delete(:id)
     if @institution.update_attributes(params[:institution])
+      @institution.update_descendants_availability(params[:institution][:is_available])
       flash[:notice] = "#{@institution.name} saved correctly."
     else
       flash[:alert] = "Failed to update #{@institution.name}."

--- a/app/controllers/catalog_manager/programs_controller.rb
+++ b/app/controllers/catalog_manager/programs_controller.rb
@@ -47,6 +47,7 @@ class CatalogManager::ProgramsController < CatalogManager::AppController
     params[:program].delete(:id)
 
     if @program.update_attributes(params[:program])
+      @program.update_descendants_availability(params[:program][:is_available])
       flash[:notice] = "#{@program.name} saved correctly."
     else
       flash[:alert] = "Failed to update #{@program.name}."

--- a/app/controllers/catalog_manager/providers_controller.rb
+++ b/app/controllers/catalog_manager/providers_controller.rb
@@ -45,6 +45,7 @@ class CatalogManager::ProvidersController < CatalogManager::AppController
 
     params[:provider].delete(:id)
     if @provider.update_attributes(params[:provider])
+      @provider.update_descendants_availability(params[:provider][:is_available])
       flash[:notice] = "#{@provider.name} saved correctly."
     else
       flash[:alert] = "Failed to update #{@provider.name}."

--- a/app/helpers/catalog_manager/catalog_helper.rb
+++ b/app/helpers/catalog_manager/catalog_helper.rb
@@ -61,6 +61,10 @@ module CatalogManager::CatalogHelper
 
     tree.join(' / ')
   end
+
+  def is_parent_available? organization_id
+    Organization.find(organization_id).parent.is_available
+  end
 end
 
 def display_name object

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -176,6 +176,7 @@ class Organization < ActiveRecord::Base
 
   # Returns an array of all children (and children of children) of this organization (deep search).
   # Optionally includes self
+  # TODO: doesn't actually include self, look into this
   def all_children (all_children=[], include_self=true, orgs)
     self.children(orgs).each do |child|
       all_children << child
@@ -185,6 +186,14 @@ class Organization < ActiveRecord::Base
     all_children << self if include_self
 
     all_children.uniq
+  end
+
+  def update_descendants_availability(is_available)
+    if is_available == "false"
+      all_child_organizations.each do |org|
+        org.update_attribute(:is_available, false)
+      end
+    end
   end
 
   # Returns an array of all services that are offered by this organization as well of all of its

--- a/app/views/catalog_manager/cores/_form.html.haml
+++ b/app/views/catalog_manager/cores/_form.html.haml
@@ -56,7 +56,7 @@
             %td= f.check_box :process_ssrs
           %tr
             %th= f.label :disabled, t(:organization_form)[:disabled]
-            %td= f.check_box :is_available, {:checked => (@core.is_available.nil? ? false : !@core.is_available) }, false, true
+            %td= f.check_box :is_available, {:checked => (@core.is_available.nil? ? false : !@core.is_available), disabled: !is_parent_available?(params[:id]) }, false, true
           %tr
             %th= t(:organization_form)[:tag_list]
             %td

--- a/app/views/catalog_manager/programs/_form.html.haml
+++ b/app/views/catalog_manager/programs/_form.html.haml
@@ -56,7 +56,7 @@
             %td= f.check_box :process_ssrs
           %tr
             %th= t(:organization_form)[:disabled]
-            %td= f.check_box :is_available, {:checked => (@program.is_available.nil? ? false : !@program.is_available) }, false, true
+            %td= f.check_box :is_available, {:checked => (@program.is_available.nil? ? false : !@program.is_available), disabled: !is_parent_available?(params[:id]) }, false, true
           %tr
             %th= t(:organization_form)[:tag_list]
             %td

--- a/app/views/catalog_manager/providers/_form.html.haml
+++ b/app/views/catalog_manager/providers/_form.html.haml
@@ -62,7 +62,7 @@
             %td= f.check_box :process_ssrs
           %tr
             %th= t(:organization_form)[:disabled]
-            %td= f.check_box :is_available, {:checked => (@provider.is_available.nil? ? false : !@provider.is_available) }, false, true
+            %td= f.check_box :is_available, {:checked => (@provider.is_available.nil? ? false : !@provider.is_available), disabled: !is_parent_available?(params[:id]) }, false, true
           %tr
             %th= t(:organization_form)[:tag_list]
             %td

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -219,6 +219,24 @@ RSpec.describe 'organization' do
     end
   end
 
+  describe 'update descendants availability' do
+
+    it 'should update all descendants availability to false' do 
+      provider = create(:provider, is_available: true)
+      program = create(:program, parent: provider, is_available: true)
+      core = create(:core, parent: program, is_available: true)
+
+      provider.update_descendants_availability("false")
+
+      program.reload
+      core.reload
+
+      expect(program.is_available).to eq(false)
+      expect(core.is_available).to eq(false)
+
+    end
+
+  end
 
   describe 'current_pricing_setup' do
 


### PR DESCRIPTION
Also wrote a spec in the organization model spec and disabled the "Do not display in SPARC" checkbox in SPARCCatalog if the parent is not displayed.

The method only changes the attributes of child organizations when the parent organization is set to not displayed.
