### PR TITLE
Call authorized user form logic when rendering modals. #134791879

### DIFF
--- a/app/assets/javascripts/associated_users_form.js.coffee
+++ b/app/assets/javascripts/associated_users_form.js.coffee
@@ -21,17 +21,9 @@ $(document).ready ->
 
   #**************** Add Authorized User Form Begin ****************
 
-  # Credentials - Dropdown
-  $(document).on 'changed.bs.select', '#project_role_identity_attributes_credentials', ->
-    if $(this).val() == 'other'
-      $('.credentials_dependent.other').removeClass('hidden')
-    else
-      $('.credentials_dependent.other').addClass('hidden')
-
-  # Role - Dropdown
-  $(document).on 'changed.bs.select', '#project_role_role', ->
+  window.update_disabled_hidden_form_items = () ->
     $('.role_dependent').addClass('hidden')
-    switch $(this).val()
+    switch $('#project_role_role').val()
       when 'other'
         $('.role_dependent.other').removeClass('hidden')
       when 'business-grants-manager'
@@ -51,6 +43,17 @@ $(document).ready ->
         $('input[name="project_role[project_rights]"]').attr('disabled', false).attr('checked', false)
         $('.role_dependent.commons_name').removeClass('hidden')
         $('.role_dependent.subspecialty').removeClass('hidden')
+
+  # Credentials - Dropdown
+  $(document).on 'changed.bs.select', '#project_role_identity_attributes_credentials', ->
+    if $(this).val() == 'other'
+      $('.credentials_dependent.other').removeClass('hidden')
+    else
+      $('.credentials_dependent.other').addClass('hidden')
+
+  # Role - Dropdown
+  $(document).on 'changed.bs.select', '#project_role_role', ->
+    window.update_disabled_hidden_form_items()
 
   # Renders warning when changing Primary PI
   $(document).on 'click', '#save_protocol_rights_button', ->

--- a/app/views/associated_users/edit.js.coffee
+++ b/app/views/associated_users/edit.js.coffee
@@ -20,3 +20,4 @@
 $("#modal_place").html("<%= escape_javascript(render( 'associated_users/user_form', protocol: @protocol, project_role: @protocol_role, identity: @identity, current_pi: @current_pi, header_text: @header_text )) %>")
 $("#modal_place").modal 'show'
 $(".selectpicker").selectpicker()
+window.update_disabled_hidden_form_items()

--- a/app/views/dashboard/associated_users/edit.js.coffee
+++ b/app/views/dashboard/associated_users/edit.js.coffee
@@ -21,3 +21,5 @@
 $("#modal_place").html("<%= escape_javascript(render(partial: 'associated_users/user_form', locals: { protocol: @protocol, project_role: @protocol_role, identity: @identity, current_pi: @current_pi, header_text: @header_text })) %>")
 $("#modal_place").modal 'show'
 $(".selectpicker").selectpicker()
+
+window.update_disabled_hidden_form_items()


### PR DESCRIPTION
Some fields were not visible when the Add/Edit Authorized User modal is first rendered.