### PR TITLE
WTH - Submission Form location and visibility adjustment

### DIFF
--- a/app/assets/javascripts/dashboard/delete_submission.js.coffee
+++ b/app/assets/javascripts/dashboard/delete_submission.js.coffee
@@ -2,7 +2,7 @@ $ ->
   $(document).on 'click', '.delete-submission', ->
     id = $(this).data('id')
     serviceId = $(this).data('service-id')
-    srId = $(this).data('sr-id')
+    lineItemId = $(this).data('line-item-id')
     protocolId = $(this).data('protocol-id')
     swal {
       title: 'Are you sure?'
@@ -13,10 +13,10 @@ $ ->
       confirmButtonText: 'Delete'
       closeOnConfirm: true
     }, ->
-      if srId != undefined && protocolId != undefined
+      if lineItemId != undefined && protocolId != undefined
         $.ajax
           type: 'DELETE'
-          url: "/services/#{serviceId}/additional_details/submissions/#{id}?protocol_id=#{protocolId}&sr_id=#{srId}"
+          url: "/services/#{serviceId}/additional_details/submissions/#{id}?protocol_id=#{protocolId}&line_item_id=#{lineItemId}"
           success: ->
             swal('Deleted', 'Submission Deleted', "success")
       else

--- a/app/controllers/additional_details/submissions_controller.rb
+++ b/app/controllers/additional_details/submissions_controller.rb
@@ -38,8 +38,10 @@ class AdditionalDetails::SubmissionsController < ApplicationController
     @service = Service.find(params[:service_id])
     @questionnaire = @service.questionnaires.active.first
     @submission = Submission.new(submission_params)
-    @protocol = Protocol.find(params[:protocol_id])
-    @service_request = ServiceRequest.find(params[:sr_id])
+    @protocol = Protocol.find(submission_params[:protocol_id])
+    @submissions = @protocol.submissions
+    @line_item = LineItem.find(submission_params[:line_item_id])
+    @service_request = @line_item.service_request
     respond_to do |format|
       if @submission.save
         format.js
@@ -66,13 +68,14 @@ class AdditionalDetails::SubmissionsController < ApplicationController
 
   def destroy
     @service = Service.find(params[:service_id])
-    @submissions = @service.submissions
     @submission = Submission.find(params[:id])
     if params[:protocol_id]
       @protocol = Protocol.find(params[:protocol_id])
+      @submissions = @protocol.submissions
     end
-    if params[:sr_id]
-      @service_request = ServiceRequest.find(params[:sr_id])
+    if params[:line_item_id]
+      @line_item = LineItem.find(params[:line_item_id])
+      @service_request = ServiceRequest.find(@line_item.service_request_id)
     end
     respond_to do |format|
       if @submission.destroy

--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -72,6 +72,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
   end
 
   def show
+    @submissions = @protocol.submissions
     respond_to do |format|
       format.js   { render }
       format.html {

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -34,6 +34,7 @@ class LineItem < ActiveRecord::Base
   has_many :procedures
   has_many :admin_rates, dependent: :destroy
   has_many :notes, as: :notable, dependent: :destroy
+  has_many :submissions, dependent: :destroy
 
   attr_accessible :service_request_id
   attr_accessible :sub_service_request_id

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -44,6 +44,7 @@ class Protocol < ActiveRecord::Base
   has_many :notes, as: :notable,          dependent: :destroy
   has_many :study_type_questions,         through: :study_type_question_group
   has_many :documents,                    dependent: :destroy
+  has_many :submissions,                  dependent: :destroy
 
   has_many :principal_investigators, -> { where(project_roles: { role: %w(pi primary-pi) }) },
     source: :identity, through: :project_roles

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,5 +1,7 @@
 class Submission < ActiveRecord::Base
   belongs_to :service
+  belongs_to :line_item
+  belongs_to :protocol
   belongs_to :identity
   belongs_to :questionnaire
   has_many :questionnaire_responses, dependent: :destroy

--- a/app/views/additional_details/_dashboard_complete_additional_details.html.haml
+++ b/app/views/additional_details/_dashboard_complete_additional_details.html.haml
@@ -1,7 +1,7 @@
 - if service_request.additional_detail_services.present?
-  - service_request.additional_detail_services.each do |service|
-    - unless Submission.where(service: service, identity: current_identity).present?
+  - service_request.line_items.each do |line_item|
+    - unless line_item.submissions.present?
       %div.alert.alert-warning
         %h5.text-center
-          = link_to t("additional_details.dashboard_complete_details", service_name: service.name),
-            new_service_additional_details_submission_path(service, protocol_id: @protocol.id, sr_id: service_request.id), remote: true
+          = link_to t("additional_details.dashboard_complete_details", service_name: Service.find(line_item.service_id).name),
+            new_service_additional_details_submission_path(line_item.service_id, protocol_id: @protocol.id, line_item_id: line_item.id), remote: true

--- a/app/views/additional_details/submissions/_new_form.html.haml
+++ b/app/views/additional_details/submissions/_new_form.html.haml
@@ -1,6 +1,6 @@
-= hidden_field_tag 'sr_id', params[:sr_id]
-= hidden_field_tag 'protocol_id', params[:protocol_id]
+= f.hidden_field :protocol_id, value: params[:protocol_id]
 = f.hidden_field :questionnaire_id, value: @questionnaire.id
+= f.hidden_field :line_item_id, value: params[:line_item_id]
 - @questionnaire.items.each do |item|
   = f.fields_for :questionnaire_responses do |qr|
     - if item.required?

--- a/app/views/additional_details/submissions/_submissions_panel.html.haml
+++ b/app/views/additional_details/submissions/_submissions_panel.html.haml
@@ -17,52 +17,47 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#additional-details-submissions-panel.panel.panel-default
-  .panel-heading
-    %h4.panel-title
-      = t(:additional_details)[:submissions][:header]
-  .panel-body
-    %table.table.table-striped.table-bordered.table-hover
-      %thead
-        %tr
-          %th.text-center
-            = t(:additional_details)[:submissions][:table_fields][:id]
-          %th.text-center
-            = t(:additional_details)[:submissions][:table_fields][:service]
-          %th.text-center
-            = t(:actions)[:view]
-          %th.text-center
-            = t(:actions)[:edit]
-          %th.text-center
-            = t(:actions)[:delete]
-      %tbody
-        - protocol.service_requests.each do |service_request|
-          - service_request.additional_detail_services.each do |service|
-            - submissions = Submission.where(service: service, identity: current_identity)
-            - if submissions.any?
-              - submissions.each do |submission|
-                %tr{ class: "submission", data: { id: "#{submission.id}", service_id: "#{service.id}" } }
-                  %td
-                    .text-center
-                      = submission.id
-                  %td
-                    .text-center
-                      = link_to_if current_identity.is_super_user? || current_identity.is_service_provider?(SubServiceRequest.find(submission.line_item.sub_service_request_id)), "#{service.name}",
-                        service_additional_details_questionnaires_path(service), target: '_blank'
-                  %td.text-center
-                    = link_to service_additional_details_submission_path(service, submission),
-                      remote: true, class: 'btn btn-primary' do
-                      %span.glyphicon.glyphicon-search
 
-                  %td.text-center
-                    = link_to edit_service_additional_details_submission_path(service, submission),
-                      remote: true, class: 'btn btn-warning' do
-                      %span.glyphicon.glyphicon-edit
-                  %td.text-center
-                    = link_to "javascript:void(0);", class: 'btn btn-danger delete-submission', data: { id: "#{submission.id}", service_id: "#{service.id}", sr_id: "#{service_request.id}", protocol_id: "#{protocol.id}" } do
-                      %span.glyphicon.glyphicon-remove
-            - else
-              %tr.warning
-                %td{ colspan: '5' }
-                  .text-center
-                    = t(:additional_details)[:submissions][:none]
+- if submissions.any?
+  .panel.panel-default
+    .panel-heading
+      %h4.panel-title
+        Additional Detail Submissions
+    .panel-body
+      %table.table.table-striped.table-bordered.table-hover
+        %thead
+          %tr
+            %th.text-center
+              = 'ID'
+            %th.text-center
+              = 'Service Name'
+            %th.text-center
+              = 'View'
+            %th.text-center
+              = 'Edit'
+            %th.text-center
+              = 'Delete'
+        %tbody
+          - submissions.each do |submission|
+            - service = Service.find(submission.service_id)
+            %tr{ class: "submission", data: { id: "#{submission.id}", service_id: "#{service.id}" } }
+              %td
+                .text-center
+                  = submission.id
+              %td
+                .text-center
+                  = link_to "#{service.name}",
+                    service_additional_details_questionnaires_path(service),
+                    target: '_blank'
+              %td.text-center
+                = link_to service_additional_details_submission_path(service, submission),
+                  remote: true, class: 'btn btn-primary' do
+                  %span.glyphicon.glyphicon-search
+
+              %td.text-center
+                = link_to edit_service_additional_details_submission_path(service, submission),
+                  remote: true, class: 'btn btn-warning' do
+                  %span.glyphicon.glyphicon-edit
+              %td.text-center
+                = link_to "javascript:void(0);", class: 'btn btn-danger delete-submission', data: { id: "#{submission.id}", service_id: "#{service.id}", protocol_id: "#{submission.protocol_id}", line_item_id: "#{submission.line_item_id}" } do
+                  %span.glyphicon.glyphicon-remove

--- a/app/views/additional_details/submissions/create.js.coffee
+++ b/app/views/additional_details/submissions/create.js.coffee
@@ -21,7 +21,7 @@
 <% if @submission.save %>
 swal("Success!", "Submission saved", "success")
 $("#submissionModal").modal('hide')
-$("#additional-details-submissions-panel").html("<%= j render 'submissions_panel', protocol: @protocol %>")
+$(".additional-details-submissions-panel").html("<%= j render 'submissions_panel', protocol: @protocol, submissions: @submissions %>")
 $(".complete-additional-details").html("<%= j render 'additional_details/dashboard_complete_additional_details', service_request: @service_request %>")
 <% else %>
 swal("Error", "Submission did not save, check the form for errors", "error")

--- a/app/views/additional_details/submissions/destroy.js.coffee
+++ b/app/views/additional_details/submissions/destroy.js.coffee
@@ -20,7 +20,10 @@
 
 <% if @submission.destroy %>
 <% if params[:protocol_id] && params[:sr_id] %>
-$('#additional-details-submissions-panel').html("<%= j render 'submissions_panel', protocol: @protocol %>")
+$('.additional-details-submissions-panel').html("<%= j render 'submissions_panel', protocol: @protocol %>")
+<% end %>
+<% if params[:protocol_id] && params[:line_item_id] %>
+$('.additional-details-submissions-panel').html("<%= j render 'submissions_panel', protocol: @protocol, submissions: @submissions %>")
 $(".complete-additional-details").html("<%= j render 'additional_details/dashboard_complete_additional_details', service_request: @service_request %>")
 <% else %>
 $('.submissions-index-table').html("<%= j render 'additional_details/submissions/submission_index_table', submissions: @submissions %>")

--- a/app/views/dashboard/protocols/show.html.haml
+++ b/app/views/dashboard/protocols/show.html.haml
@@ -21,8 +21,9 @@
   = render 'dashboard/protocols/summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit || @admin
   = render 'dashboard/associated_users/table', protocol: @protocol, permission_to_edit: @permission_to_edit || @admin
   = render 'dashboard/documents/documents_table', protocol: @protocol, permission_to_edit: @permission_to_edit || @admin
-  = render "additional_details/submissions/submissions_panel", protocol: @protocol
   = render 'dashboard/service_requests/service_requests', protocol: @protocol, super_user_orgs: @super_user_orgs, permission_to_edit: @permission_to_edit, user: @user, view_only: false, show_view_ssr_back: @show_view_ssr_back
+  .additional-details-submissions-panel
+    = render "additional_details/submissions/submissions_panel", protocol: @protocol, submissions: @submissions
 
 = render 'additional_details/submissions/submission_modal'
 

--- a/db/migrate/20161018182459_add_protocol_id_to_submissions.rb
+++ b/db/migrate/20161018182459_add_protocol_id_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddProtocolIdToSubmissions < ActiveRecord::Migration
+  def change
+    add_reference :submissions, :protocol, index: true, foreign_key: true, after: :questionnaire_id
+  end
+end

--- a/db/migrate/20161019140434_add_line_item_id_to_submissions.rb
+++ b/db/migrate/20161019140434_add_line_item_id_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddLineItemIdToSubmissions < ActiveRecord::Migration
+  def change
+    add_reference :submissions, :line_item, index: true, foreign_key: true, after: :protocol_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160930185037) do
+ActiveRecord::Schema.define(version: 20161019140434) do
 
   create_table "admin_rates", force: :cascade do |t|
     t.integer  "line_item_id", limit: 4
@@ -1046,14 +1046,18 @@ ActiveRecord::Schema.define(version: 20160930185037) do
   add_index "submission_emails", ["organization_id"], name: "index_submission_emails_on_organization_id", using: :btree
 
   create_table "submissions", force: :cascade do |t|
-    t.integer  "service_id",       limit: 4
     t.integer  "identity_id",      limit: 4
     t.integer  "questionnaire_id", limit: 4
+    t.integer  "protocol_id",      limit: 4
+    t.integer  "line_item_id",     limit: 4
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.integer  "service_id",       limit: 4
   end
 
   add_index "submissions", ["identity_id"], name: "index_submissions_on_identity_id", using: :btree
+  add_index "submissions", ["line_item_id"], name: "index_submissions_on_line_item_id", using: :btree
+  add_index "submissions", ["protocol_id"], name: "index_submissions_on_protocol_id", using: :btree
   add_index "submissions", ["questionnaire_id"], name: "index_submissions_on_questionnaire_id", using: :btree
   add_index "submissions", ["service_id"], name: "index_submissions_on_service_id", using: :btree
 
@@ -1281,6 +1285,8 @@ ActiveRecord::Schema.define(version: 20160930185037) do
   add_foreign_key "questionnaire_responses", "submissions"
   add_foreign_key "questionnaires", "services"
   add_foreign_key "submissions", "identities"
+  add_foreign_key "submissions", "line_items"
+  add_foreign_key "submissions", "protocols"
   add_foreign_key "submissions", "questionnaires"
   add_foreign_key "submissions", "services"
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :submission do
+    service_id nil
+    identity_id nil
+    questionnaire_id nil
+    protocol_id nil
+    line_item_id nil
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Submission, type: :model do
 
   it { is_expected.to belong_to(:identity) }
 
+  it { is_expected.to belong_to(:questionnaire) }
+
+  it { is_expected.to belong_to(:protocol) }
+
+  it { is_expected.to belong_to(:line_item) }
+
   it { is_expected.to have_many(:questionnaire_responses) }
 
   it { is_expected.to accept_nested_attributes_for(:questionnaire_responses) }

--- a/spec/views/dashboard/protocols/show.html.haml_spec.rb
+++ b/spec/views/dashboard/protocols/show.html.haml_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'dashboard/protocols/show', type: :view do
     assign(:user, jug2)
     assign(:protocol_type, 'Study')
     assign(:permission_to_edit, false)
-    
+    assign(:submissions, [create(:submission, protocol: protocol, service: create(:service))])
     render
   end
 


### PR DESCRIPTION
I moved the Additional Detail Submissions table underneath where Service
Requests are currently. Also, if there are no submissions for that
protocol, hide the submissions table.

I associated submissions to a Protocol and Line Item. That way I could
access more data points than the way it was set up
backend-wise. [#132617999]
