### PR TITLE
SAW - Hide 'Null' Services Descriptions

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,7 +45,9 @@ class SearchController < ApplicationController
         :parents      => s.parents.map(&:abbreviation).join(' | '),
         :label        => s.name,
         :value        => s.id,
-        :description  => s.description,
+        :description  => (s.description.nil? || s.description.blank?) ?
+                            t(:proper)[:catalog][:no_description] :
+                            s.description,
         :sr_id        => session[:service_request_id],
         :from_portal  => session[:from_portal],
         :first_service => first_service,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,7 @@ en:
   proper:
     catalog:
       ctrc_lock: "SCTR Research Nexus services are already present on this request (%{protocol_id}-%{ssr_id}) pertaining to this %{protocol_type}, '%{short_title}'. Please call (843) 792-8688 to edit the existing request."
+      no_description: "No Description Available"
 
   dashboard:
     ###########


### PR DESCRIPTION
Services that have no description now display "No Description Available" in the search results.
