### PR TITLE
SAW - Status History Table Sequence Bug

### DIFF
--- a/app/helpers/dashboard/application_helper.rb
+++ b/app/helpers/dashboard/application_helper.rb
@@ -30,7 +30,7 @@ module Dashboard::ApplicationHelper
 
   def format_datetime date
     if date.present?
-      date.strftime('%D %I:%M %p')
+      date.strftime('%D %I:%M:%S %p')
     else
       ''
     end


### PR DESCRIPTION
Added seconds to format_datetime method so that seconds can be included when filtering the Status History table by date.
The seconds should appear in all tables that can be filtered by date and time for consistency.