### PR TITLE
KG - Service Search No Results

### DIFF
--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -81,11 +81,13 @@ $(document).ready ->
                                           <span><strong>Abbreviation: {{abbreviation}}</strong></span><br>
                                           <span><strong>CPT Code: {{cpt_code}}</strong></span>
                                         </button>')
+        notFound: Handlebars.compile('<div class="tt-suggestion">No Results</div>')
       }
     }
   ).on('typeahead:render', (event, a, b, c) ->
     $('[data-toggle="tooltip"]').tooltip()
   ).on('typeahead:select', (event, suggestion) ->
+    asd
     srid = $(this).data('srid')
     id = suggestion.value
     $.ajax

--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -81,7 +81,7 @@ $(document).ready ->
                                           <span><strong>Abbreviation: {{abbreviation}}</strong></span><br>
                                           <span><strong>CPT Code: {{cpt_code}}</strong></span>
                                         </button>')
-        notFound: Handlebars.compile('<div class="tt-suggestion">No Results</div>')
+        notFound: '<div class="tt-suggestion">No Results</div>'
       }
     }
   ).on('typeahead:render', (event, a, b, c) ->

--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -87,7 +87,6 @@ $(document).ready ->
   ).on('typeahead:render', (event, a, b, c) ->
     $('[data-toggle="tooltip"]').tooltip()
   ).on('typeahead:select', (event, suggestion) ->
-    asd
     srid = $(this).data('srid')
     id = suggestion.value
     $.ajax

--- a/app/assets/stylesheets/twitter_typeahead.sass
+++ b/app/assets/stylesheets/twitter_typeahead.sass
@@ -22,6 +22,7 @@
   max-height: 200px
   overflow-y: auto
   margin-top: 12px
+  padding: 8px 0
   background-color: #fff
   border: 1px solid #ccc
   border: 1px solid rgba(0, 0, 0, 0.2)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,4 @@
-  # Copyright © 2011-2016 MUSC Foundation for Research Development
+# Copyright © 2011-2016 MUSC Foundation for Research Development
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,4 @@
-# Copyright © 2011-2016 MUSC Foundation for Research Development
+  # Copyright © 2011-2016 MUSC Foundation for Research Development
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -51,8 +51,6 @@ class SearchController < ApplicationController
         term:           params[:term]
       }
     }
-
-    results = [{label: 'No Results'}] if results.empty?
 
     render json: results.to_json
   end


### PR DESCRIPTION
The controller code was causing the No Results to be displayed like a service. Typeahead has the custom template notFound that we can use instead. We can render a quick Handlebar template for that case.