### PR TITLE
On the confirmation page, the status of the request should change to …

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -614,10 +614,10 @@ class ServiceRequestsController < ApplicationController
     Notifier.notify_for_epic_user_approval(protocol).deliver unless QUEUE_EPIC
   end
 
-  def update_service_request_status(service_request, status, validate=true, submit_button=false)
+  def update_service_request_status(service_request, status, validate=true, submit=false)
     requests = []
     service_request.sub_service_requests.each do |ssr|
-      if UPDATABLE_STATUSES.include?(ssr.status) || !submit_button
+      if UPDATABLE_STATUSES.include?(ssr.status) || !submit
         requests << ssr
       end
     end
@@ -625,11 +625,8 @@ class ServiceRequestsController < ApplicationController
     if (status == 'submitted')
       service_request.previous_submitted_at = service_request.submitted_at
       service_request.update_attribute(:submitted_at, Time.now)
-      requests.each { |ssr| ssr.update_attributes(submitted_at: Time.now) }
-    else
-      requests.each { |ssr| ssr.update_attributes(status: status) }
     end
-    to_notify = service_request.update_status(status, validate)
+    to_notify = service_request.update_status(status, validate, submit)
 
     to_notify
   end

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -423,7 +423,7 @@ class ServiceRequest < ActiveRecord::Base
 
   # Change the status of the service request and all the sub service
   # requests to the given status.
-  def update_status(new_status, use_validation=true)
+  def update_status(new_status, use_validation=true, submit=false)
     to_notify = []
 
     self.assign_attributes(status: new_status)
@@ -435,7 +435,7 @@ class ServiceRequest < ActiveRecord::Base
       changeable = available & editable
 
       if changeable.include?(new_status)
-        if (ssr.status != new_status) && UPDATABLE_STATUSES.include?(ssr.status)
+        if (ssr.status != new_status) && (UPDATABLE_STATUSES.include?(ssr.status) || !submit)
           ssr.update_attribute(:status, new_status)
           to_notify << ssr.id
         end


### PR DESCRIPTION
…either draft or get_a_cost_estimate if those buttons are clicked even if not in an updatable status.