### PR TITLE
wth - epic emr access column table fix

### DIFF
--- a/app/assets/stylesheets/associated_users_table.scss
+++ b/app/assets/stylesheets/associated_users_table.scss
@@ -1,4 +1,5 @@
 #associated-users-table {
-  table-layout: fixed;
-  word-wrap: break-word;
+  tbody, tr {
+    word-break: break-word;
+  }
 }


### PR DESCRIPTION
Show full table header, but break word if necessary. [#134878077]