### PR TITLE
Admin identities fixes

### DIFF
--- a/app/assets/stylesheets/admin/application.css
+++ b/app/assets/stylesheets/admin/application.css
@@ -5,7 +5,6 @@
  *= require admin/bootstrap.min
  *= require admin/bootstrap-theme.min
  *= require admin/bootstrap-accessibility
- *= require admin/bootstrap-datetimepicker
  *= require admin/ui-grid.min
  *= require_self
 */

--- a/app/views/layouts/admin/identities.html.haml
+++ b/app/views/layouts/admin/identities.html.haml
@@ -27,9 +27,7 @@
               %li
                 %a{:href=> catalog_manager_root_path() }= t(:admin_identities)[:catalog_manager]
               %li
-                %a{:href=> portal_admin_path() }= t(:admin_identities)[:portal_admin]
-              %li
-                %a{:href=> portal_root_path() }= t(:admin_identities)[:portal]
+                %a{:href=> DASHBOARD_LINK }= t(:admin_identities)[:portal]
               %li
                 %a{:href=> root_path() }= t(:admin_identities)[:request_services]
     .container-fluid


### PR DESCRIPTION
there were 2 issues with the advanced user search:
1. Original portal and admin portal links need to be replaced by the merged dashboard
2. An un-used bs datetimepicker was added to app/assets/stylesheets/admin/application.css which caused error - see attached screenshot
![missing bs dateetimepicker error](https://cloud.githubusercontent.com/assets/7648699/16456055/278265f8-3ddc-11e6-8d69-82326d1bfb6e.jpg)
