### PR TITLE
Jw fixing email story part 3

### DIFF
--- a/app/views/notifier/_user_information.html.haml
+++ b/app/views/notifier/_user_information.html.haml
@@ -27,7 +27,7 @@
       %th.skinny-black-border= t(:notifier)[:name]
       %th.skinny-black-border= t(:notifier)[:contact_info]
       %th.skinny-black-border= t(:notifier)[:role]
-      - if !@protocol.selected_for_epic.nil?
+      - if @protocol.selected_for_epic == true
         %th.skinny-black-border= t(:notifier)[:epic_access]
   %tbody
     - @protocol.project_roles.each do |pr|
@@ -38,7 +38,7 @@
           %td.skinny-black-border.center= pr.role.upcase + " " + t(:notifier)[:requester]
         - else
           %td.skinny-black-border.center= pr.role.upcase
-        - if !@protocol.selected_for_epic.nil?
+        - if @protocol.selected_for_epic == true
           %td.skinny-black-border.center= pr.epic_access == true ? "Yes" : "No"
 %br
 %br

--- a/app/views/user_mailer/_intro.html.haml
+++ b/app/views/user_mailer/_intro.html.haml
@@ -4,7 +4,5 @@
     = t(:mailer)[:delete_intro]
   - if @action == "add"
     = t(:mailer)[:add_intro]
-  - if @action == "update"
-    = t(:mailer)[:update]
 %p{ :style => 'display: inline;' }
   %a{:style => "color: blue; font-weight: bold;", :href => @protocol_link}=t(:mailer)[:sparc_dashboard_period]

--- a/app/views/user_mailer/_user_info_table.html.haml
+++ b/app/views/user_mailer/_user_info_table.html.haml
@@ -8,7 +8,7 @@
       %th{:style => 'border: 1px solid black;'}= t(:notifier)[:contact_info]
       %th{:style => 'border: 1px solid black;'}= t(:notifier)[:role]
       %th{:style => 'border: 1px solid black;'}= t(:mailer)[:proxy]
-      - if !@protocol.selected_for_epic.nil?
+      - if @protocol.selected_for_epic == true
         %th{:style => 'border: 1px solid black;'}= t(:notifier)[:epic_access]
   %tbody
     %tr{:style => 'border: 1px solid black;'}
@@ -16,5 +16,5 @@
       %td{:style => 'border: 1px solid black; text-align: center;'}= @modified_role.identity.email
       %td{:style => 'border: 1px solid black; text-align: center;'}= @modified_role.role.upcase
       %td{:style => 'border: 1px solid black; text-align: center;'}= @modified_role.display_rights
-      - if !@protocol.selected_for_epic.nil?
+      - if @protocol.selected_for_epic == true
         %td{:style => 'border: 1px solid black; text-align: center;'}= @modified_role.epic_access == true ? "Yes" : "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1560,7 +1560,6 @@ en:
     sparc_dashboard_period: "SPARCDashboard."
     title1: "Short Title:"
     title2: "Project Title:"
-    update:  "An Authorized User has been modified in"
     user_info: "User Information:"
     user_modification: "User Modification"
 

--- a/lib/dashboard/associated_user_updater.rb
+++ b/lib/dashboard/associated_user_updater.rb
@@ -44,7 +44,6 @@ module Dashboard
 
         # must come after the use of ActiveModel::Dirty methods above
         @protocol_role.save
-        protocol.email_about_change_in_authorized_user(@protocol_role, "update")
 
         if USE_EPIC && protocol.selected_for_epic && !QUEUE_EPIC
           if access_removed

--- a/spec/lib/dashboard/associated_user_updater_spec.rb
+++ b/spec/lib/dashboard/associated_user_updater_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
 
   context "params[:project_role] describes a valid ProjectRole" do
     it "should update ProjectRole from params[:id] with params[:project_role]" do
-      protocol = create(:study_without_validations, primary_pi: primary_pi)
-      create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
+      protocol = create(:protocol_without_validations, primary_pi: primary_pi)
       project_role = ProjectRole.create(identity_id: identity.id,
         protocol_id: protocol.id,
         role: "important",
@@ -41,8 +40,7 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
 
   context "changing role to 'primary-pi'" do
     it "should change current primary pi to a general-access-user" do
-      protocol = create(:study_without_validations, primary_pi: primary_pi)
-      create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
+      protocol = create(:protocol_without_validations, primary_pi: primary_pi)
       project_role = ProjectRole.create(identity_id: identity.id,
         protocol_id: protocol.id,
         role: "primary-pi",
@@ -55,75 +53,9 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
     end
   end
 
-  context "SEND_AUTHORIZED_USER_EMAILS == true && protocol has non-draft status" do
-    it "should notify associated users about user change" do
-      protocol = create(:study_without_validations, primary_pi: primary_pi)
-      user = create(:identity)
-      create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
-      stub_const("SEND_AUTHORIZED_USER_EMAILS", true)
-      project_role = ProjectRole.create(identity_id: identity.id,
-        protocol_id: protocol.id,
-        role: "important",
-        project_rights: "to-party")
-      expect(UserMailer).to receive(:authorized_user_changed) do
-        mailer_stub = double('mailer')
-        expect(mailer_stub).to receive(:deliver)
-        mailer_stub
-      end
-      expect(UserMailer).to receive(:authorized_user_changed) do
-        mailer_stub = double('mailer')
-        expect(mailer_stub).to receive(:deliver)
-        mailer_stub
-      end
-
-      Dashboard::AssociatedUserUpdater.new(id: project_role.id, project_role: { role: "not-important" })
-    end
-  end
-
-  context "SEND_AUTHORIZED_USER_EMAILS == true && protocol has draft status" do
-    it "should notify associated users about user change" do
-      protocol = create(:study_without_validations, primary_pi: primary_pi)
-      user = create(:identity)
-      create(:sub_service_request, status: 'draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
-      stub_const("SEND_AUTHORIZED_USER_EMAILS", true)
-      project_role = ProjectRole.create(identity_id: identity.id,
-        protocol_id: protocol.id,
-        role: "important",
-        project_rights: "to-party")
-      expect(UserMailer).not_to receive(:authorized_user_changed) do
-        mailer_stub = double('mailer')
-        expect(mailer_stub).to receive(:deliver)
-        mailer_stub
-      end
-      expect(UserMailer).not_to receive(:authorized_user_changed) do
-        mailer_stub = double('mailer')
-        expect(mailer_stub).to receive(:deliver)
-        mailer_stub
-      end
-
-      Dashboard::AssociatedUserUpdater.new(id: project_role.id, project_role: { role: "not-important" })
-    end
-  end
-
-  context "SEND_AUTHORIZED_USER_EMAILS == false" do
-    it "should not notify associated users about user change" do
-      protocol = create(:study_without_validations, primary_pi: primary_pi)
-      stub_const("SEND_AUTHORIZED_USER_EMAILS", false)
-      project_role = ProjectRole.create(identity_id: identity.id,
-        protocol_id: protocol.id,
-        role: "important",
-        project_rights: "to-party")
-      allow(UserMailer).to receive(:authorized_user_changed)
-
-      Dashboard::AssociatedUserUpdater.new(id: project_role.id, project_role: { role: "not-important" })
-
-      expect(UserMailer).not_to have_received(:authorized_user_changed)
-    end
-  end
-
   context "USE_EPIC == true && Protocol selected for epic && QUEUE_EPIC == false" do
     let(:protocol) do
-      create(:study_without_validations,
+      create(:protocol_without_validations,
         primary_pi: primary_pi,
         selected_for_epic: true)
     end
@@ -141,7 +73,6 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
           project_rights: "to-party",
           epic_access: true)
 
-        create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
 
         expect(Notifier).to receive(:notify_for_epic_access_removal) do |p, pr|
           # make sure the correct objects are being passed
@@ -166,7 +97,6 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
           project_rights: "to-party",
           epic_access: false)
 
-        create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
 
         expect(Notifier).to receive(:notify_for_epic_user_approval) do |p|
           # make sure the correct objects are being passed
@@ -190,7 +120,6 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
           epic_access: false)
         project_role.epic_rights.create(right: "left", position: 1)
 
-        create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
 
         expect(Notifier).to receive(:notify_for_epic_rights_changes) do |p, pr, epic_rights|
           # make sure the correct objects are being passed
@@ -209,7 +138,7 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
 
   describe "#protocol_role" do
     it "should return updated ProjectRole, regardless of validity" do
-      protocol = create(:study_without_validations, primary_pi: primary_pi)
+      protocol = create(:protocol_without_validations, primary_pi: primary_pi)
       project_role = ProjectRole.create(identity_id: identity.id,
         protocol_id: protocol.id,
         role: "important",
@@ -222,7 +151,7 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
   end
 
   describe "#successful?" do
-    let(:protocol) { create(:study_without_validations, primary_pi: primary_pi) }
+    let(:protocol) { create(:protocol_without_validations, primary_pi: primary_pi) }
 
     context "update resulted in invalid ProjectRole" do
       it "should return false" do
@@ -244,7 +173,6 @@ RSpec.describe Dashboard::AssociatedUserUpdater do
           role: "important",
           project_rights: "to-party")
 
-        create(:sub_service_request, status: 'not_draft', organization: create(:organization), service_request: create(:service_request_without_validations, protocol: protocol))
 
         updater = Dashboard::AssociatedUserUpdater.new(id: project_role.id, project_role: { role: "not-important" })
 

--- a/spec/mailers/notifier/get_a_cost_estimate_spec.rb
+++ b/spec/mailers/notifier/get_a_cost_estimate_spec.rb
@@ -109,6 +109,17 @@ RSpec.describe Notifier do
         assert_email_user_information_when_selected_for_epic(mail.body)
       end
     end
+
+    context 'when protocol is not selected for epic' do
+
+      before do
+        service_request.protocol.update_attribute(:selected_for_epic, false)
+      end
+
+      it 'should not show epic column' do
+        assert_email_user_information_when_not_selected_for_epic(mail.body)
+      end
+    end
   end
 
   context 'users' do
@@ -147,6 +158,17 @@ RSpec.describe Notifier do
 
       it 'should show epic column' do
         assert_email_user_information_when_selected_for_epic(mail.body.parts.first.body)
+      end
+    end
+
+    context 'when protocol is not selected for epic' do
+
+      before do
+        service_request.protocol.update_attribute(:selected_for_epic, false)
+      end
+
+      it 'should not show epic column' do
+        assert_email_user_information_when_not_selected_for_epic(mail.body.parts.first.body)
       end
     end
   end
@@ -189,6 +211,17 @@ RSpec.describe Notifier do
 
       it 'should show epic column' do
         assert_email_user_information_when_selected_for_epic(mail.body.parts.first.body)
+      end
+    end
+
+    context 'when protocol is not selected for epic' do
+
+      before do
+        service_request.protocol.update_attribute(:selected_for_epic, false)
+      end
+
+      it 'should not show epic column' do
+        assert_email_user_information_when_not_selected_for_epic(mail.body.parts.first.body)
       end
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -25,8 +25,23 @@ RSpec.describe UserMailer do
       protocol_information_table
     end
 
-    it "should display the User information table" do
-      user_information_table
+    context 'when protocol has selected for epic' do
+      before do
+        study.update_attribute(:selected_for_epic, true)
+      end
+
+      it 'should show epic column' do
+        user_information_table_with_epic_col
+      end
+    end
+
+    context 'when protocol does not have selected for epic' do
+      before do
+        study.update_attribute(:selected_for_epic, false)
+      end
+      it 'should not show epic col' do
+        user_information_table_without_epic_col
+      end
     end
 
     it "should display message conclusion" do
@@ -58,8 +73,23 @@ RSpec.describe UserMailer do
       protocol_information_table
     end
 
-    it "should display the User information table" do
-      user_information_table
+    context 'when protocol has selected for epic' do
+      before do
+        study.update_attribute(:selected_for_epic, true)
+      end
+
+      it 'should show epic column' do
+        user_information_table_with_epic_col
+      end
+    end
+
+    context 'when protocol does not have selected for epic' do
+      before do
+        study.update_attribute(:selected_for_epic, false)
+      end
+      it 'should not show epic col' do
+        user_information_table_without_epic_col
+      end
     end
 
     it "should display message conclusion" do

--- a/spec/support/emails/tables.rb
+++ b/spec/support/emails/tables.rb
@@ -59,6 +59,23 @@ module EmailHelpers
     end
   end
 
+  def assert_email_user_information_when_not_selected_for_epic(mail_response)
+    # Should display 'Epic Access' column
+    expect(mail_response).to have_xpath "//table//strong[text()='User Information']"
+    expect(mail_response).to have_xpath "//th[text()='User Name']/following-sibling::th[text()='Contact Information']/following-sibling::th[text()='Role']"
+    expect(mail_response).not_to have_xpath "//following-sibling::th[text()='Epic Access']"
+    service_request.protocol.project_roles.each do |role|
+      if identity.id == service_request.sub_service_requests.first.service_requester_id
+        requester_flag = " (Requester)"
+      else
+        requester_flag = ""
+      end
+      user_epic_access = role.epic_access == false ? "No" : "Yes"
+      expect(mail_response).to have_xpath "//td[text()='#{role.identity.full_name}']/following-sibling::td[text()='#{role.identity.email}']/following-sibling::td[text()='#{role.role.upcase}#{requester_flag}']"
+      expect(mail_response).not_to have_xpath "//following-sibling::td[text()='#{user_epic_access}']"
+    end
+  end
+
   def assert_email_srid_information_for_service_provider
     # Expect table to show only SSR's (hyper-link) that are associated with service provider 
     expect(mail.body).to have_xpath "//table//strong[text()='Service Request Information']"

--- a/spec/support/user_mailer_emails/tables.rb
+++ b/spec/support/user_mailer_emails/tables.rb
@@ -9,7 +9,7 @@ module EmailHelpers
     expect(@mail).to have_xpath "//th[text()='Funding Source']/following-sibling::td[text()='#{study.funding_source.capitalize}']"
   end
 
-  def user_information_table
+  def user_information_table_with_epic_col
     expect(@mail).to have_xpath "//table//strong[text()='User Information']"
     expect(@mail).to have_xpath "//th[text()='User Modification']/following-sibling::th[text()='Contact Information']/following-sibling::th[text()='Role']/following-sibling::th[text()='SPARC Proxy Rights']/following-sibling::th[text()='Epic Access']"
     expect(@mail).to have_xpath "//td[text()='#{@modified_identity.full_name}']/following-sibling::td[text()='#{@modified_identity.email}']/following-sibling::td[text()='#{@modified_identity.project_roles.first.role.upcase}']/following-sibling::td[text()='#{@modified_identity.project_roles.first.display_rights}']"
@@ -17,6 +17,19 @@ module EmailHelpers
       expect(@mail).to have_xpath "//td[text()='No']"
     else
       expect(@mail).to have_xpath "//td[text()='Yes']"
+    end
+  end
+
+  def user_information_table_without_epic_col
+    expect(@mail).to have_xpath "//table//strong[text()='User Information']"
+    expect(@mail).to have_xpath "//th[text()='User Modification']/following-sibling::th[text()='Contact Information']/following-sibling::th[text()='Role']/following-sibling::th[text()='SPARC Proxy Rights']"
+    expect(@mail).not_to have_xpath "//following-sibling::th[text()='Epic Access']"
+    expect(@mail).to have_xpath "//td[text()='#{@modified_identity.full_name}']/following-sibling::td[text()='#{@modified_identity.email}']/following-sibling::td[text()='#{@modified_identity.project_roles.first.role.upcase}']/following-sibling::td[text()='#{@modified_identity.project_roles.first.display_rights}']"
+
+    if @modified_identity.project_roles.first.epic_access == false
+      expect(@mail).not_to have_xpath "//td[text()='No']"
+    else
+      expect(@mail).not_to have_xpath "//td[text()='Yes']"
     end
   end
 end


### PR DESCRIPTION
Wenjun and team only want emails sent out when adding/deleting a user.  Originally they also wanted emails sent out when a user was updated, but they felt that this would overwhelm the user.  So in this pull request, i'm getting rid of the logic that sends out emails for updated users. 

In the email content, there is a user information table that displays an epic col if the protocol is selected for epic.  Beside each user it says whether that user has epic access or not.  The logic for the epic col was not hiding/showing appropriately.  So that is now fixed and has full spec coverage.