### PR TITLE
wth - fix table layout when showing epic emr access

### DIFF
--- a/app/assets/stylesheets/associated_users_table.scss
+++ b/app/assets/stylesheets/associated_users_table.scss
@@ -1,0 +1,4 @@
+#associated-users-table {
+  table-layout: fixed;
+  word-wrap: break-word;
+}

--- a/app/views/service_requests/protocol.html.haml
+++ b/app/views/service_requests/protocol.html.haml
@@ -18,6 +18,7 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 = javascript_include_tag 'protocol'
+= stylesheet_link_tag 'associated_users_table'
 
 = render '/service_requests/navigation/steps', service_request: @service_request, step: @step_text, css_class: @css_class
 = render 'service_requests/modals/request_submitted_modal', service_request: @service_request


### PR DESCRIPTION
I set the table layout to fixed and to have the words wrap. Adding
authorized users was causing table overflow. [#134878077]