### PR TITLE
SAW - remove tags from institutions (1.7.5)

### DIFF
--- a/app/views/catalog_manager/institutions/_form.html.haml
+++ b/app/views/catalog_manager/institutions/_form.html.haml
@@ -60,13 +60,6 @@
           %tr
             %th= f.label :disabled, t(:organization_form)[:disabled]
             %td= f.check_box :is_available, {:checked => (@institution.is_available.nil? ? false : !@institution.is_available) }, false, true
-          %tr
-            %th= t(:organization_form)[:tag_list]
-            %td
-              - Tag.all.each do |tag|
-                %span{:style => "margin-right:10px;"}
-                  %span= f.label (t(:tags)[tag.name.gsub(" ", "_").to_sym] ? t(:tags)[tag.name.gsub(" ", "_").to_sym] : tag.name.humanize)
-                  %span= f.check_box :tag_list, { :multiple => true }, tag.name, nil
 
     %br
     

--- a/spec/features/catalog_manager/edit_institution_spec.rb
+++ b/spec/features/catalog_manager/edit_institution_spec.rb
@@ -45,26 +45,6 @@ RSpec.describe 'edit an institution', js: true do
     end
 
 
-    context "adding and removing tags" do
-      before :each do
-        @institution = Organization.where(abbreviation: "MUSC").first
-        wait_for_javascript_to_finish
-      end
-
-      it "should list the tags" do
-        expect(page).to have_css("#institution_tag_list_ctrc")
-      end
-
-      it "should be able to check a tag box" do
-        find('#institution_tag_list_ctrc').click
-        first("#save_button").click
-        expect(page).to have_content( 'Medical University of South Carolina saved successfully' )
-        expect(find('#institution_tag_list_ctrc')).to be_checked
-        expect(@institution.tag_list).to eq(['ctrc'])
-      end
-    end
-
-
     context "viewing user rights section" do
       it "should show user rights section" do
         find('#user_rights').click


### PR DESCRIPTION
Removed Tag checkboxes from institutions form only in SPARCCatalog and deleted the specs that tested them since they are no longer a part of the form