### PR TITLE
Allow emails to be turned off per deployment

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -25,9 +25,11 @@ class Notifier < ActionMailer::Base
   def new_identity_waiting_for_approval identity
     @identity = identity
 
-    email = Rails.env == 'production' ? ADMIN_MAIL_TO : DEFAULT_MAIL_TO
-    cc = Rails.env == 'production' ? NEW_USER_CC : nil
-    subject = Rails.env == 'production' ? "New Question from #{t(:mailer)[:application_title]}" : "[#{Rails.env.capitalize} - EMAIL TO #{ADMIN_MAIL_TO} AND CC TO #{NEW_USER_CC}] Request for new #{t(:mailer)[:application_title]} account submitted and awaiting approval"
+    email = ADMIN_MAIL_TO
+    cc = NEW_USER_CC
+
+    ##REVIEW: This subject appears incorrect? Copy paste from previous method?
+    subject = "New Question from #{t(:mailer)[:application_title]}"
 
     mail(:to => email, :cc => cc, :from => @identity.email, :subject => subject)
   end
@@ -50,8 +52,8 @@ class Notifier < ActionMailer::Base
     attachments["service_request_#{@service_request.protocol.id}.xlsx"] = xls
 
     # only send these to the correct person in the production env
-    email = Rails.env == 'production' ? @identity.email : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? "#{t(:mailer)[:application_title]} service request" : "[#{Rails.env.capitalize} - EMAIL TO #{@identity.email}] #{t(:mailer)[:application_title]} service request"
+    email = @identity.email
+    subject = "#{t(:mailer)[:application_title]} service request"
 
     mail(:to => email, :from => NO_REPLY_FROM, :subject => subject)
   end
@@ -76,8 +78,8 @@ class Notifier < ActionMailer::Base
     @audit_report = audit_report
     attachments["service_request_#{@service_request.protocol.id}.xlsx"] = xls
 
-    email = Rails.env == 'production' ?  submission_email_address : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? "#{t(:mailer)[:application_title]} service request" : "[#{Rails.env.capitalize} - EMAIL TO #{submission_email_address}] #{t(:mailer)[:application_title]} service request"
+    email =  submission_email_address
+    subject = "#{t(:mailer)[:application_title]} service request"
 
     mail(:to => email, :from => NO_REPLY_FROM, :subject => subject)
   end
@@ -116,8 +118,8 @@ class Notifier < ActionMailer::Base
     end
 
     # only send these to the correct person in the production env
-    email = Rails.env == 'production' ? service_provider.identity.email : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? "#{@protocol.id} - #{t(:mailer)[:application_title]} service request" : "#{@protocol.id} - [#{Rails.env.capitalize} - EMAIL TO #{service_provider.identity.email}] #{t(:mailer)[:application_title]} service request"
+    email = service_provider.identity.email
+    subject = "#{@protocol.id} - #{t(:mailer)[:application_title]} service request"
 
     mail(:to => email, :from => NO_REPLY_FROM, :subject => subject)
   end
@@ -125,9 +127,10 @@ class Notifier < ActionMailer::Base
   def account_status_change identity, approved
     @approved = approved
 
+    ##REVIEW: Why do we care what the from is?
     email_from = Rails.env == 'production' ? ADMIN_MAIL_TO : DEFAULT_MAIL_TO
-    email_to = Rails.env == 'production' ? identity.email : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? "#{t(:mailer)[:application_title]} account request - status change" : "[#{Rails.env.capitalize} - EMAIL TO #{identity.email}] #{t(:mailer)[:application_title]} account request - status change"
+    email_to = identity.email
+    subject = "#{t(:mailer)[:application_title]} account request - status change"
 
     mail(:to => email_to, :from => email_from, :subject => subject)
   end
@@ -139,7 +142,7 @@ class Notifier < ActionMailer::Base
   def provide_feedback feedback
     @feedback = feedback
 
-    email_to = Rails.env == 'production' ? FEEDBACK_MAIL_TO : DEFAULT_MAIL_TO
+    email_to = FEEDBACK_MAIL_TO
     email_from = @feedback.email.blank? ? DEFAULT_MAIL_TO : @feedback.email
 
     mail(:to => email_to, :from => email_from, :subject => "Feedback")
@@ -152,8 +155,8 @@ class Notifier < ActionMailer::Base
     @service_request = sub_service_request.service_request
     @ssr = sub_service_request
 
-    email_to = Rails.env == 'production' ? identity.email : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? "#{t(:mailer)[:application_title]} - service request deleted" : "[#{Rails.env.capitalize} - EMAIL TO #{identity.email}] #{t(:mailer)[:application_title]} - service request deleted"
+    email_to = identity.email
+    subject = "#{t(:mailer)[:application_title]} - service request deleted"
 
     mail(:to => email_to, :from => NO_REPLY_FROM, :subject => subject)
   end
@@ -171,7 +174,7 @@ class Notifier < ActionMailer::Base
     @protocol = protocol
     @primary_pi = @protocol.primary_principal_investigator
 
-    email_to = Rails.env == 'production' ? @primary_pi.email : DEFAULT_MAIL_TO
+    email_to = @primary_pi.email
     subject = 'Epic Rights User Approval'
 
     mail(:to => email_to, :from => NO_REPLY_FROM, :subject => subject)

--- a/app/mailers/survey_notification.rb
+++ b/app/mailers/survey_notification.rb
@@ -25,9 +25,10 @@ class SurveyNotification < ActionMailer::Base
     @response_set = response_set
     @identity = Identity.find response_set.user_id
 
-    email = Rails.env == 'production' ? ADMIN_MAIL_TO : DEFAULT_MAIL_TO
-    cc = Rails.env == 'production' ? SYSTEM_SATISFACTION_SURVEY_CC : nil
-    subject = Rails.env == 'production' ? "System satisfaction survey completed in #{t(:mailer)[:application_title]}" : "[#{Rails.env.capitalize} - EMAIL TO #{ADMIN_MAIL_TO} AND CC TO #{SYSTEM_SATISFACTION_SURVEY_CC}] System satisfaction survey completed in #{t(:mailer)[:application_title]}"
+    email = ADMIN_MAIL_TO
+    cc = SYSTEM_SATISFACTION_SURVEY_CC
+    subject = "System satisfaction survey completed in #{t(:mailer)[:application_title]}"
+
     mail(:to => email, :cc => cc, :from => @identity.email, :subject => subject)
   end
 
@@ -35,8 +36,8 @@ class SurveyNotification < ActionMailer::Base
     @identity = identity
     @surveys = surveys
     @ssr = ssr
-    email = Rails.env == 'production' ? @identity.email : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? "#{t(:mailer)[:application_title]} Survey Notification" : "[#{Rails.env.capitalize} - EMAIL TO #{@identity.email}] #{t(:mailer)[:application_title]} Survey Notification"
+    email = @identity.email
+    subject = "#{t(:mailer)[:application_title]} Survey Notification"
     mail(:to => email, :from => NO_REPLY_FROM, :subject => subject)
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -53,8 +53,7 @@ class UserMailer < ActionMailer::Base
   private
 
   def send_message subject, is_service_provider='false', ssr_id=''
-    email = Rails.env == 'production' ? @send_to.email : DEFAULT_MAIL_TO
-    subject = Rails.env == 'production' ? subject : "[#{Rails.env.capitalize} - EMAIL TO #{@send_to.email}] #{subject}"
+    email = @send_to.email
     @is_service_provider = is_service_provider
     @ssr_id = ssr_id
 

--- a/config/initializers/01_obis_setup.rb
+++ b/config/initializers/01_obis_setup.rb
@@ -22,6 +22,12 @@ begin
   application_config ||= YAML.load_file(Rails.root.join('config', 'application.yml'))[Rails.env]
 
   DEFAULT_MAIL_TO                           = application_config['default_mail_to']
+
+  # Flag must be enabled for the system to
+  # send emails to actual users.
+  # Otherwise all emails will be routed to DEFAULT_MAIL_TO
+  SEND_EMAILS_TO_REAL_USERS                 = application_config['send_emails_to_real_users']
+
   ADMIN_MAIL_TO                             = application_config['admin_mail_to']
   EPIC_RIGHTS_MAIL_TO                       = application_config['approve_epic_rights_mail_to']
   FEEDBACK_MAIL_TO                          = application_config['feedback_mail_to']

--- a/config/initializers/mail_send_interceptor.rb
+++ b/config/initializers/mail_send_interceptor.rb
@@ -1,0 +1,17 @@
+class MailSendInterceptor
+
+  class << self
+    def delivering_email(mail)
+      cc_to = " AND CC TO #{mail.cc}" if mail.cc.present?
+
+      mail.subject = "[#{HOST} - EMAIL TO #{mail.to} #{cc_to}] #{mail.subject}"
+      mail.to = DEFAULT_MAIL_TO
+      mail.cc = nil
+    end
+  end
+end
+
+# This initializer depends on obis_setup having been run first in order to read in application config values
+if SEND_EMAILS_TO_REAL_USERS != true
+  ActionMailer::Base.register_interceptor(MailSendInterceptor)
+end

--- a/spec/mailers/notifier/get_a_cost_estimate_spec.rb
+++ b/spec/mailers/notifier/get_a_cost_estimate_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Notifier do
                                                                         identity,
                                                                         service_request.sub_service_requests.first.id) }
     it 'should display correct subject' do
-      expect(mail).to have_subject("#{service_request.protocol.id} - [Test - EMAIL TO glennj@musc.edu] SPARCRequest service request")
+      expect(mail).to have_subject("#{service_request.protocol.id} - SPARCRequest service request")
     end
 
     # Expected service provider message is defined under get_a_cost_estimate_service_provider_admin_message

--- a/spec/mailers/notifier/submitted_spec.rb
+++ b/spec/mailers/notifier/submitted_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Notifier do
                                                                           false) }
 
       it 'should display correct subject' do
-        expect(mail).to have_subject("#{service_request.protocol.id} - [Test - EMAIL TO glennj@musc.edu] SPARCRequest service request")
+        expect(mail).to have_subject("#{service_request.protocol.id} - SPARCRequest service request")
       end
       # Expected service provider message is defined under submitted_service_provider_and_admin_message
       it 'should display service provider intro message, conclusion, link, and should not display acknowledgments' do

--- a/spec/mailers/survey_notification_spec.rb
+++ b/spec/mailers/survey_notification_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SurveyNotification do
 
     #ensure that the subject is correct
     it 'renders the subject' do
-      expect(mail).to have_subject("[Test - EMAIL TO catesa@musc.edu AND CC TO amcates@gmail.com, catesa@musc.edu] System satisfaction survey completed in SPARCRequest")
+      expect(mail).to have_subject("System satisfaction survey completed in SPARCRequest")
     end
 
     #ensure that the receiver is correct
@@ -55,7 +55,7 @@ RSpec.describe SurveyNotification do
 
     #ensure that the sender is correct
     it 'renders the sender email' do
-      expect(mail).to deliver_to(DEFAULT_MAIL_TO)
+      expect(mail).to deliver_to(ADMIN_MAIL_TO)
     end
 
     #ensure that the e-mail body is correct
@@ -75,12 +75,12 @@ RSpec.describe SurveyNotification do
 
     #ensure that the subject is correct
     it 'renders the subject' do
-      expect(mail).to have_subject("[Test - EMAIL TO nobody@nowhere.com] SPARCRequest Survey Notification")
+      expect(mail).to have_subject("SPARCRequest Survey Notification")
     end
 
     #ensure that the receiver is correct
     it 'renders the receiver email' do
-      expect(mail).to deliver_to(DEFAULT_MAIL_TO)
+      expect(mail).to deliver_to(identity.email)
     end
 
     #ensure that the sender is correct


### PR DESCRIPTION
We needed to be able to disable sending of emails to real users in our test and staging environments, but relying on a check for the Rails environment is problematic and was duplicated in several places in the code.

This change removes the duplication and contains the logic in a single place. It also moves the setting to application.yml.

This setting is intentionally off by default so that someone couldn't accidentally deploy to testing and have it start sending emails on them.
## 

I created this branch based on the release-1.8.0 tag thinking that it would then not pick up any changes that were not ready to be released. But it looks like the tags get created off musc_production but musc_production has stuff that's not in master?
