### PR TITLE
SAW - SR with subsidy 'Back' bug

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -206,7 +206,9 @@ class ServiceRequestsController < ApplicationController
   end
 
   def document_management
-    unless @service_request.sub_service_requests.map(&:has_subsidy?).any?
+    has_subsidy = @service_request.sub_service_requests.map(&:has_subsidy?).any?
+    eligible_for_subsidy = @service_request.sub_service_requests.map(&:eligible_for_subsidy?).any?
+    unless (has_subsidy || eligible_for_subsidy)
       @back = 'service_calendar'
     end
   end

--- a/spec/controllers/service_requests_controller/get_document_management_spec.rb
+++ b/spec/controllers/service_requests_controller/get_document_management_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ServiceRequestsController do
+  stub_controller
+  let_there_be_lane
+
+  before :each do
+    session[:identity_id] = jug2.id
+  end
+
+  describe 'GET document_management' do
+    it 'Should set @back to service_calendar if no SSR has or is eligible for a subsidy' do
+      organization        = create(:provider)
+      service_request     = create(:service_request_without_validations)
+      sub_service_request = create(:sub_service_request_without_validations,
+                                    service_request_id: service_request.id,
+                                    organization_id: organization.id)
+
+      xhr :get, :document_management, id: service_request.id
+
+      expect(assigns(:back)).to eq('service_calendar')
+    end
+
+    it 'Should not set @back to service_calendar if no SSR has or is eligible for a subsidy' do
+      organization        = create(:provider)
+      service_request     = create(:service_request_without_validations)
+      sub_service_request = create(:sub_service_request_with_subsidy,
+                                    service_request_id: service_request.id,
+                                    organization_id: organization.id)
+
+      xhr :get, :document_management, id: service_request.id
+
+      expect(assigns(:back)).to eq('service_subsidy')
+    end
+  end
+
+end


### PR DESCRIPTION
back was being set to 'service_calendar' only if an SSR did not have subsidy, now back is set to 'service_calendar' if an SSR does not have a subsidy and is not eligible for a subsidy.