### PR TITLE
KG - Add Service next_ssr_id bug

### DIFF
--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -444,7 +444,7 @@ class ServiceRequest < ActiveRecord::Base
 
   # Make sure that all the sub service requests have an ssr id
   def ensure_ssr_ids
-    next_ssr_id = self.protocol ? self.protocol.next_ssr_id : 1
+    next_ssr_id = self.protocol && self.protocol.next_ssr_id.present? ? self.protocol.next_ssr_id : 1
 
     self.sub_service_requests.each do |ssr|
       unless ssr.ssr_id


### PR DESCRIPTION
When a protocol did not have a next_ssr_id in the database, it could not be interpolated as "%04d" % next_ssr_id