### PR TITLE
KG - Admin Edit Locked SSR Display Bug

### DIFF
--- a/app/controllers/dashboard/sub_service_requests_controller.rb
+++ b/app/controllers/dashboard/sub_service_requests_controller.rb
@@ -55,6 +55,7 @@ class Dashboard::SubServiceRequestsController < Dashboard::BaseController
         @protocol           = @service_request.protocol
         @tab                = 'calendar'
         @portal             = true
+        @admin              = false
         @review             = true
         @merged             = false
         @consolidated       = false

--- a/app/controllers/service_calendars_controller.rb
+++ b/app/controllers/service_calendars_controller.rb
@@ -24,6 +24,8 @@
 ############################################
 ## portal:        Are we accessing the calendar from the dashboard? True or False
 ##
+## admin:         Are we accessing the calendar by clicking Admin Edit from the dashboard? True or False
+##
 ## merged:        Are we accessing the Consolidated Request calendar? True or False
 ##
 ## review:        Are we viewing the Step 4 Review calendar? True or False
@@ -70,6 +72,7 @@ class ServiceCalendarsController < ApplicationController
     @tab          = params[:tab]
     @review       = params[:review] == 'true'
     @portal       = params[:portal] == 'true'
+    @admin        = @portal && @sub_service_request.present?
     @merged       = false
     @consolidated = false
 
@@ -85,6 +88,7 @@ class ServiceCalendarsController < ApplicationController
     @tab          = params[:tab]
     @review       = params[:review] == 'true'
     @portal       = params[:portal] == 'true'
+    @admin        = @portal && @sub_service_request.present?
     @merged       = true
     @consolidated = false
 
@@ -100,6 +104,7 @@ class ServiceCalendarsController < ApplicationController
     @tab                = 'calendar'
     @review             = false
     @portal             = true
+    @admin              = false
     @merged             = true
     @consolidated       = true
     @protocol           = Protocol.find(params[:protocol_id])

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -161,6 +161,7 @@ class ServiceRequestsController < ApplicationController
     @tab          = 'calendar'
     @review       = true
     @portal       = false
+    @admin        = false
     @merged       = false
     @consolidated = true
 

--- a/app/views/dashboard/sub_service_requests/_user_modal_ssr_show.html.haml
+++ b/app/views/dashboard/sub_service_requests/_user_modal_ssr_show.html.haml
@@ -30,10 +30,10 @@
         - if sub_service_request.has_per_patient_per_visit_services?
           - service_request.arms.each do |arm|
             - next if arm.visit_groups.empty?
-            = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, review: review, portal: portal, merged: merged, consolidated: consolidated
+            = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, review: review, portal: portal, admin: admin, merged: merged, consolidated: consolidated
 
         - if sub_service_request.has_one_time_fee_services? 
-          = render 'service_calendars/master_calendar/otf/otf_calendar', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal, merged: merged, consolidated: consolidated
+          = render 'service_calendars/master_calendar/otf/otf_calendar', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal, admin: admin, merged: merged, consolidated: consolidated
         .panel.panel-primary
           .panel-heading
             %h4.panel-title

--- a/app/views/dashboard/sub_service_requests/show.js.coffee
+++ b/app/views/dashboard/sub_service_requests/show.js.coffee
@@ -18,6 +18,6 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$('#modal_place').html("<%= escape_javascript(render( 'dashboard/sub_service_requests/user_modal_ssr_show', sub_service_request: @sub_service_request, show_view_ssr_back: @show_view_ssr_back, service_request: @service_request, service_list: @service_list, tab: @tab, portal: @portal, review: @review, consolidated: @consolidated, pages: @pages, merged: @merged, protocol: @protocol )) %>")
+$('#modal_place').html("<%= escape_javascript(render( 'dashboard/sub_service_requests/user_modal_ssr_show', sub_service_request: @sub_service_request, show_view_ssr_back: @show_view_ssr_back, service_request: @service_request, service_list: @service_list, tab: @tab, portal: @portal, admin: @admin, review: @review, consolidated: @consolidated, pages: @pages, merged: @merged, protocol: @protocol )) %>")
 $('#modal_place').modal 'show'
 $('.selectpicker').selectpicker()

--- a/app/views/service_calendars/_view_full_calendar.html.haml
+++ b/app/views/service_calendars/_view_full_calendar.html.haml
@@ -32,10 +32,10 @@
             - if has_pppv = service_request.sub_service_requests.where.not(status: ['first_draft', 'draft']).joins(line_items: :service).where(services: { one_time_fee: false }).any? #Are there any non-'first_draft'-or-'draft' SSRs with PPPV services?
               - service_request.arms.each do |arm|
                 - next if arm.visit_groups.empty? || SubServiceRequest.where(id: arm.line_items.map(&:sub_service_request_id)).where.not(status: ['first_draft', 'draft']).empty?
-                = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, review: review, portal: portal, merged: merged, consolidated: consolidated
+                = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, review: review, portal: portal, admin: admin, merged: merged, consolidated: consolidated
 
             - if has_otf = service_request.sub_service_requests.where.not(status: ['first_draft', 'draft']).joins(line_items: :service).where(services: { one_time_fee: true }).any? #Are there any non-'first_draft'-or-'draft' SSRs with OTF services?
-              = render 'service_calendars/master_calendar/otf/otf_calendar', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal, merged: merged, consolidated: consolidated
+              = render 'service_calendars/master_calendar/otf/otf_calendar', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal, admin: admin, merged: merged, consolidated: consolidated
 
             - if has_pppv || has_otf
               = render 'service_calendars/master_calendar/merged_grand_totals', service_request: service_request

--- a/app/views/service_calendars/master_calendar/otf/_otf_calendar.html.haml
+++ b/app/views/service_calendars/master_calendar/otf/_otf_calendar.html.haml
@@ -25,4 +25,4 @@
     %thead
       = render 'service_calendars/master_calendar/otf/otf_header', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal
     %tbody
-      = render 'service_calendars/master_calendar/otf/otf_line_items', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal, merged: merged, consolidated: consolidated
+      = render 'service_calendars/master_calendar/otf/otf_line_items', tab: tab, service_request: service_request, sub_service_request: sub_service_request, review: review, portal: portal, admin: admin, merged: merged, consolidated: consolidated

--- a/app/views/service_calendars/master_calendar/otf/_otf_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/otf/_otf_line_items.html.haml
@@ -19,9 +19,9 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 - service_request.service_list(true).each do |_, value| # get only one time fee services and group them
   - next unless sub_service_request.nil? || sub_service_request.organization.name == value[:process_ssr_organization_name]
-  - ssr           = value[:line_items][0].sub_service_request
+  - ssr = value[:line_items][0].sub_service_request
   - next if ssr.status == 'first_draft' || (consolidated && ssr.status == 'draft')
-  - locked        = !ssr.can_be_edited?
+  - locked = !ssr.can_be_edited? && !admin
   
   %tr.organization-header{ class: locked ? 'bg-danger text-danger' : '' }
     %th{ colspan: 14 }

--- a/app/views/service_calendars/master_calendar/pppv/_billing_strategy_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_billing_strategy_line_items.html.haml
@@ -21,7 +21,7 @@
 - Dashboard::ServiceCalendars.pppv_line_items_visits_to_display(arm, service_request, sub_service_request, merged: merged, portal: portal, review: review, consolidated: consolidated).each do |org_name, livs|
   - line_items_visits << livs
   - ssr    = livs[0].sub_service_request
-  - locked = !ssr.can_be_edited?
+  - locked = !ssr.can_be_edited? && !admin
 
   -# SSR Header Row
   %tr.organization-header{ class: locked ? 'text-danger' : '' }

--- a/app/views/service_calendars/master_calendar/pppv/_calendar_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_calendar_line_items.html.haml
@@ -21,7 +21,7 @@
 - Dashboard::ServiceCalendars.pppv_line_items_visits_to_display(arm, service_request, sub_service_request, merged: merged, portal: portal, review: review, consolidated: consolidated).each do |org_name, livs|
   - line_items_visits << livs
   - ssr    = livs[0].sub_service_request
-  - locked = !ssr.can_be_edited?
+  - locked = !ssr.can_be_edited? && !admin
 
   -# SSR Header Row
   %tr.organization-header{ class: locked ? 'text-danger' : '' }

--- a/app/views/service_calendars/master_calendar/pppv/_pppv_calendar.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_pppv_calendar.html.haml
@@ -32,4 +32,4 @@
     %thead
       = render "service_calendars/master_calendar/pppv/#{tab}_header", service_request: service_request, sub_service_request: sub_service_request, arm: arm, tab: tab, pages: pages, page: page, review: review, portal: portal, visit_groups: visit_groups
     %tbody
-      = render "service_calendars/master_calendar/pppv/#{tab}_line_items", service_request: service_request, sub_service_request: sub_service_request, arm: arm, tab: tab, pages: pages, page: page, review: review, portal: portal, merged: merged, consolidated: consolidated, visit_groups: visit_groups
+      = render "service_calendars/master_calendar/pppv/#{tab}_line_items", service_request: service_request, sub_service_request: sub_service_request, arm: arm, tab: tab, pages: pages, page: page, review: review, portal: portal, admin: admin, merged: merged, consolidated: consolidated, visit_groups: visit_groups

--- a/app/views/service_calendars/master_calendar/pppv/_template_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_template_line_items.html.haml
@@ -21,7 +21,7 @@
 - Dashboard::ServiceCalendars.pppv_line_items_visits_to_display(arm, service_request, sub_service_request, merged: merged, portal: portal, review: review, consolidated: consolidated).each do |org_name, livs|
   - line_items_visits << livs
   - ssr    = livs[0].sub_service_request
-  - locked = !ssr.can_be_edited?
+  - locked = !ssr.can_be_edited? && !admin
 
   -# SSR Header Row
   %tr.organization-header{ class: locked ? 'text-danger' : '' }

--- a/app/views/service_calendars/merged_calendar.html.haml
+++ b/app/views/service_calendars/merged_calendar.html.haml
@@ -23,9 +23,9 @@
 - if @service_request.has_per_patient_per_visit_services?
   - @service_request.arms.each do |arm|
     - next if arm.visit_groups.empty?
-    = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[arm.id], pages: @pages, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated
+    = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[arm.id], pages: @pages, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated
 
 - if @service_request.has_one_time_fee_services?
-  = render 'service_calendars/master_calendar/otf/otf_calendar', tab: @tab, service_request: @service_request, sub_service_request: @sub_service_request, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated
+  = render 'service_calendars/master_calendar/otf/otf_calendar', tab: @tab, service_request: @service_request, sub_service_request: @sub_service_request, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated
 
 = render 'service_calendars/master_calendar/merged_grand_totals', service_request: @service_request

--- a/app/views/service_calendars/merged_calendar.js.coffee
+++ b/app/views/service_calendars/merged_calendar.js.coffee
@@ -17,7 +17,7 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$(".arm-calendar-container-<%= @arm.id %>").html("<%= escape_javascript(render( '/service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[@arm.id], pages: @pages, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated )) %>")
+$(".arm-calendar-container-<%= @arm.id %>").html("<%= escape_javascript(render( '/service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[@arm.id], pages: @pages, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated )) %>")
 $('.selectpicker').selectpicker()
 setup_xeditable_fields()
 changing_tabs_calculating_rates()

--- a/app/views/service_calendars/table.html.haml
+++ b/app/views/service_calendars/table.html.haml
@@ -23,7 +23,7 @@
 - if @sub_service_request ? @sub_service_request.has_per_patient_per_visit_services? : @service_request.has_per_patient_per_visit_services?
   - @service_request.arms.each do |arm|
     - next if arm.visit_groups.empty?
-    = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[arm.id], pages: @pages, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated
+    = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[arm.id], pages: @pages, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated
 
 - if !@portal && (@sub_service_request ? @sub_service_request.has_one_time_fee_services? : @service_request.has_one_time_fee_services?)
-  = render 'service_calendars/master_calendar/otf/otf_calendar', tab: @tab, service_request: @service_request, sub_service_request: @sub_service_request, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated
+  = render 'service_calendars/master_calendar/otf/otf_calendar', tab: @tab, service_request: @service_request, sub_service_request: @sub_service_request, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated

--- a/app/views/service_calendars/table.js.coffee
+++ b/app/views/service_calendars/table.js.coffee
@@ -17,7 +17,7 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$(".arm-calendar-container-<%= @arm.id %>").html("<%= escape_javascript(render( '/service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[@arm.id], pages: @pages, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated )) %>")
+$(".arm-calendar-container-<%= @arm.id %>").html("<%= escape_javascript(render( '/service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @pages[@arm.id], pages: @pages, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated )) %>")
 $('.selectpicker').selectpicker()
 setup_xeditable_fields()
 changing_tabs_calculating_rates()

--- a/app/views/service_calendars/view_full_calendar.js.coffee
+++ b/app/views/service_calendars/view_full_calendar.js.coffee
@@ -17,7 +17,7 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$('#modal_place').html("<%= escape_javascript(render( 'service_calendars/view_full_calendar', tab: @tab, service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, review: @review, portal: @portal, merged: @merged, consolidated: @consolidated )) %>")
+$('#modal_place').html("<%= escape_javascript(render( 'service_calendars/view_full_calendar', tab: @tab, service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, review: @review, portal: @portal, admin: @admin, merged: @merged, consolidated: @consolidated )) %>")
 $('#modal_place').modal('show')
 $('.selectpicker').selectpicker()
 changing_tabs_calculating_rates()

--- a/app/views/service_requests/review.html.haml
+++ b/app/views/service_requests/review.html.haml
@@ -27,7 +27,7 @@
     = render 'service_requests/review/authorized_users', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/documents', protocol: @service_request.protocol
     = render 'service_requests/review/notes', service_request: @service_request, notable_id: @service_request.id, notable_type: 'ServiceRequest'
-    = render 'service_requests/review/calendars', service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, tab: @tab, arm: @arm, portal: @portal, review: @review, merged: @merged, consolidated: @consolidated
+    = render 'service_requests/review/calendars', service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, tab: @tab, arm: @arm, portal: @portal, admin: @admin, review: @review, merged: @merged, consolidated: @consolidated
 = render 'service_requests/navigation/footer', service_request: @service_request, css_class: @css_class, back: @back, forward: @forward
 
 - if SYSTEM_SATISFACTION_SURVEY

--- a/app/views/service_requests/review/_calendars.html.haml
+++ b/app/views/service_requests/review/_calendars.html.haml
@@ -25,12 +25,12 @@
           = t(:proper)[:review][:pppv_calendars_notice]
       - service_request.arms.each do |arm|
         - next if arm.visit_groups.empty?
-        = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, portal: portal, review: review, merged: merged, consolidated: consolidated
+        = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, portal: portal, admin: admin, review: review, merged: merged, consolidated: consolidated
   .otf-calendars
     .page-header
       %h3
         = t(:proper)[:review][:otf_calendar_notice]
-    = render 'service_calendars/master_calendar/otf/otf_calendar', tab: tab, service_request: service_request, sub_service_request: sub_service_request, portal: portal, review: review, merged: merged, consolidated: consolidated, protocol: service_request.protocol
+    = render 'service_calendars/master_calendar/otf/otf_calendar', tab: tab, service_request: service_request, sub_service_request: sub_service_request, portal: portal, admin: admin, review: review, merged: merged, consolidated: consolidated, protocol: service_request.protocol
   .totals
     .page-header
       %h3


### PR DESCRIPTION
When trying to Admin Edit a locked SSR, the admin's study schedule calendars would incorrectly show the styles for a locked SSR. This is incorrect because the admin has full access to edit the request from Admin Edit.