### PR TITLE
Jjh session

### DIFF
--- a/app/assets/javascripts/associated_users.js.coffee
+++ b/app/assets/javascripts/associated_users.js.coffee
@@ -18,12 +18,16 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 $(document).ready ->
+  getSRId = () ->
+    $('input[name="service_request_id"]').val()
+
   $(document).on 'click', '#new-associated-user-button', ->
     $.ajax
       type: 'get'
       url: '/associated_users/new.js'
       data:
         protocol_id: $(this).data('protocol-id')
+        service_request_id: getSRId()
     return false
 
   $(document).on 'click', '.edit-associated-user-button', (event) ->
@@ -31,6 +35,8 @@ $(document).ready ->
     $.ajax
       type: 'get'
       url: "/associated_users/#{project_role_id}/edit.js"
+      data:
+        service_request_id: getSRId()
       success: ->
         if $('#project_role_role').val() == 'other'
           $('.role_dependent.other').show()
@@ -57,5 +63,5 @@ $(document).ready ->
       if confirm(confirm_message)
         $.ajax
           type: 'delete'
-          url: "/associated_users/#{project_role_id}"
+          url: "/associated_users/#{project_role_id}?service_request_id=#{getSRId()}"
     return false

--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -23,6 +23,7 @@
 $(document).ready ->
   getSRId = () ->
     $('input[name="service_request_id"]').val()
+
   ### ACCORDION LOGIC ###
   $(document).on 'click', '.institution-header, .provider-header, .program-link:not(.locked-program)', ->
     if $(this).hasClass('institution-header')
@@ -68,7 +69,7 @@ $(document).ready ->
     datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
     queryTokenizer: Bloodhound.tokenizers.whitespace,
     remote:
-      url: '/search/services?term=%QUERY',
+      url: "/search/services?term=%QUERY&service_request_id=#{getSRId()}",
       wildcard: '%QUERY'
   )
   services_bloodhound.initialize() # Initialize the Bloodhound suggestion engine
@@ -99,6 +100,8 @@ $(document).ready ->
     $.ajax
       type: 'POST'
       url: "/service_requests/#{srid}/add_service/#{id}"
+      data:
+        service_request_id: getSRId()
   )
 
   ### CONTINUE BUTTON ###

--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -105,7 +105,7 @@ $(document).ready ->
   $(document).on 'click', '.submit-request-button', ->
     signed_in = parseInt($('#signed_in').val())
     if signed_in == 0
-      window.location.replace('/identities/sign_in')
+      window.location.href = $('#login-link').attr('href')
       return false
     else if $('#line_item_count').val() <= 0
       $('#modal_place').html($('#submit-error-modal').html())

--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -21,6 +21,8 @@
 #= require cart
 
 $(document).ready ->
+  getSRId = () ->
+    $('input[name="service_request_id"]').val()
   ### ACCORDION LOGIC ###
   $(document).on 'click', '.institution-header, .provider-header, .program-link:not(.locked-program)', ->
     if $(this).hasClass('institution-header')
@@ -34,7 +36,9 @@ $(document).ready ->
       $('.program-link').removeClass('clicked')
     $(this).addClass('clicked')
     id    = $(this).data('id')
-    data  = process_ssr_found : $(this).data('process-ssr-found') 
+    data =
+      process_ssr_found: $(this).data('process-ssr-found')
+      service_request_id: getSRId()
     $.ajax
       type: 'POST'
       data: data

--- a/app/assets/javascripts/dashboard/documents.js.coffee
+++ b/app/assets/javascripts/dashboard/documents.js.coffee
@@ -19,12 +19,17 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 $ ->
+  getSRId = ->
+    $("input[name='service_request_id']").val()
 
   # DOCUMENTS LISTENERS BEGIN
 
   $(document).on 'click', '#document-new', ->
     if $(this).data('permission')
-      data = 'protocol_id': $(this).data('protocol-id')
+      data =
+        protocol_id: $(this).data('protocol-id')
+        service_request_id: getSRId()
+
       $.ajax
         type: 'GET'
         url: '/dashboard/documents/new'
@@ -37,6 +42,8 @@ $ ->
       $.ajax
         type: 'GET'
         url: "/dashboard/documents/#{document_id}/edit"
+        data:
+          service_request_id: getSRId()
 
   $(document).on 'click', '.document-delete', ->
     if $(this).data('permission')
@@ -45,7 +52,7 @@ $ ->
       if confirm "Are you sure you want to delete the selected Document from this Protocol?"
         $.ajax
           type: 'DELETE'
-          url: "/dashboard/documents/#{document_id}"
+          url: "/dashboard/documents/#{document_id}?service_request_id=#{getSRId()}"
 
   $(document).on 'change', '#document_doc_type', ->
     if $(this).val() == 'other'

--- a/app/assets/javascripts/dashboard/protocols.js.coffee
+++ b/app/assets/javascripts/dashboard/protocols.js.coffee
@@ -23,6 +23,9 @@
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 $(document).ready ->
   Sparc.protocol =
+    getSRId = () ->
+      $('input[name="service_request_id"]').val()
+
     ready: ->
       $('.service-requests-table').on 'all.bs.table', ->
         $(this).find('.selectpicker').selectpicker() #Find descendant selectpickers

--- a/app/assets/javascripts/dashboard/protocols.js.coffee
+++ b/app/assets/javascripts/dashboard/protocols.js.coffee
@@ -23,10 +23,10 @@
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 $(document).ready ->
   Sparc.protocol =
-    getSRId = () ->
-      $('input[name="service_request_id"]').val()
-
     ready: ->
+      getSRId = () ->
+        $('input[name="service_request_id"]').val()
+
       $('.service-requests-table').on 'all.bs.table', ->
         $(this).find('.selectpicker').selectpicker() #Find descendant selectpickers
 
@@ -119,6 +119,8 @@ $(document).ready ->
         $.ajax
           method: 'get'
           url: "/dashboard/protocols/#{protocol_id}/view_details"
+          data:
+            service_request_id: $("input[name='service_request_id']").val()
 
       $(document).on 'click', '.edit-protocol-information-button', ->
         if $(this).data('permission')

--- a/app/assets/javascripts/document_management.js.coffee
+++ b/app/assets/javascripts/document_management.js.coffee
@@ -22,8 +22,13 @@
 #= require cart
 
 $(document).ready ->
+  getSRId = ->
+    $("input[name='service_request_id']").val()
+
   $(document).on 'click', '#document-new', ->
-    data = 'protocol_id': $(this).data('protocol-id')
+    data =
+      protocol_id: $(this).data('protocol-id')
+      service_request_id: getSRId()
     $.ajax
       type: 'GET'
       url: '/documents/new'
@@ -36,6 +41,8 @@ $(document).ready ->
     $.ajax
       type: 'GET'
       url: "/documents/#{document_id}/edit"
+      data:
+          service_request_id: getSRId()
 
   $(document).on 'click', '.document-delete', ->
     row_index   = $(this).parents('tr').data('index')
@@ -43,7 +50,7 @@ $(document).ready ->
     if confirm I18n['documents']['delete_confirm']
       $.ajax
         type: 'DELETE'
-        url: "/documents/#{document_id}"
+        url: "/documents/#{document_id}?service_request_id=#{getSRId()}"
 
   $(document).on 'change', '#document_doc_type', ->
     if $(this).val() == 'other'
@@ -62,4 +69,5 @@ $(document).ready ->
           notable_type: notable_type
           notable_id: notable_id
         in_dashboard: false
+        service_request_id: getSRId()
     return false

--- a/app/assets/javascripts/document_management.js.coffee
+++ b/app/assets/javascripts/document_management.js.coffee
@@ -42,7 +42,7 @@ $(document).ready ->
       type: 'GET'
       url: "/documents/#{document_id}/edit"
       data:
-          service_request_id: getSRId()
+        service_request_id: getSRId()
 
   $(document).on 'click', '.document-delete', ->
     row_index   = $(this).parents('tr').data('index')

--- a/app/assets/javascripts/protocol.js.coffee
+++ b/app/assets/javascripts/protocol.js.coffee
@@ -38,4 +38,6 @@ $(document).ready ->
     $.ajax
       type: 'get'
       url: "/protocols/#{protocol_id}/view_details"
+      data:
+        service_request_id: $("input[name='service_request_id']").val()
     return false

--- a/app/assets/javascripts/service_calendar.js.coffee
+++ b/app/assets/javascripts/service_calendar.js.coffee
@@ -21,6 +21,12 @@
 #= require navigation
 
 $(document).ready ->
+  getSRId = ->
+    $("input[name='service_request_id']").val()
+
+  getSSRId = ->
+    $("input[name='sub_service_request_id']").val()
+
   $(document).on 'click', '.page-change-arrow', ->
     unless $(this).attr('disabled')
       $.ajax
@@ -53,7 +59,9 @@ $(document).ready ->
     $.ajax
       type: 'GET'
       url: '/service_calendars/show_move_visits'
-      data: arm_id: arm_id
+      data:
+        arm_id: arm_id
+        service_request_id: getSRId()
     return false
 
   $(document).on 'change', '.visit-quantity', ->
@@ -67,6 +75,8 @@ $(document).ready ->
         visit_id: $(this).data('visit-id')
         portal: $(this).data('portal')
         sub_service_request_id: $(this).data('ssrid')
+        service_request_id: getSRId()
+        sub_service_request_id: getSSRId()
       url: $(this).attr('update')
 
 (exports ? this).changing_tabs_calculating_rates = ->
@@ -100,14 +110,18 @@ calculate_max_rates = (arm_id) ->
     $(".arm-calendar-container-#{arm_id}:visible #{column}.max-indirect-per-patient").html(indirect_total_display)
     $(".arm-calendar-container-#{arm_id}:visible #{column}.max-total-per-patient").html(max_total_display)
 
+getSRId = ->
+  $("input[name='service_request_id']").val()
+
 (exports ? this).setup_xeditable_fields = () ->
   reload_calendar = (arm_id) ->
     # E.g. "billing-strategy-tab" -> "billing_strategy"
     tab = $('li.custom-tab.active a').last().attr('id')
-    tab = tab.substring(0, tab.indexOf("tab") - 1).replace("-", "_");
+    tab = tab.substring(0, tab.indexOf("tab") - 1).replace("-", "_")
     data = $('#service-calendars').data()
     data.tab = tab
     data.arm_id = arm_id
+    data.service_request_id = getSRId()
     # Reload calendar
     $.get '/service_calendars/table.js', data
 
@@ -125,24 +139,36 @@ calculate_max_rates = (arm_id) ->
 
   $('.window-before').editable
     params: (params) ->
-      data = 'visit_group': { 'window_before': params.value }
-      return data
+      {
+        visit_group:
+          window_before: params.value
+        service_request_id: getSRId()
+      }
 
   $('.day').editable
     params: (params) ->
-      data = 'visit_group': { 'day': params.value }
-      return data
+      {
+        visit_group:
+          day: params.value
+        service_request_id: getSRId()
+      }
     emptytext: '(?)'
 
   $('.window-after').editable
     params: (params) ->
-      data = 'visit_group': { 'window_after': params.value }
-      return data
+      {
+        visit_group:
+          window_after: params.value
+        service_request_id: getSRId()
+      }
 
   $('.visit-group-name').editable
     params: (params) ->
-      data = 'visit_group': { 'name': params.value }
-      return data
+      {
+        visit_group:
+          name: params.value
+        service_request_id: getSRId()
+      }
     emptytext: '(?)'
 
   $('.edit-your-cost').editable
@@ -150,40 +176,61 @@ calculate_max_rates = (arm_id) ->
       # display field as currency, edit as quantity
       $(this).text("$" + parseFloat(value).toFixed(2))
     params: (params) ->
-      data = 'line_item': { 'displayed_cost': params.value }
-      return data
+      {
+        line_item:
+          displayed_cost: params.value
+        service_request_id: getSRId()
+      }
     success: ->
 
   $('.edit-subject-count').editable
     params: (params) ->
-      data = 'line_items_visit': { 'subject_count': params.value }
-      return data
+      {
+        line_items_visit:
+          subject_count: params.value
+        service_request_id: getSRId()
+      }
     success: () ->
       reload_calendar($(this).data('armId'))
 
   $('.edit-research-billing-qty').editable
     params: (params) ->
-      data = 'visit': { 'research_billing_qty': params.value }
-      return data
+      {
+        visit:
+          research_billing_qty: params.value
+        service_request_id: getSRId()
+      }
     success: () ->
       reload_calendar($(this).data('armId'))
 
   $('.edit-insurance-billing-qty').editable
     params: (params) ->
-      data = 'visit': { 'insurance_billing_qty': params.value }
-      return data
+      {
+        visit:
+          insurance_billing_qty: params.value
+        service_request_id: getSRId()
+      }
 
   $('.edit-effort-billing-qty').editable
     params: (params) ->
-      data = 'visit': { 'effort_billing_qty': params.value }
-      return data
+      {
+        visit:
+          effort_billing_qty: params.value
+        service_request_id: getSRId()
+      }
 
   $('.edit-qty').editable
     params: (params) ->
-      data = 'line_item': { 'quantity': params.value }
-      return data
+      {
+        line_item:
+          quantity: params.value
+        service_request_id: getSRId()
+      }
 
   $('.edit-units-per-qty').editable
     params: (params) ->
-      data = 'line_item': { 'units_per_quantity': params.value }
-      return data
+      {
+        line_item:
+          units_per_quantity: params.value
+        service_request_id: getSRId()
+      }

--- a/app/assets/javascripts/service_details.js.coffee
+++ b/app/assets/javascripts/service_details.js.coffee
@@ -22,12 +22,16 @@
 #= require cart
 
 $(document).ready ->
+  getSRId = ->
+    $("input[name='service_request_id']").val()
+
   $(document).on 'click', '#new-arm-button', ->
     $.ajax
       type: 'get'
       url: '/arms/new'
       data:
         protocol_id: $(this).data('protocol-id')
+        service_request_id: getSRId()
     return false
 
   $(document).on 'click', '.edit-arm-button', ->
@@ -35,6 +39,8 @@ $(document).ready ->
     $.ajax
       type: 'get'
       url: "/arms/#{arm_id}/edit"
+      data:
+        service_request_id: getSRId()
 
   $(document).on 'click', '#edit-arm-form-button', ->
     $(this).attr('disabled','disabled')
@@ -45,7 +51,7 @@ $(document).ready ->
       arm_id = $(this).data('arm-id')
       $.ajax
         type: 'delete'
-        url: "/arms/#{arm_id}"
+        url: "/arms/#{arm_id}?service_request_id=#{getSRId()}"
 
   $('#arms-table').on 'all.bs.table', ->
     $('.screening-info').tooltip()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,7 @@ class ApplicationController < ActionController::Base
         # the first time), then create a new service request.
         create_new_service_request
       end
-    elsif params[:controller] == 'devise/sessions'
+    elsif params[:controller] == 'devise/sessions' || params[:controller] == 'identities/sessions'
       if params[:id]
         use_existing_service_request(params[:id])
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -114,7 +114,7 @@ class ApplicationController < ActionController::Base
     else
       # For controllers other than the service requests controller, we
       # look up the service request, but do not display any errors.
-      use_existing_service_request(params[:service_request_id])
+      use_existing_service_request(params[:service_request_id] || params[:srid])
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,9 @@ class ApplicationController < ActionController::Base
   protected
 
   def after_sign_in_path_for(resource)
-    stored_location_for(resource) || "/service_requests/#{session[:service_request_id]}/catalog" || root_path
+    stored_location_for(resource) ||
+      (session[:service_request_id] && "/service_requests/#{session[:service_request_id]}/catalog") ||
+      root_path
   end
 
   def set_highlighted_link  # default value, override inside controllers
@@ -88,34 +90,11 @@ class ApplicationController < ActionController::Base
     @line_items_count = nil
     @sub_service_requests = {}
 
-    if params[:edit_original]
-      # If editing the original service request, we delete the sub
-      # service request id (remember, a sub service request is a service
-      # request that has been split out).
-      session.delete(:sub_service_request_id)
-    end
-
     if params[:controller] == 'service_requests'
-      if params[:action] == 'catalog' and params[:id].nil?
-        # Catalog is the main service requests page; this is where the
-        # service request is first created.  We will create the service
-        # request in a moment.
-        #
-        # If the "go back" button is used, then params[:id] will be
-        # non-nil, and we will not create a new service request.
-        session.delete(:service_request_id)
-        session.delete(:sub_service_request_id)
-      else
-        # For all other service request controller actions, we go ahead
-        # and set the cookie.
-        session[:service_request_id] = params[:id] if params[:id]
-        session[:sub_service_request_id] = params[:sub_service_request_id] if params[:sub_service_request_id]
-      end
-
-      if session[:service_request_id]
+      if ServiceRequest.exists?(id: params[:id])
         # If the cookie is non-nil, then lookup the service request.  If
         # the service request is not found, display an error.
-        use_existing_service_request
+        use_existing_service_request(params[:id])
         validate_existing_service_request
       elsif params[:from_portal]
         create_or_use_request_from_portal(params)
@@ -123,21 +102,19 @@ class ApplicationController < ActionController::Base
         # If the cookie is nil (as with visiting the main catalog for
         # the first time), then create a new service request.
         create_new_service_request
-        session.delete(:from_portal)
       end
     elsif params[:controller] == 'devise/sessions'
-      if session[:service_request_id]
-        use_existing_service_request
+      if params[:id]
+        use_existing_service_request(params[:id])
       else
         @service_request = ServiceRequest.new(status: 'first_draft')
         @service_request.save(validate: false)
         @line_items_count = []
-        session[:service_request_id] = @service_request.id
       end
     else
       # For controllers other than the service requests controller, we
       # look up the service request, but do not display any errors.
-      use_existing_service_request
+      use_existing_service_request(params[:service_request_id])
     end
   end
 
@@ -151,10 +128,6 @@ class ApplicationController < ActionController::Base
       @line_items_count = @service_request.try(:line_items).try(:count)
       @sub_service_requests = @service_request.cart_sub_service_requests
       @sub_service_request = @service_request.sub_service_requests.last
-      session[:service_request_id] = @service_request.id
-      if @sub_service_request
-        session[:sub_service_request_id] = @sub_service_request.id
-      end
     else
       create_new_service_request(true)
     end
@@ -162,10 +135,10 @@ class ApplicationController < ActionController::Base
 
   # Set @service_request, @sub_service_request, and @line_items_count from the
   # ids stored in the session.
-  def use_existing_service_request
-    @service_request = ServiceRequest.find session[:service_request_id]
-    if session[:sub_service_request_id]
-      @sub_service_request = @service_request.sub_service_requests.find session[:sub_service_request_id]
+  def use_existing_service_request(id)
+    @service_request = ServiceRequest.find(id)
+    if params[:sub_service_request_id]
+      @sub_service_request = @service_request.sub_service_requests.find params[:sub_service_request_id]
       @line_items_count = @sub_service_request.try(:line_items).try(:count)
     else
       @line_items_count = @service_request.try(:line_items).try(:count)
@@ -184,7 +157,7 @@ class ApplicationController < ActionController::Base
     if @service_request.nil?
       authorization_error "The service request you are trying to access can not be found.",
                           "SR#{params[:id]}"
-    elsif session[:sub_service_request_id] and @sub_service_request.nil?
+    elsif params[:sub_service_request_id] and @sub_service_request.nil?
       authorization_error "The service request you are trying to access can not be found.",
                           "SSR#{params[:sub_service_request_id]}"
     end
@@ -206,7 +179,6 @@ class ApplicationController < ActionController::Base
     end
 
     @service_request.save(validate: false)
-    session[:service_request_id] = @service_request.id
     redirect_to catalog_service_request_path(@service_request)
   end
 
@@ -231,10 +203,10 @@ class ApplicationController < ActionController::Base
 
     if @sub_service_request.nil?
       authorization_error "The service request you are trying to access is not editable.",
-                          "SR#{session[:service_request_id]}"
+                          "SR#{params[:id]}"
     else
       authorization_error "The service request you are trying to access is not editable.",
-                          "SSR#{session[:sub_service_request_id]}"
+                          "SSR#{params[:sub_service_request_id]}"
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,9 +29,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def after_sign_in_path_for(resource)
-    stored_location_for(resource) ||
-      (session[:service_request_id] && "/service_requests/#{session[:service_request_id]}/catalog") ||
-      root_path
+    stored_location_for(resource) || root_path
   end
 
   def set_highlighted_link  # default value, override inside controllers

--- a/app/controllers/dashboard/epic_queues_controller.rb
+++ b/app/controllers/dashboard/epic_queues_controller.rb
@@ -19,7 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Dashboard::EpicQueuesController < Dashboard::BaseController
-  
+
   before_filter :get_epic_queue, only: [:destroy]
   before_filter :authorize_overlord
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -67,7 +67,7 @@ class DocumentsController < ApplicationController
 
   def destroy
     DocumentRemover.new(params[:id])
-    
+
     flash.now[:success] = t(:documents)[:destroyed]
   end
 

--- a/app/controllers/identities/sessions_controller.rb
+++ b/app/controllers/identities/sessions_controller.rb
@@ -1,0 +1,35 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class Identities::SessionsController < Devise::SessionsController
+  def new
+    # Redirect url after login.
+    @redirect_to = params[:redirect_to]
+    super
+  end
+
+  def create
+    self.resource = resource_class.new(sign_in_params)
+
+    # Pass redirect url to ApplicationController for redirect.
+    store_location_for(resource, params[:redirect_to])
+    super
+  end
+end

--- a/app/controllers/navigations_controller.rb
+++ b/app/controllers/navigations_controller.rb
@@ -23,7 +23,5 @@ class NavigationsController < ApplicationController
   before_filter :authorize_identity
   def index
     @institutions = Institution.all
-    #@service_request = current_user.service_requests.find session[:service_request_id]
-    @service_request = ServiceRequest.find session[:service_request_id]
   end
 end

--- a/app/controllers/portal/sub_service_requests_controller.rb
+++ b/app/controllers/portal/sub_service_requests_controller.rb
@@ -26,8 +26,6 @@ class Portal::SubServiceRequestsController < Portal::BaseController
   def show
     @sub_service_request = SubServiceRequest.find(params[:id])
     @admin = true
-    session[:sub_service_request_id] = @sub_service_request.id
-    session[:service_request_id] = @sub_service_request.service_request_id
     session[:service_calendar_pages] = params[:pages] if params[:pages]
     if @user.can_edit_fulfillment? @sub_service_request.organization
       @user_toasts = @user.received_toast_messages.select {|x| x.sending_class == 'SubServiceRequest'}.select {|y| y.sending_class_id == @sub_service_request.id}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -45,7 +45,7 @@ class SearchController < ApplicationController
         label:          s.name,
         value:          s.id,
         description:    (s.description.nil? || s.description.blank?) ? t(:proper)[:catalog][:no_description] : s.description,
-        sr_id:          session[:service_request_id],
+        sr_id:          @service_request.id,
         abbreviation:   s.abbreviation,
         cpt_code:       s.cpt_code,
         term:           params[:term]

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -75,7 +75,7 @@ class ServiceRequestsController < ApplicationController
   # service request wizard pages
 
   def catalog
-    if session[:sub_service_request_id] && @sub_service_request
+    if @sub_service_request
       @institutions = Institution.where(id: @sub_service_request.organization.parents.select{|x| x.type == 'Institution'}.map(&:id))
     else
       @institutions = Institution.order('`order`')
@@ -305,7 +305,7 @@ class ServiceRequestsController < ApplicationController
 
     line_items.reload
 
-    @service_request = ServiceRequest.find(session[:service_request_id])
+    @service_request.reload
     @page = request.referrer.split('/').last # we need for pages other than the catalog
 
     # Have the protocol clean up the arms

--- a/app/controllers/study_tracker/sub_service_requests_controller.rb
+++ b/app/controllers/study_tracker/sub_service_requests_controller.rb
@@ -28,8 +28,6 @@ class StudyTracker::SubServiceRequestsController < StudyTracker::BaseController
     # methods without having to call #show, in case we add unintended
     # side-effects to #show
 
-    session[:sub_service_request_id] = @sub_service_request.id
-    session[:service_request_id] = @sub_service_request.service_request_id
     session[:service_calendar_pages] = params[:pages] if params[:pages]
 
     @service_request = @sub_service_request.service_request

--- a/app/views/arms/_arm_form.html.haml
+++ b/app/views/arms/_arm_form.html.haml
@@ -31,6 +31,7 @@
         .row
           .col-md-12
             = hidden_field_tag :protocol_id, protocol.id
+            = hidden_field_tag :service_request_id, service_request.id
             .form-group
               = a.label :name, t(:arms)[:form_fields][:name], class: "col-sm-4 control-label required", title: t(:arms)[:name_tooltip], data: { toggle: 'tooltip', animation: 'false' }
               .col-sm-7

--- a/app/views/arms/edit.js.coffee
+++ b/app/views/arms/edit.js.coffee
@@ -18,6 +18,6 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#modal_place").html("<%= escape_javascript(render( 'arms/arm_form', arm: @arm, protocol: @protocol, header_text: @header_text, path: @path )) %>");
+$("#modal_place").html("<%= escape_javascript(render( 'arms/arm_form', arm: @arm, protocol: @protocol, header_text: @header_text, path: @path, service_request: @service_request)) %>");
 $("#modal_place").modal 'show'
 set_required_fields()

--- a/app/views/arms/new.js.coffee
+++ b/app/views/arms/new.js.coffee
@@ -18,7 +18,7 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#modal_place").html("<%= escape_javascript(render( 'arms/arm_form', arm: @arm, protocol: @protocol, header_text: @header_text, path: @path )) %>");
+$("#modal_place").html("<%= escape_javascript(render( 'arms/arm_form', arm: @arm, protocol: @protocol, header_text: @header_text, path: @path, service_request: @service_request)) %>");
 $("#modal_place").modal 'show'
 $("[data-toggle='tooltip']").tooltip()
 set_required_fields()

--- a/app/views/associated_users/_table.html.haml
+++ b/app/views/associated_users/_table.html.haml
@@ -26,7 +26,7 @@
       #associated-users-custom-toolbar
         %button.btn.btn-success#new-associated-user-button{ data: { protocol_id: protocol.id } }
           = t(:authorized_users)[:add_user]
-      %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: associated_users_path(format: :json, protocol_id: protocol.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
+      %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: associated_users_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
         %thead.primary-header
           %tr
             %th{ data: { field: 'name', align: 'left', sortable: 'true' } }

--- a/app/views/associated_users/new.js.coffee
+++ b/app/views/associated_users/new.js.coffee
@@ -17,6 +17,8 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+getSRId = () ->
+  $('input[name="service_request_id"]').val()
 
 <% if @errors.present? %> #User already associated with Protocol
 $("#modal_place #modal_errors").html("<%= escape_javascript(render( 'shared/modal_errors', errors: @errors )) %>")
@@ -32,7 +34,7 @@ identities_bloodhound = new Bloodhound(
     Bloodhound.tokenizers.whitespace datum.value
   queryTokenizer: Bloodhound.tokenizers.whitespace
   remote:
-    url: '/associated_users/search_identities?term=%QUERY',
+    url: "/associated_users/search_identities?term=%QUERY&service_request_id=#{getSRId()}",
     wildcard: '%QUERY'
 )
 identities_bloodhound.initialize() # Initialize the Bloodhound suggestion engine
@@ -57,6 +59,7 @@ $('#authorized_user_search').typeahead(
     data:
       protocol_id: $(this).data('protocol-id')
       identity_id: suggestion.value
+      service_request_id: getSRId()
     success: ->
       $("#loading_authorized_user_spinner").addClass('hidden')
 <% end %>

--- a/app/views/dashboard/associated_users/_table.html.haml
+++ b/app/views/dashboard/associated_users/_table.html.haml
@@ -26,7 +26,7 @@
       #associated-users-custom-toolbar
         %button.btn.btn-success#new-associated-user-button{ class: permission_to_edit ? "" : "disabled", data: { protocol_id: protocol.id, permission: permission_to_edit.to_s } }
           = t(:authorized_users)[:add_user]
-      %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_associated_users_path(format: :json, protocol_id: protocol.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
+      %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_associated_users_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
         %thead.primary-header
           %tr
             %th{ data: { field: 'name', align: 'left', sortable: 'true' } }

--- a/app/views/dashboard/associated_users/_table.html.haml
+++ b/app/views/dashboard/associated_users/_table.html.haml
@@ -26,7 +26,7 @@
       #associated-users-custom-toolbar
         %button.btn.btn-success#new-associated-user-button{ class: permission_to_edit ? "" : "disabled", data: { protocol_id: protocol.id, permission: permission_to_edit.to_s } }
           = t(:authorized_users)[:add_user]
-      %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_associated_users_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
+      %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_associated_users_path(format: :json, protocol_id: protocol.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
         %thead.primary-header
           %tr
             %th{ data: { field: 'name', align: 'left', sortable: 'true' } }

--- a/app/views/dashboard/associated_users/new.js.coffee
+++ b/app/views/dashboard/associated_users/new.js.coffee
@@ -17,6 +17,8 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+getSRId = () ->
+  $('input[name="service_request_id"]').val()
 
 <% if @errors.present? %> #User already associated with Protocol
 $("#modal_errors").html("<%= escape_javascript(render( 'shared/modal_errors', errors: @errors )) %>")
@@ -32,7 +34,7 @@ identities_bloodhound = new Bloodhound(
     Bloodhound.tokenizers.whitespace datum.value
   queryTokenizer: Bloodhound.tokenizers.whitespace
   remote:
-    url: '/dashboard/associated_users/search_identities?term=%QUERY',
+    url: "/dashboard/associated_users/search_identities?term=%QUERY&service_request_id=#{getSRId()}",
     wildcard: '%QUERY'
 )
 identities_bloodhound.initialize() # Initialize the Bloodhound suggestion engine
@@ -57,6 +59,7 @@ $('#authorized_user_search').typeahead(
     data:
       protocol_id: $(this).data('protocol-id')
       identity_id: suggestion.value
+      service_request_id: getSRId()
     success: ->
       $("#loading_authorized_user_spinner").addClass('hidden')
 <% end %>

--- a/app/views/dashboard/documents/_documents_table.html.haml
+++ b/app/views/dashboard/documents/_documents_table.html.haml
@@ -26,7 +26,7 @@
       #documents-custom-toolbar
         %button.btn.btn-success#document-new{ class: permission_to_edit ? '' : 'disabled', data: { protocol_id: protocol.id, permission: permission_to_edit.to_s } }
           = t(:documents)[:add_document]
-      %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_documents_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
+      %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_documents_path(format: :json, protocol_id: protocol.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
         %thead.primary-header
           %tr
             %th{ data: { class: 'type', align: "left", sortable: "true", field: "type" } }

--- a/app/views/dashboard/documents/_documents_table.html.haml
+++ b/app/views/dashboard/documents/_documents_table.html.haml
@@ -26,7 +26,7 @@
       #documents-custom-toolbar
         %button.btn.btn-success#document-new{ class: permission_to_edit ? '' : 'disabled', data: { protocol_id: protocol.id, permission: permission_to_edit.to_s } }
           = t(:documents)[:add_document]
-      %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_documents_path(format: :json, protocol_id: protocol.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
+      %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: dashboard_documents_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
         %thead.primary-header
           %tr
             %th{ data: { class: 'type', align: "left", sortable: "true", field: "type" } }

--- a/app/views/devise/sessions/_login_form.html.haml
+++ b/app/views/devise/sessions/_login_form.html.haml
@@ -19,6 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .hidden#login-form
   = form_for resource, as: resource_name, url: session_path(resource_name), role: 'form' do |f|
+    = hidden_field_tag :redirect_to, redirect_to
     .form-group
       = f.label :ldap_uid, t(:devise)[:sessions][:login]
       = f.text_field :ldap_uid, autofocus: true, class: 'form-control'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -33,5 +33,5 @@
     .form-group.return-button
       %a.btn.btn-primary{ href: root_path }
         = t(:devise)[:sessions][:return]
-    = render 'login_form'
+    = render 'login_form', redirect_to: @redirect_to
   .col-md-3

--- a/app/views/documents/_document_form.html.haml
+++ b/app/views/documents/_document_form.html.haml
@@ -31,6 +31,7 @@
         .row
           .col-md-12
             = hidden_field_tag :protocol_id, form.object.protocol.id
+            = hidden_field_tag :service_request_id, service_request.id
             .form-group
               = form.label :doc_type, t(:documents)[:form_fields][:document_type], class: 'col-sm-4 control-label required'
               .col-sm-7

--- a/app/views/documents/_table.html.haml
+++ b/app/views/documents/_table.html.haml
@@ -21,7 +21,7 @@
   #documents-custom-toolbar
     %button.btn.btn-success#document-new{ data: { protocol_id: protocol.id } }
       = t(:documents)[:add_document]
-  %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: documents_path(format: :json, protocol_id: protocol.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
+  %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: documents_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
     %thead.primary-header
       %tr
         %th{ data: { class: 'type', align: "left", sortable: "true", field: "type" } }

--- a/app/views/documents/edit.js.coffee
+++ b/app/views/documents/edit.js.coffee
@@ -18,7 +18,7 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#modal_place").html("<%= escape_javascript(render( 'documents/document_form', document: @document, header_text: @header_text, path: @path )) %>");
+$("#modal_place").html("<%= escape_javascript(render( 'documents/document_form', document: @document, header_text: @header_text, path: @path, service_request: @service_request)) %>");
 $("#modal_place").modal 'show'
 $(".selectpicker").selectpicker()
 set_required_fields()

--- a/app/views/documents/new.js.coffee
+++ b/app/views/documents/new.js.coffee
@@ -18,7 +18,7 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#modal_place").html("<%= escape_javascript(render( 'documents/document_form', document: @document, header_text: @header_text, path: @path )) %>");
+$("#modal_place").html("<%= escape_javascript(render( 'documents/document_form', document: @document, header_text: @header_text, path: @path, service_request: @service_request)) %>");
 $("#modal_place").modal 'show'
 $(".selectpicker").selectpicker()
 set_required_fields()

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -29,4 +29,4 @@
           = I18n.t('proper.navbar.logged_in', email: current_user.email)
         = link_to t(:proper)[:navbar][:logout], destroy_identity_session_path, method: :delete, class: 'btn btn-warning'
       - else
-        = link_to t(:proper)[:navbar][:login], new_identity_session_path, class: 'btn btn-primary'
+        = link_to t(:proper)[:navbar][:login], new_identity_session_path(redirect_to: catalog_service_request_path(id: service_request.id)), class: 'btn btn-primary', id: 'login-link'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -38,6 +38,9 @@
   %body#body
     - if @service_request
       = hidden_field_tag :service_request_id, @service_request.id, disabled: true
+    - if @sub_service_request
+      = hidden_field_tag :sub_service_request_id, @sub_service_request.id, disabled: true
+
     #container
       #header
         = render 'layouts/header_logos', location: "proper"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,7 +42,7 @@
       #header
         = render 'layouts/header_logos', location: "proper"
         %input#current_user_id{ type: 'hidden', value: @user.try(:id) }
-      = render 'layouts/header', user: @user
+      = render 'layouts/header', user: @user, service_request: @service_request
       .flash
         = render 'shared/flash'
       #inner-content.row

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -36,6 +36,8 @@
       window.I18n = #{current_translations.to_json.html_safe};
 
   %body#body
+    - if @service_request
+      = hidden_field_tag :service_request_id, @service_request.id, disabled: true
     #container
       #header
         = render 'layouts/header_logos', location: "proper"

--- a/app/views/protocols/form/_protocol_form.html.haml
+++ b/app/views/protocols/form/_protocol_form.html.haml
@@ -21,10 +21,11 @@
 
 #protocol-form-display
   = form_for protocol, as: :protocol, remote: true, html: { class: 'form-horizontal', autocomplete: 'off' } do |form|
+    -# TODO rename :srid to :service_request_id in controller action
+    = hidden_field_tag :service_request_id, service_request.id
     = hidden_field_tag :srid, service_request.id
     = form.hidden_field :requester_id
     = form.hidden_field :type
-
     - if protocol.type.capitalize == "Study"
       .edit-study-view.container-fluid
         .row.user-edit-protocol-view

--- a/app/views/service_calendars/_move_visits_modal.haml
+++ b/app/views/service_calendars/_move_visits_modal.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .modal-dialog.modal-md
   .modal-content
-    = form_for arm, url: move_visit_position_service_calendars_path(arm_id: arm.id), remote: true, method: :post, html: { class: 'form-horizontal', role: 'form' } do |f|
+    = form_for arm, url: move_visit_position_service_calendars_path(arm_id: arm.id, service_request_id: service_request.id), remote: true, method: :post, html: { class: 'form-horizontal', role: 'form' } do |f|
       .modal-header
         %button.close{type: 'button', data: {dismiss: 'modal'}}
           %span{aria: {hidden:'true'}} &times;

--- a/app/views/service_calendars/master_calendar/pppv/_visit_groups.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_visit_groups.html.haml
@@ -31,22 +31,22 @@
         - if portal || tab == 'calendar'
           = visit_group.window_before
         - else
-          %a.window-before{ href: 'javascript:void(0)', data: { name: 'window_before', title: t(:calendars)[:pppv][:editable_fields][:window_before], value: visit_group.window_before, url: visit_group_path(visit_group) } }
+          %a.window-before{ href: 'javascript:void(0)', data: { name: 'window_before', title: t(:calendars)[:pppv][:editable_fields][:window_before], value: visit_group.window_before, url: visit_group_path(visit_group, service_request_id: service_request.id) } }
       .col-xs-4.no-padding.text-center
         - if portal || tab == 'calendar'
           = visit_group.day
         - else
-          %a.day{ href: 'javascript:void(0)', data: { name: 'day', value: visit_group.day, title: t(:calendars)[:pppv][:editable_fields][:day], url: visit_group_path(visit_group) } }
+          %a.day{ href: 'javascript:void(0)', data: { name: 'day', value: visit_group.day, title: t(:calendars)[:pppv][:editable_fields][:day], url: visit_group_path(visit_group, service_request_id: service_request.id) } }
       .col-xs-4.no-padding.text-center
         - if portal || tab == 'calendar'
           = visit_group.window_after
         - else
-          %a.window-after{ href: 'javascript:void(0)', data: { name: 'window_after', title: t(:calendars)[:pppv][:editable_fields][:window_after], value: visit_group.window_after, url: visit_group_path(visit_group) } }
+          %a.window-after{ href: 'javascript:void(0)', data: { name: 'window_after', title: t(:calendars)[:pppv][:editable_fields][:window_after], value: visit_group.window_after, url: visit_group_path(visit_group, service_request_id: service_request.id) } }
     .row.visit-group-names.text-center
       .col-sm-12.text-center{ data: { visit_group_id: visit_group.id } }
         - if portal || tab == 'calendar'
           = visit_group.name
         - else
-          %a.visit-group-name{ href: 'javascript:void(0)', data: { name: 'name', title: t(:calendars)[:pppv][:editable_fields][:visit_name], value: visit_group.name, url: visit_group_path(visit_group) } }
+          %a.visit-group-name{ href: 'javascript:void(0)', data: { name: 'name', title: t(:calendars)[:pppv][:editable_fields][:visit_name], value: visit_group.name, url: visit_group_path(visit_group, service_request_id: service_request.id) } }
 - (visit_groups.size...Visit.per_page).each do |index|
   %th.col-sm-1.text-center

--- a/app/views/service_calendars/show_move_visits.js.coffee
+++ b/app/views/service_calendars/show_move_visits.js.coffee
@@ -17,6 +17,6 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$('#modal_place').html("<%= escape_javascript(render( 'service_calendars/move_visits_modal', arm: @arm )) %>")
+$('#modal_place').html("<%= escape_javascript(render( 'service_calendars/move_visits_modal', arm: @arm, service_request: @service_request)) %>")
 $('#modal_place').modal('show')
 $('.selectpicker').selectpicker()

--- a/app/views/service_requests/document_management/_document_management_left.html.haml
+++ b/app/views/service_requests/document_management/_document_management_left.html.haml
@@ -20,6 +20,6 @@
 .col-md-9.document-management-left
   = render 'service_requests/document_management/documents', service_request: service_request
   = render 'service_requests/document_management/notes', service_request: service_request
-  - if @service_request.additional_detail_services.present?
+  - if service_request.additional_detail_services.present?
     .document-management-submissions
-      = render "additional_details/document_management_submissions", service_request: @service_request
+      = render "additional_details/document_management_submissions", service_request: service_request

--- a/app/views/service_requests/document_management/_documents.html.haml
+++ b/app/views/service_requests/document_management/_documents.html.haml
@@ -23,4 +23,4 @@
       = t(:proper)[:document_management][:documents_notice]
       %small
         = t(:proper)[:document_management][:documents_instructions]
-  = render 'documents/table', protocol: service_request.protocol, permission_to_edit: true, in_dashboard: false
+  = render 'documents/table', protocol: service_request.protocol, permission_to_edit: true, in_dashboard: false, service_request: service_request

--- a/app/views/service_requests/protocol.html.haml
+++ b/app/views/service_requests/protocol.html.haml
@@ -19,7 +19,6 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 = javascript_include_tag 'protocol'
 = stylesheet_link_tag 'associated_users_table'
-= hidden_field_tag :service_request_id, @service_request.id, disabled: true
 = render '/service_requests/navigation/steps', service_request: @service_request, step: @step_text, css_class: @css_class
 = render 'service_requests/modals/request_submitted_modal', service_request: @service_request
 .col-sm-12.body-container#protocols-page

--- a/app/views/service_requests/protocol.html.haml
+++ b/app/views/service_requests/protocol.html.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 = javascript_include_tag 'protocol'
 = stylesheet_link_tag 'associated_users_table'
-
+= hidden_field_tag :service_request_id, @service_request.id, disabled: true
 = render '/service_requests/navigation/steps', service_request: @service_request, step: @step_text, css_class: @css_class
 = render 'service_requests/modals/request_submitted_modal', service_request: @service_request
 .col-sm-12.body-container#protocols-page

--- a/app/views/service_requests/protocol/_protocol_display.html.haml
+++ b/app/views/service_requests/protocol/_protocol_display.html.haml
@@ -25,7 +25,7 @@
         %small
           = t(:proper)[:protocol][:review_protocol_instructions]
     = render 'protocols/summary', protocol: protocol, protocol_type: protocol.type, service_request: service_request, allow_edit: true
-    = render 'associated_users/table', protocol: protocol
+    = render 'associated_users/table', protocol: protocol, service_request: service_request
   - else
     .page-header
       %h3
@@ -33,5 +33,5 @@
         %small
           = t(:proper)[:protocol][:create_protocol_instructions]
     .col-sm-12.protocol-container.text-center
-      = link_to t(:protocols)[:studies][:new], new_protocol_path(srid: service_request.id, protocol_type: 'Study'), class: 'btn btn-lg btn-success new-study', title: t(:proper)[:protocol][:study_tooltip], data: { toggle: 'tooltip' }
-      = link_to t(:protocols)[:projects][:new], new_protocol_path(srid: service_request.id, protocol_type: 'Project'), class: 'btn btn-lg btn-primary new-project', title: t(:proper)[:protocol][:project_tooltip], data: { toggle: 'tooltip' }
+      = link_to t(:protocols)[:studies][:new], new_protocol_path(srid: service_request.id, protocol_type: 'Study', service_request_id: service_request.id), class: 'btn btn-lg btn-success new-study', title: t(:proper)[:protocol][:study_tooltip], data: { toggle: 'tooltip' }
+      = link_to t(:protocols)[:projects][:new], new_protocol_path(srid: service_request.id, protocol_type: 'Project', service_request_id: service_request.id), class: 'btn btn-lg btn-primary new-project', title: t(:proper)[:protocol][:project_tooltip], data: { toggle: 'tooltip' }

--- a/app/views/service_requests/review.html.haml
+++ b/app/views/service_requests/review.html.haml
@@ -25,7 +25,7 @@
     = render 'service_requests/review/instructions'
     = render 'service_requests/review/protocol_information', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/authorized_users', service_request: @service_request, protocol: @service_request.protocol
-    = render 'service_requests/review/documents', protocol: @service_request.protocol
+    = render 'service_requests/review/documents', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/notes', service_request: @service_request, notable_id: @service_request.id, notable_type: 'ServiceRequest'
     = render 'service_requests/review/calendars', service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, tab: @tab, arm: @arm, portal: @portal, admin: @admin, review: @review, merged: @merged, consolidated: @consolidated
 = render 'service_requests/navigation/footer', service_request: @service_request, css_class: @css_class, back: @back, forward: @forward

--- a/app/views/service_requests/review/_authorized_users.html.haml
+++ b/app/views/service_requests/review/_authorized_users.html.haml
@@ -23,7 +23,7 @@
       = t(:proper)[:review][:authorized_users_notice]
   .bootstrap-table-dropdown-overflow
     #associated-users-custom-toolbar
-    %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: associated_users_path(format: :json, protocol_id: protocol.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
+    %table#associated-users-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: associated_users_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: 'true', toolbar: '#associated-users-custom-toolbar' } }
       %thead.primary-header
         %tr
           %th{ data: { field: 'name', align: 'left', sortable: 'true' } }

--- a/app/views/service_requests/review/_documents.html.haml
+++ b/app/views/service_requests/review/_documents.html.haml
@@ -23,7 +23,7 @@
       = t(:proper)[:review][:documents_notice]
   .bootstrap-table-dropdown-overflow
     #documents-custom-toolbar
-    %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: documents_path(format: :json, protocol_id: protocol.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
+    %table#documents-table{ data: { toggle: 'table', search: "true", "show-columns" => "true", "show-refresh" => "true", "show-toggle" => "true", url: documents_path(format: :json, protocol_id: protocol.id, service_request_id: service_request.id), striped: "true", toolbar: "#documents-custom-toolbar", "show-export" => "false", "export-types" => ['excel'] } }
       %thead.primary-header
         %tr
           %th{ data: { class: 'type', align: "left", sortable: "true", field: "type" } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,12 +39,14 @@ SparcRails::Application.routes.draw do
   if USE_SHIBBOLETH_ONLY
     devise_for :identities,
                controllers: {
-                 omniauth_callbacks: 'identities/omniauth_callbacks'
+                 omniauth_callbacks: 'identities/omniauth_callbacks',
+                 sessions: 'identities/sessions'
                }, path_names: { sign_in: 'auth/shibboleth' }
   else
     devise_for :identities,
                controllers: {
-                 omniauth_callbacks: 'identities/omniauth_callbacks'
+                 omniauth_callbacks: 'identities/omniauth_callbacks',
+                 sessions: 'identities/sessions'
                }
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -160,18 +160,16 @@ RSpec.describe ApplicationController, type: :controller do
         end
       end
 
-      context 'session[:service_request_id] present' do
-        before(:each) { session[:service_request_id] = service_request.id }
-
+      context 'params[:service_request_id] present' do
         it 'should set @service_request' do
-          get :index
+          get :index, service_request_id: service_request.id
           expect(assigns(:service_request)).to eq service_request
         end
 
-        context 'session[:sub_service_request_id] present' do
+        context 'params[:sub_service_request_id] present' do
           before(:each) do
-            session[:sub_service_request_id] = sub_service_request.id
-            get :index
+            get :index, service_request_id: service_request.id,
+              sub_service_request_id: sub_service_request.id
           end
 
           it 'should set @sub_service_request' do
@@ -180,7 +178,7 @@ RSpec.describe ApplicationController, type: :controller do
         end
 
         context 'session[:sub_service_request_id] absent' do
-          before(:each) { get :index }
+          before(:each) { get :index, service_request_id: service_request.id }
 
           it 'should not set @sub_service_request' do
             expect(assigns(:sub_service_request)).to_not be

--- a/spec/controllers/arms/delete_destroy_spec.rb
+++ b/spec/controllers/arms/delete_destroy_spec.rb
@@ -38,10 +38,9 @@ RSpec.describe ArmsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       arm       = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:arm)).to eq(arm)
@@ -52,10 +51,9 @@ RSpec.describe ArmsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       arm       = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(Arm.where(id: arm.id).empty?).to eq(true)
@@ -66,10 +64,9 @@ RSpec.describe ArmsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       arm       = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:destroy)
@@ -80,10 +77,9 @@ RSpec.describe ArmsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       arm       = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/arms/get_edit_spec.rb
+++ b/spec/controllers/arms/get_edit_spec.rb
@@ -38,10 +38,9 @@ RSpec.describe ArmsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:arm)).to eq(arm)
@@ -52,10 +51,9 @@ RSpec.describe ArmsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol)).to eq(protocol)
@@ -66,10 +64,9 @@ RSpec.describe ArmsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:header_text)).to be
@@ -80,10 +77,9 @@ RSpec.describe ArmsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:path)).to eq(arm_path(assigns(:arm)))
@@ -94,13 +90,12 @@ RSpec.describe ArmsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
-      expect(controller).to render_template(:edit)      
+      expect(controller).to render_template(:edit)
     end
 
     it 'should respond ok' do
@@ -108,10 +103,9 @@ RSpec.describe ArmsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: arm.id
+        id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/arms/get_index_spec.rb
+++ b/spec/controllers/arms/get_index_spec.rb
@@ -36,10 +36,8 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @arms' do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       @sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = @sr.id
 
-      xhr :get, :index
+      xhr :get, :index, service_request_id: @sr.id
 
       expect(assigns(:arms)).to eq(@sr.arms)
     end
@@ -47,10 +45,8 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @arms_editable' do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       @sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = @sr.id
 
-      xhr :get, :index
+      xhr :get, :index, service_request_id: @sr.id
 
       expect(assigns(:arms_editable)).to eq(@sr.arms_editable?)
     end
@@ -58,10 +54,8 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @arm_count' do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       @sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = @sr.id
 
-      xhr :get, :index
+      xhr :get, :index, service_request_id: @sr.id
 
       expect(assigns(:arm_count)).to eq(@sr.arms.count)
     end
@@ -69,21 +63,17 @@ RSpec.describe ArmsController, type: :controller do
     it 'should render template' do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       @sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = @sr.id
 
-      xhr :get, :index
+      xhr :get, :index, service_request_id: @sr.id
 
       expect(controller).to render_template(:index)
     end
-    
+
     it 'should respond ok' do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       @sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = @sr.id
 
-      xhr :get, :index
+      xhr :get, :index, service_request_id: @sr.id
 
       expect(controller).to respond_with :ok
     end

--- a/spec/controllers/arms/get_new_spec.rb
+++ b/spec/controllers/arms/get_new_spec.rb
@@ -36,11 +36,10 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @protocol' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol)).to eq(protocol)
@@ -49,11 +48,10 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @arm' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:arm).class).to eq(Arm)
@@ -63,11 +61,10 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @header_text' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:header_text)).to be
@@ -76,11 +73,10 @@ RSpec.describe ArmsController, type: :controller do
     it 'should assign @path' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:path)).to eq(arms_path(assigns(:arm)))
@@ -89,24 +85,22 @@ RSpec.describe ArmsController, type: :controller do
     it 'should render template' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
-      expect(controller).to render_template(:new)      
+      expect(controller).to render_template(:new)
     end
 
     it 'should respond ok' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/arms/post_create_spec.rb
+++ b/spec/controllers/arms/post_create_spec.rb
@@ -39,9 +39,8 @@ RSpec.describe ArmsController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :create, {
+          service_request_id: sr.id,
           protocol_id: protocol.id,
           arm: arm_params
         }
@@ -56,9 +55,8 @@ RSpec.describe ArmsController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         arm_params  = { name: '', subject_count: -1, visit_count: -1 }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :create, {
+          service_request_id: sr.id,
           protocol_id: protocol.id,
           arm: arm_params
         }
@@ -71,9 +69,8 @@ RSpec.describe ArmsController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         arm_params  = { name: '', subject_count: -1, visit_count: -1 }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :create, {
+          service_request_id: sr.id,
           protocol_id: protocol.id,
           arm: arm_params
         }
@@ -87,9 +84,8 @@ RSpec.describe ArmsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :create, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         arm: arm_params
       }
@@ -102,9 +98,8 @@ RSpec.describe ArmsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :create, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         arm: arm_params
       }

--- a/spec/controllers/arms/put_update_spec.rb
+++ b/spec/controllers/arms/put_update_spec.rb
@@ -40,11 +40,10 @@ RSpec.describe ArmsController, type: :controller do
       arm         = create(:arm_without_validations, protocol: protocol)
       arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-      session[:service_request_id] = sr.id
-
       xhr :put, :update, {
         id: arm.id,
-        arm: arm_params
+        arm: arm_params,
+        service_request_id: sr.id
       }
 
       expect(assigns(:arm)).to eq(arm)
@@ -57,11 +56,10 @@ RSpec.describe ArmsController, type: :controller do
         arm         = create(:arm_without_validations, protocol: protocol)
         arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: arm.id,
-          arm: arm_params
+          arm: arm_params,
+          service_request_id: sr.id
         }
 
         expect(arm.reload.name).to eq('Armada')
@@ -75,11 +73,10 @@ RSpec.describe ArmsController, type: :controller do
         arm         = create(:arm_without_validations, protocol: protocol)
         arm_params  = { name: 'Mi Armigo', subject_count: -1, visit_count: -1 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: arm.id,
-          arm: arm_params
+          arm: arm_params,
+          service_request_id: sr.id
         }
 
         expect(arm.reload.name).to_not eq('Mi Armigo')
@@ -91,11 +88,10 @@ RSpec.describe ArmsController, type: :controller do
         arm         = create(:arm_without_validations, protocol: protocol)
         arm_params  = { name: '', subject_count: -1, visit_count: -1 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: arm.id,
-          arm: arm_params
+          arm: arm_params,
+          service_request_id: sr.id
         }
 
         expect(assigns(:errors)).to be
@@ -108,11 +104,10 @@ RSpec.describe ArmsController, type: :controller do
       arm         = create(:arm_without_validations, protocol: protocol)
       arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-      session[:service_request_id] = sr.id
-
       xhr :put, :update, {
         id: arm.id,
-        arm: arm_params
+        arm: arm_params,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:update)
@@ -124,11 +119,10 @@ RSpec.describe ArmsController, type: :controller do
       arm         = create(:arm_without_validations, protocol: protocol)
       arm_params  = { name: 'Armada', subject_count: 1, visit_count: 1 }
 
-      session[:service_request_id] = sr.id
-
       xhr :put, :update, {
         id: arm.id,
-        arm: arm_params
+        arm: arm_params,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/associated_users/delete_destroy_spec.rb
+++ b/spec/controllers/associated_users/delete_destroy_spec.rb
@@ -39,10 +39,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr        = create(:project_role, identity: other_user, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: pr.id
+        id: pr.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol_role)).to eq(pr)
@@ -53,10 +52,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr        = create(:project_role, identity: other_user, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: pr.id
+        id: pr.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol)).to eq(protocol)
@@ -67,10 +65,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr        = create(:project_role, identity: other_user, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: pr.id
+        id: pr.id,
+        service_request_id: sr.id
       }
 
       expect(ProjectRole.count).to eq(1)
@@ -85,10 +82,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         stub_const("USE_EPIC", true)
         stub_const("QUEUE_EPIC", false)
 
-        session[:service_request_id] = sr.id
-
         expect {
           xhr :delete, :destroy, {
+            service_request_id: sr.id,
             id: pr.id
           }
         }.to change(ActionMailer::Base.deliveries, :count).by(1)
@@ -100,10 +96,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr        = create(:project_role, identity: other_user, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: pr.id
+        id: pr.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:destroy)
@@ -114,10 +109,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr        = create(:project_role, identity: other_user, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :delete, :destroy, {
-        id: pr.id
+        id: pr.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/associated_users/get_edit_spec.rb
+++ b/spec/controllers/associated_users/get_edit_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 
@@ -52,9 +52,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 
@@ -66,9 +66,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 
@@ -80,9 +80,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 
@@ -94,9 +94,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 
@@ -108,9 +108,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 
@@ -122,9 +122,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       pr       = protocol.project_roles.first
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :edit, {
+        service_request_id: sr.id,
         id: pr.id
       }
 

--- a/spec/controllers/associated_users/get_index_spec.rb
+++ b/spec/controllers/associated_users/get_index_spec.rb
@@ -37,10 +37,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :index, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol)).to eq(protocol)
@@ -51,10 +50,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
-
       xhr :get, :index, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:current_user)).to eq(logged_in_user)
@@ -64,10 +62,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :index, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol_roles)).to eq(protocol.project_roles)
@@ -77,10 +74,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :index, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:index)
@@ -90,10 +86,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :index, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/associated_users/get_new_spec.rb
+++ b/spec/controllers/associated_users/get_new_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }
@@ -52,9 +52,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }
@@ -66,9 +66,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }
@@ -80,9 +80,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }
@@ -96,9 +96,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }
@@ -111,9 +111,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
 
         xhr :get, :new, {
+        service_request_id: sr.id,
           protocol_id: protocol.id,
           identity_id: logged_in_user.id
         }
@@ -126,9 +126,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }
@@ -140,9 +140,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         identity_id: other_user.id
       }

--- a/spec/controllers/associated_users/get_search_identities_spec.rb
+++ b/spec/controllers/associated_users/get_search_identities_spec.rb
@@ -32,33 +32,5 @@ RSpec.describe AssociatedUsersController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-
-    # it 'should return JSON' do
-    #   protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
-    #   sr        = create(:service_request_without_validations, protocol: protocol)
-
-    #   session[:service_request_id] = sr.id
-
-    #   xhr :get, :search_identities, {
-    #     term: 'Bob'
-    #   }
-      
-    #   json = JSON.parse(response.body)
-    # end
-
-    # it 'should respond ok' do
-    #   protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
-    #   sr        = create(:service_request_without_validations, protocol: protocol)
-
-    #   session[:service_request_id] = sr.id
-
-    #   xhr :get, :search_identities, {
-    #     term: 'Bob'
-    #   }
-      
-    #   json = JSON.parse(response.body)
-
-    #   expect(controller).to respond_with(:ok)
-    # end
   end
 end

--- a/spec/controllers/associated_users/post_create_spec.rb
+++ b/spec/controllers/associated_users/post_create_spec.rb
@@ -40,10 +40,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         sr        = create(:service_request_without_validations, protocol: protocol)
         pr_params = { protocol_id: protocol.id, identity_id: other_user.id, project_rights: 'member', role: 'consultant' }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :create, {
-          project_role: pr_params
+          project_role: pr_params,
+          service_request_id: sr.id
         }
 
         expect(ProjectRole.count).to eq(2)
@@ -56,10 +55,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         sr        = create(:service_request_without_validations, protocol: protocol)
         pr_params = { protocol_id: protocol.id, identity_id: logged_in_user.id, project_rights: 'member', role: 'consultant' }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :create, {
-          project_role: pr_params
+          project_role: pr_params,
+          service_request_id: sr.id
         }
 
         expect(ProjectRole.count).to eq(1)
@@ -70,10 +68,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         sr        = create(:service_request_without_validations, protocol: protocol)
         pr_params = { protocol_id: protocol.id, identity_id: logged_in_user.id, project_rights: 'member', role: 'consultant' }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :create, {
-          project_role: pr_params
+          project_role: pr_params,
+          service_request_id: sr.id
         }
 
         expect(assigns(:errors)).to be
@@ -85,10 +82,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr_params = { protocol_id: protocol.id, identity_id: other_user.id, project_rights: 'member', role: 'consultant' }
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :create, {
-        project_role: pr_params
+        project_role: pr_params,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:create)
@@ -99,10 +95,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       pr_params = { protocol_id: protocol.id, identity_id: other_user.id, project_rights: 'member', role: 'consultant' }
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :create, {
-        project_role: pr_params
+        project_role: pr_params,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/associated_users/put_update_spec.rb
+++ b/spec/controllers/associated_users/put_update_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         pr        = create(:project_role, identity: other_user, protocol: protocol, role: 'noob')
         pr_params = { role: 'not noob' }
 
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
+        service_request_id: sr.id,
           id: pr.id,
           project_role: pr_params
         }
@@ -59,9 +59,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         pr        = create(:project_role, identity: other_user, protocol: protocol, role: 'noob')
         pr_params = { role: nil }
 
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
+        service_request_id: sr.id,
           id: pr.id,
           project_role: pr_params
         }
@@ -75,9 +75,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
         pr        = create(:project_role, identity: other_user, protocol: protocol, role: 'noob')
         pr_params = { role: nil }
 
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
+        service_request_id: sr.id,
           id: pr.id,
           project_role: pr_params
         }
@@ -92,9 +92,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       pr        = create(:project_role, identity: other_user, protocol: protocol, role: 'noob')
       pr_params = { role: 'not noob' }
 
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
+        service_request_id: sr.id,
         id: pr.id,
         project_role: pr_params
       }
@@ -108,9 +108,9 @@ RSpec.describe AssociatedUsersController, type: :controller do
       pr        = create(:project_role, identity: other_user, protocol: protocol, role: 'noob')
       pr_params = { role: 'not noob' }
 
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
+        service_request_id: sr.id,
         id: pr.id,
         project_role: pr_params
       }

--- a/spec/controllers/catalogs/post_update_description_spec.rb
+++ b/spec/controllers/catalogs/post_update_description_spec.rb
@@ -42,10 +42,9 @@ RSpec.describe CatalogsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       org       = create(:organization)
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :update_description, {
-        id: org.id
+        id: org.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:organization)).to eq(org)
@@ -56,11 +55,10 @@ RSpec.describe CatalogsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       org       = create(:organization)
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :update_description, {
         id: org.id,
-        process_ssr_found: 'true'
+        process_ssr_found: 'true',
+        service_request_id: sr.id
       }
 
       expect(assigns(:process_ssr_found)).to eq(true)
@@ -73,12 +71,11 @@ RSpec.describe CatalogsController, type: :controller do
         org       = create(:organization)
         ssr       = create(:sub_service_request_without_validations, service_request: sr, organization: org)
 
-      session[:service_request_id]     = sr.id
-      session[:sub_service_request_id] = ssr.id
-
       xhr :post, :update_description, {
         id: org.id,
-        process_ssr_found: 'true'
+        process_ssr_found: 'true',
+        service_request_id: sr.id,
+        sub_service_request_id: ssr.id
       }
 
       expect(assigns(:ssr_org)).to eq(org)
@@ -90,10 +87,9 @@ RSpec.describe CatalogsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       org       = create(:organization)
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :update_description, {
-        id: org.id
+        id: org.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:update_description)
@@ -104,10 +100,9 @@ RSpec.describe CatalogsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
       org       = create(:organization)
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :update_description, {
-        id: org.id
+        id: org.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)

--- a/spec/controllers/documents/delete_destroy_spec.rb
+++ b/spec/controllers/documents/delete_destroy_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :delete, :destroy, {
+        service_request_id: sr.id,
         id: doc.id
       }
 
@@ -53,9 +53,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :delete, :destroy, {
+        service_request_id: sr.id,
         id: doc.id
       }
 
@@ -67,9 +67,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :delete, :destroy, {
+        service_request_id: sr.id,
         id: doc.id
       }
 
@@ -81,9 +81,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :delete, :destroy, {
+        service_request_id: sr.id,
         id: doc.id
       }
 

--- a/spec/controllers/documents/get_edit_spec.rb
+++ b/spec/controllers/documents/get_edit_spec.rb
@@ -39,10 +39,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: doc.id
+        id: doc.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:document)).to eq(doc)
@@ -53,10 +52,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: doc.id
+        id: doc.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:header_text)).to be
@@ -67,10 +65,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: doc.id
+        id: doc.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:path)).to eq(document_path(assigns(:document)))
@@ -81,10 +78,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: doc.id
+        id: doc.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:edit)
@@ -95,14 +91,12 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc         = create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :edit, {
-        id: doc.id
+        id: doc.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)
     end
   end
 end
-

--- a/spec/controllers/documents/get_index_spec.rb
+++ b/spec/controllers/documents/get_index_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
                   create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         protocol_id: protocol.id
       }
 
@@ -53,9 +53,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
                   create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         protocol_id: protocol.id
       }
 
@@ -67,9 +67,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
                   create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         protocol_id: protocol.id
       }
 
@@ -81,9 +81,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr        = create(:service_request_without_validations, protocol: protocol)
                   create(:document, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         protocol_id: protocol.id
       }
 

--- a/spec/controllers/documents/get_new_spec.rb
+++ b/spec/controllers/documents/get_new_spec.rb
@@ -38,10 +38,9 @@ RSpec.describe DocumentsController, type: :controller do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:protocol)).to eq(protocol)
@@ -51,10 +50,9 @@ RSpec.describe DocumentsController, type: :controller do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:document).class).to eq(Document)
@@ -65,10 +63,9 @@ RSpec.describe DocumentsController, type: :controller do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:header_text)).to be
@@ -78,10 +75,9 @@ RSpec.describe DocumentsController, type: :controller do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:path)).to eq(documents_path(assigns(:document)))
@@ -91,10 +87,9 @@ RSpec.describe DocumentsController, type: :controller do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to render_template(:new)
@@ -104,14 +99,12 @@ RSpec.describe DocumentsController, type: :controller do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :new, {
-        protocol_id: protocol.id
+        protocol_id: protocol.id,
+        service_request_id: sr.id
       }
 
       expect(controller).to respond_with(:ok)
     end
   end
 end
-

--- a/spec/controllers/documents/post_create_spec.rb
+++ b/spec/controllers/documents/post_create_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc_params  = { doc_type: 'Neurology',  }
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         document: doc_params
       }
@@ -54,9 +54,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc_params  = { doc_type: 'Neurology', document: Rack::Test::UploadedFile.new(File.join('doc', 'musc_installation_example.txt'),'txt/plain') }
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         document: doc_params
       }
@@ -71,10 +71,10 @@ RSpec.describe DocumentsController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         doc_params  = { doc_type: 'Neurology', document: Rack::Test::UploadedFile.new(File.join('doc', 'musc_installation_example.txt'),'text/plain') }
 
-        session[:service_request_id] = sr.id
 
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           protocol_id: protocol.id,
           document: doc_params
         }
@@ -89,9 +89,9 @@ RSpec.describe DocumentsController, type: :controller do
         ssr         = create(:sub_service_request_without_validations, organization: org, service_request: sr)
         doc_params  = { doc_type: 'Neurology', document: Rack::Test::UploadedFile.new(File.join('doc', 'musc_installation_example.txt'),'text/plain') }
 
-        session[:service_request_id] = sr.id
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           protocol_id: protocol.id,
           org_ids: [org.id],
           document: doc_params
@@ -107,9 +107,9 @@ RSpec.describe DocumentsController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         doc_params  = { doc_type: '' }
 
-        session[:service_request_id] = sr.id
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           protocol_id: protocol.id,
           document: doc_params
         }
@@ -122,9 +122,9 @@ RSpec.describe DocumentsController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         doc_params  = { doc_type: '' }
 
-        session[:service_request_id] = sr.id
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           protocol_id: protocol.id,
           document: doc_params
         }
@@ -138,9 +138,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc_params  = { doc_type: 'Neurology', document: Rack::Test::UploadedFile.new(File.join('doc', 'musc_installation_example.txt'),'txt/plain') }
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         document: doc_params
       }
@@ -153,9 +153,9 @@ RSpec.describe DocumentsController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       doc_params  = { doc_type: 'Neurology', document: Rack::Test::UploadedFile.new(File.join('doc', 'musc_installation_example.txt'),'txt/plain') }
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         document: doc_params
       }

--- a/spec/controllers/documents/put_update_spec.rb
+++ b/spec/controllers/documents/put_update_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe DocumentsController, type: :controller do
       doc         = create(:document, protocol: protocol)
       doc_params  = { doc_type: 'Neurology' }
 
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
+        service_request_id: sr.id,
         id: doc.id,
         document: doc_params
       }
@@ -56,9 +56,9 @@ RSpec.describe DocumentsController, type: :controller do
       doc         = create(:document, protocol: protocol)
       doc_params  = { doc_type: 'Neurology' }
 
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
+        service_request_id: sr.id,
         id: doc.id,
         document: doc_params
       }
@@ -73,9 +73,9 @@ RSpec.describe DocumentsController, type: :controller do
         doc         = create(:document, protocol: protocol)
         doc_params  = { doc_type: 'Neurology' }
 
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
+        service_request_id: sr.id,
           id: doc.id,
           document: doc_params
         }
@@ -91,9 +91,9 @@ RSpec.describe DocumentsController, type: :controller do
         doc         = create(:document, protocol: protocol, doc_type: 'Blah')
         doc_params  = { doc_type: '' }
 
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
+        service_request_id: sr.id,
           id: doc.id,
           document: doc_params
         }
@@ -107,9 +107,9 @@ RSpec.describe DocumentsController, type: :controller do
         doc         = create(:document, protocol: protocol)
         doc_params  = { doc_type: '' }
 
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
+        service_request_id: sr.id,
           id: doc.id,
           document: doc_params
         }
@@ -124,9 +124,9 @@ RSpec.describe DocumentsController, type: :controller do
       doc         = create(:document, protocol: protocol)
       doc_params  = { doc_type: 'Neurology' }
 
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
+        service_request_id: sr.id,
         id: doc.id,
         document: doc_params
       }
@@ -140,9 +140,9 @@ RSpec.describe DocumentsController, type: :controller do
       doc         = create(:document, protocol: protocol)
       doc_params  = { doc_type: 'Neurology' }
 
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
+        service_request_id: sr.id,
         id: doc.id,
         document: doc_params
       }

--- a/spec/controllers/line_items/put_update_spec.rb
+++ b/spec/controllers/line_items/put_update_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe LineItemsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should assign @line_item' do
       protocol  = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr        = create(:service_request_without_validations, protocol: protocol)
@@ -42,8 +42,6 @@ RSpec.describe LineItemsController, type: :controller do
       service   = create(:service, one_time_fee: true)
       li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
       li_params = { quantity: 2 }
-
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
         id: li.id,
@@ -62,8 +60,6 @@ RSpec.describe LineItemsController, type: :controller do
       service   = create(:service, one_time_fee: true)
       li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
       li_params = { quantity: 2 }
-
-      session[:service_request_id] = sr.id
 
       xhr :put, :update, {
         id: li.id,
@@ -84,8 +80,6 @@ RSpec.describe LineItemsController, type: :controller do
         li        = create(:line_item_without_validations, sub_service_request: ssr, quantity: 1, service: service, service_request: sr)
         li_params = { quantity: 2 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: li.id,
           srid: sr.id,
@@ -103,8 +97,6 @@ RSpec.describe LineItemsController, type: :controller do
         service   = create(:service, one_time_fee: true)
         li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
         li_params = { quantity: 2 }
-
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
           id: li.id,
@@ -124,8 +116,6 @@ RSpec.describe LineItemsController, type: :controller do
         li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
         li_params = { quantity: 2 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: li.id,
           srid: sr.id,
@@ -144,8 +134,6 @@ RSpec.describe LineItemsController, type: :controller do
         li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
         li_params = { quantity: 2 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: li.id,
           srid: sr.id,
@@ -163,8 +151,6 @@ RSpec.describe LineItemsController, type: :controller do
         service   = create(:service, one_time_fee: true)
         li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
         li_params = { quantity: 2 }
-
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
           id: li.id,
@@ -186,8 +172,6 @@ RSpec.describe LineItemsController, type: :controller do
         li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
         li_params = { quantity: nil }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: li.id,
           srid: sr.id,
@@ -206,8 +190,6 @@ RSpec.describe LineItemsController, type: :controller do
         li        = create(:line_item_without_validations, sub_service_request: ssr, service: service, service_request: sr)
         li_params = { quantity: nil }
 
-        session[:service_request_id] = sr.id
-        
         xhr :put, :update, {
           id: li.id,
           srid: sr.id,

--- a/spec/controllers/notes/get_index_spec.rb
+++ b/spec/controllers/notes/get_index_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe NotesController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -44,9 +44,9 @@ RSpec.describe NotesController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -58,9 +58,9 @@ RSpec.describe NotesController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -72,9 +72,9 @@ RSpec.describe NotesController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         note: note_params,
         in_dashboard: 'true'
       }
@@ -89,9 +89,9 @@ RSpec.describe NotesController, type: :controller do
                       create(:note, notable: sr, identity: logged_in_user)
         note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-        session[:service_request_id] = sr.id
 
         xhr :get, :index, {
+        service_request_id: sr.id,
           note: note_params,
           format: :json
         }
@@ -104,9 +104,9 @@ RSpec.describe NotesController, type: :controller do
         sr          = create(:service_request_without_validations, protocol: protocol)
         note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-        session[:service_request_id] = sr.id
 
         xhr :get, :index, {
+        service_request_id: sr.id,
           note: note_params,
           format: :json
         }
@@ -120,9 +120,9 @@ RSpec.describe NotesController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -134,9 +134,9 @@ RSpec.describe NotesController, type: :controller do
       sr          = create(:service_request_without_validations, protocol: protocol)
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :index, {
+        service_request_id: sr.id,
         note: note_params
       }
 

--- a/spec/controllers/notes/get_new_spec.rb
+++ b/spec/controllers/notes/get_new_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -46,9 +46,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -61,9 +61,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -76,9 +76,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params,
         in_dashboard: 'true'
       }
@@ -92,9 +92,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -108,9 +108,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -123,9 +123,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :new, {
+        service_request_id: sr.id,
         note: note_params
       }
 

--- a/spec/controllers/notes/post_create_spec.rb
+++ b/spec/controllers/notes/post_create_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -46,9 +46,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -61,9 +61,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -76,9 +76,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         note: note_params,
         in_dashboard: 'true'
       }
@@ -93,9 +93,9 @@ RSpec.describe NotesController, type: :controller do
         note_params = { notable_id: sr.id, notable_type: 'ServiceRequest', body: 'asdf' }
 
         session[:identity_id] = logged_in_user.id
-        session[:service_request_id] = sr.id
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           note: note_params
         }
 
@@ -110,9 +110,9 @@ RSpec.describe NotesController, type: :controller do
         note_params = { notable_id: sr.id, notable_type: 'ServiceRequest', body: '' }
 
         session[:identity_id] = logged_in_user.id
-        session[:service_request_id] = sr.id
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           note: note_params
         }
 
@@ -125,9 +125,9 @@ RSpec.describe NotesController, type: :controller do
         note_params = { notable_id: sr.id, notable_type: 'ServiceRequest', body: '' }
 
         session[:identity_id] = logged_in_user.id
-        session[:service_request_id] = sr.id
 
         xhr :post, :create, {
+        service_request_id: sr.id,
           note: note_params
         }
 
@@ -141,9 +141,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         note: note_params
       }
 
@@ -156,9 +156,9 @@ RSpec.describe NotesController, type: :controller do
       note_params = { notable_id: sr.id, notable_type: 'ServiceRequest' }
 
       session[:identity_id] = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :post, :create, {
+        service_request_id: sr.id,
         note: note_params
       }
 

--- a/spec/controllers/search/get_services_spec.rb
+++ b/spec/controllers/search/get_services_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe SearchController do
       s1  = create(:service, organization: org, name: 'Serve me Well')
       s2  = create(:service, organization: org, name: 'Evres me Poorly')
       
-      session[:service_request_id] = sr.id
 
       xhr :get, :services, {
+        service_request_id: sr.id,
         term: 'Serve'
       }
 
@@ -59,9 +59,9 @@ RSpec.describe SearchController do
       s1  = create(:service, organization: org, abbreviation: 'Serve me Well')
       s2  = create(:service, organization: org, abbreviation: 'Evres me Poorly')
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :services, {
+        service_request_id: sr.id,
         term: 'Serve'
       }
 
@@ -77,9 +77,9 @@ RSpec.describe SearchController do
       s1  = create(:service, organization: org, cpt_code: 1234)
       s2  = create(:service, organization: org, cpt_code: 4321)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :services, {
+        service_request_id: sr.id,
         term: '1234'
       }
 
@@ -95,9 +95,9 @@ RSpec.describe SearchController do
       s1  = create(:service, organization: org, name: 'Service 123', is_available: 1)
       s2  = create(:service, organization: org, name: 'Service 321', is_available: 0)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :services, {
+        service_request_id: sr.id,
         term: 'Service'
       }
 
@@ -120,9 +120,9 @@ RSpec.describe SearchController do
       s2    = create(:service, organization: org2, name: 'Service 321')
 
       stub_const("EDITABLE_STATUSES", { org.id => ['draft'] })
-      session[:service_request_id]  = sr.id
 
       xhr :get, :services, {
+        service_request_id: sr.id,
         term: 'Service'
       }
 
@@ -141,10 +141,10 @@ RSpec.describe SearchController do
         s1    = create(:service, organization: org, name: 'Service 123')
         s2    = create(:service, organization: org2, name: 'Service 321')
 
-        session[:service_request_id]      = sr.id
         session[:sub_service_request_id]  = ssr.id
 
         xhr :get, :services, {
+        service_request_id: sr.id,
           term: 'Service'
         }
 

--- a/spec/controllers/search/get_services_spec.rb
+++ b/spec/controllers/search/get_services_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SearchController do
       org = create(:organization)
       s1  = create(:service, organization: org, name: 'Serve me Well')
       s2  = create(:service, organization: org, name: 'Evres me Poorly')
-      
+
 
       xhr :get, :services, {
         service_request_id: sr.id,
@@ -141,10 +141,9 @@ RSpec.describe SearchController do
         s1    = create(:service, organization: org, name: 'Service 123')
         s2    = create(:service, organization: org2, name: 'Service 321')
 
-        session[:sub_service_request_id]  = ssr.id
-
         xhr :get, :services, {
-        service_request_id: sr.id,
+          service_request_id: sr.id,
+          sub_service_request_id: ssr.id,
           term: 'Service'
         }
 

--- a/spec/controllers/service_calendars/get_merged_calendar_spec.rb
+++ b/spec/controllers/service_calendars/get_merged_calendar_spec.rb
@@ -38,10 +38,9 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :merged_calendar, {
-        tab: 'template'
+        tab: 'template',
+        service_request_id: sr.id
       }
 
       expect(assigns(:tab)).to eq('template')
@@ -51,10 +50,9 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :merged_calendar, {
-        review: 'true'
+        review: 'true',
+        service_request_id: sr.id
       }
 
       expect(assigns(:review)).to eq(true)
@@ -64,10 +62,9 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :merged_calendar, {
-        portal: 'false'
+        portal: 'false',
+        service_request_id: sr.id
       }
 
       expect(assigns(:portal)).to eq(false)
@@ -77,9 +74,7 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
-      xhr :get, :merged_calendar
+      xhr :get, :merged_calendar, service_request_id: sr.id
 
       expect(assigns(:merged)).to eq(true)
     end
@@ -90,9 +85,7 @@ RSpec.describe ServiceCalendarsController do
       arm1      = create(:arm, protocol: protocol, name: "Arm 1")
       arm2      = create(:arm, protocol: protocol, name: "Arm 2")
 
-      session[:service_request_id] = sr.id
-
-      xhr :get, :merged_calendar
+      xhr :get, :merged_calendar, service_request_id: sr.id
 
       expect(assigns(:pages).count).to eq(2)
       expect(assigns(:pages)[arm1.id]).to be
@@ -104,10 +97,9 @@ RSpec.describe ServiceCalendarsController do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm, protocol: protocol, name: "Arm")
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :merged_calendar, {
-        arm_id: arm.id
+        arm_id: arm.id,
+        service_request_id: sr.id
       }
 
       expect(assigns(:arm)).to eq(arm)
@@ -118,10 +110,9 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :merged_calendar, {
-          format: :js
+          format: :js,
+          service_request_id: sr.id
         }
 
         expect(controller).to render_template(:merged_calendar)
@@ -131,10 +122,9 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :merged_calendar, {
-          format: :js
+          format: :js,
+          service_request_id: sr.id
         }
 
         expect(controller).to respond_with(:ok)
@@ -146,10 +136,9 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :merged_calendar, {
-          format: :html
+          format: :html,
+          service_request_id: sr.id
         }
 
         expect(controller).to render_template(:merged_calendar)
@@ -159,10 +148,9 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :merged_calendar, {
-          format: :html
+          format: :html,
+          service_request_id: sr.id
         }
 
         expect(controller).to respond_with(:ok)

--- a/spec/controllers/service_calendars/get_show_move_visits_spec.rb
+++ b/spec/controllers/service_calendars/get_show_move_visits_spec.rb
@@ -39,9 +39,8 @@ RSpec.describe ServiceCalendarsController do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm, protocol: protocol, name: "Arm")
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :show_move_visits, {
+        service_request_id: sr.id,
         arm_id: arm.id
       }
 
@@ -53,9 +52,8 @@ RSpec.describe ServiceCalendarsController do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm, protocol: protocol, name: "Arm")
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :show_move_visits, {
+        service_request_id: sr.id,
         arm_id: arm.id
       }
 
@@ -67,9 +65,8 @@ RSpec.describe ServiceCalendarsController do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm, protocol: protocol, name: "Arm")
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :show_move_visits, {
+        service_request_id: sr.id,
         arm_id: arm.id
       }
 

--- a/spec/controllers/service_calendars/get_table_spec.rb
+++ b/spec/controllers/service_calendars/get_table_spec.rb
@@ -38,9 +38,8 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :table, {
+        service_request_id: sr.id,
         tab: 'template'
       }
 
@@ -51,9 +50,8 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :table, {
+        service_request_id: sr.id,
         review: 'true'
       }
 
@@ -64,9 +62,8 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :table, {
+        service_request_id: sr.id,
         portal: 'false'
       }
 
@@ -77,9 +74,7 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
-      xhr :get, :table
+      xhr :get, :table, service_request_id: sr.id
 
       expect(assigns(:merged)).to eq(false)
     end
@@ -90,9 +85,7 @@ RSpec.describe ServiceCalendarsController do
       arm1      = create(:arm, protocol: protocol, name: "Arm 1")
       arm2      = create(:arm, protocol: protocol, name: "Arm 2")
 
-      session[:service_request_id] = sr.id
-
-      xhr :get, :table
+      xhr :get, :table, service_request_id: sr.id
 
       expect(assigns(:pages).count).to eq(2)
       expect(assigns(:pages)[arm1.id]).to be
@@ -104,9 +97,8 @@ RSpec.describe ServiceCalendarsController do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm, protocol: protocol, name: "Arm")
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :table, {
+        service_request_id: sr.id,
         arm_id: arm.id
       }
 
@@ -118,9 +110,8 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :table, {
+          service_request_id: sr.id,
           format: :js
         }
 
@@ -131,9 +122,8 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :table, {
+          service_request_id: sr.id,
           format: :js
         }
 
@@ -146,9 +136,8 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :table, {
+          service_request_id: sr.id,
           format: :html
         }
 
@@ -159,9 +148,8 @@ RSpec.describe ServiceCalendarsController do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :table, {
+          service_request_id: sr.id,
           format: :html
         }
 

--- a/spec/controllers/service_calendars/get_view_full_calendar_spec.rb
+++ b/spec/controllers/service_calendars/get_view_full_calendar_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }
@@ -53,10 +53,10 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }
@@ -68,10 +68,10 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }
@@ -83,10 +83,10 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }
@@ -100,10 +100,10 @@ RSpec.describe ServiceCalendarsController do
       arm1      = create(:arm, protocol: protocol, name: "Arm 1")
       arm2      = create(:arm, protocol: protocol, name: "Arm 2")
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }
@@ -118,10 +118,10 @@ RSpec.describe ServiceCalendarsController do
       sr       = create(:service_request_without_validations, protocol: protocol)
       arm      = create(:arm, protocol: protocol, name: "Arm")
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true',
         arm_id: arm.id
@@ -134,10 +134,10 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }
@@ -149,10 +149,10 @@ RSpec.describe ServiceCalendarsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :get, :view_full_calendar, {
+        service_request_id: sr.id,
         protocol_id: protocol.id,
         portal: 'true'
       }

--- a/spec/controllers/service_calendars/post_move_visit_position_spec.rb
+++ b/spec/controllers/service_calendars/post_move_visit_position_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe ServiceCalendarsController do
       vg2      = create(:visit_group, arm: arm, position: 1)
       vg3      = create(:visit_group, arm: arm, position: 2)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :move_visit_position, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         visit_group: vg1.id,
         position: 3
@@ -64,9 +64,9 @@ RSpec.describe ServiceCalendarsController do
         vg2      = create(:visit_group, arm: arm, position: 1)
         vg3      = create(:visit_group, arm: arm, position: 2)
 
-        session[:service_request_id] = sr.id
 
         xhr :post, :move_visit_position, {
+        service_request_id: sr.id,
           arm_id: arm.id,
           visit_group: vg1.id,
           position: ''
@@ -86,9 +86,9 @@ RSpec.describe ServiceCalendarsController do
       vg2      = create(:visit_group, arm: arm, position: 1)
       vg3      = create(:visit_group, arm: arm, position: 2)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :move_visit_position, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         visit_group: vg1.id,
         position: 3
@@ -105,9 +105,9 @@ RSpec.describe ServiceCalendarsController do
       vg2      = create(:visit_group, arm: arm, position: 1)
       vg3      = create(:visit_group, arm: arm, position: 2)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :move_visit_position, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         visit_group: vg1.id,
         position: 3

--- a/spec/controllers/service_calendars/post_toggle_calendar_column_spec.rb
+++ b/spec/controllers/service_calendars/post_toggle_calendar_column_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ServiceCalendarsController do
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
       session[:identity_id] = logged_in_user.id
-      
+
       xhr :post, :toggle_calendar_column, {
         service_request_id: sr.id,
         arm_id: arm.id,
@@ -205,7 +205,7 @@ RSpec.describe ServiceCalendarsController do
           portal: 'false'
         }
 
-        expect(sr.reload.status).to eq('draft')        
+        expect(sr.reload.status).to eq('draft')
       end
 
       context 'editing sub service request' do
@@ -223,11 +223,11 @@ RSpec.describe ServiceCalendarsController do
           vg        = create(:visit_group, arm: arm)
           v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 1, research_billing_qty: 1, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-          session[:sub_service_request_id] = ssr.id
           session[:identity_id] = logged_in_user.id
 
           xhr :post, :toggle_calendar_column, {
-        service_request_id: sr.id,
+            sub_service_request_id: ssr.id,
+            service_request_id: sr.id,
             arm_id: arm.id,
             check: 'true',
             portal: 'false'

--- a/spec/controllers/service_calendars/post_toggle_calendar_column_spec.rb
+++ b/spec/controllers/service_calendars/post_toggle_calendar_column_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
       
       xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         check: 'true',
         portal: 'false'
@@ -89,10 +89,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         check: 'true',
         portal: 'false'
@@ -114,10 +114,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 0, research_billing_qty: 0, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-        session[:service_request_id] = sr.id
         session[:identity_id] = logged_in_user.id
 
         xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
           arm_id: arm.id,
           check: 'true',
           portal: 'false'
@@ -143,10 +143,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 1, research_billing_qty: 1, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-        session[:service_request_id] = sr.id
         session[:identity_id] = logged_in_user.id
 
         xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
           arm_id: arm.id,
           uncheck: 'true',
           portal: 'false'
@@ -172,10 +172,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 1, research_billing_qty: 1, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-        session[:service_request_id] = sr.id
         session[:identity_id] = logged_in_user.id
 
         xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
           arm_id: arm.id,
           check: 'true',
           portal: 'false'
@@ -196,10 +196,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 1, research_billing_qty: 1, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-        session[:service_request_id] = sr.id
         session[:identity_id] = logged_in_user.id
 
         xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
           arm_id: arm.id,
           check: 'true',
           portal: 'false'
@@ -224,10 +224,10 @@ RSpec.describe ServiceCalendarsController do
           v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 1, research_billing_qty: 1, insurance_billing_qty: 1, effort_billing_qty: 1)
 
           session[:sub_service_request_id] = ssr.id
-          session[:service_request_id]     = sr.id
           session[:identity_id] = logged_in_user.id
 
           xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
             arm_id: arm.id,
             check: 'true',
             portal: 'false'
@@ -251,10 +251,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         check: 'true',
         portal: 'false'
@@ -275,10 +275,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :post, :toggle_calendar_column, {
+        service_request_id: sr.id,
         arm_id: arm.id,
         check: 'true',
         portal: 'false'

--- a/spec/controllers/service_calendars/post_toggle_calendar_row_spec.rb
+++ b/spec/controllers/service_calendars/post_toggle_calendar_row_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
         line_items_visit_id: liv.id,
         check: 'true',
         portal: 'false'
@@ -70,10 +70,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id] = logged_in_user.id
 
       xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
         line_items_visit_id: liv.id,
         check: 'true',
         portal: 'false'
@@ -95,10 +95,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 0, research_billing_qty: 0, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-        session[:service_request_id] = sr.id
         session[:identity_id] = logged_in_user.id
 
         xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
           line_items_visit_id: liv.id,
           check: 'true',
           portal: 'false'
@@ -124,10 +124,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg, quantity: 1, research_billing_qty: 1, insurance_billing_qty: 1, effort_billing_qty: 1)
 
-        session[:service_request_id] = sr.id
         session[:identity_id] = logged_in_user.id
 
         xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
           line_items_visit_id: liv.id,
           uncheck: 'true',
           portal: 'false'
@@ -153,10 +153,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-        session[:service_request_id] = sr.id
         session[:identity_id]        = logged_in_user.id
 
         xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
           line_items_visit_id: liv.id,
           check: 'true',
           portal: 'false'
@@ -177,10 +177,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-        session[:service_request_id] = sr.id
         session[:identity_id]        = logged_in_user.id
 
         xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
           line_items_visit_id: liv.id,
           check: 'true',
           portal: 'false'
@@ -202,10 +202,10 @@ RSpec.describe ServiceCalendarsController do
         vg        = create(:visit_group, arm: arm)
         v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-        session[:service_request_id] = sr.id
         session[:identity_id]        = logged_in_user.id
 
         xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
           line_items_visit_id: liv.id,
           check: 'true',
           portal: 'false'
@@ -227,10 +227,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id]        = logged_in_user.id
 
       xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
         line_items_visit_id: liv.id,
         check: 'true',
         portal: 'false'
@@ -251,10 +251,10 @@ RSpec.describe ServiceCalendarsController do
       vg        = create(:visit_group, arm: arm)
       v         = create(:visit, line_items_visit: liv, visit_group: vg)
 
-      session[:service_request_id] = sr.id
       session[:identity_id]        = logged_in_user.id
 
       xhr :post, :toggle_calendar_row, {
+        service_request_id: sr.id,
         line_items_visit_id: liv.id,
         check: 'true',
         portal: 'false'

--- a/spec/controllers/service_requests/get_catalog_spec.rb
+++ b/spec/controllers/service_requests/get_catalog_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
 
         xhr :get, :catalog, {
           id: sr.id
@@ -72,7 +71,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, organization: prgrm, service_request: sr)
 
         session[:sub_service_request_id]  = ssr.id
-        session[:service_request_id]      = sr.id
 
         xhr :get, :catalog, {
           id: sr.id
@@ -89,7 +87,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
 
         stub_const('USE_GOOGLE_CALENDAR', true)
-        session[:service_request_id] = sr.id
 
         xhr :get, :catalog, {
           id: sr.id
@@ -105,7 +102,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
 
         stub_const('USE_NEWS_FEED', true)
-        session[:service_request_id] = sr.id
 
         xhr :get, :catalog, {
           id: sr.id
@@ -119,7 +115,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :catalog, {
         id: sr.id
@@ -132,7 +127,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
 
       xhr :get, :catalog, {
         id: sr.id

--- a/spec/controllers/service_requests/get_catalog_spec.rb
+++ b/spec/controllers/service_requests/get_catalog_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-
         xhr :get, :catalog, {
           id: sr.id
         }
@@ -70,9 +69,8 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, organization: prgrm, service_request: sr)
 
-        session[:sub_service_request_id]  = ssr.id
-
         xhr :get, :catalog, {
+          sub_service_request_id: ssr.id,
           id: sr.id
         }
 

--- a/spec/controllers/service_requests/get_confirmation_spec.rb
+++ b/spec/controllers/service_requests/get_confirmation_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
       session[:identity_id]        = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :confirmation, {
         id: sr.id
@@ -81,7 +80,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
@@ -100,7 +98,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       it 'should send request amendment email to admin' do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
@@ -133,7 +130,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
@@ -151,7 +147,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
 
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
@@ -191,7 +186,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
@@ -209,7 +203,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
 
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
@@ -235,7 +228,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should NOT send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
@@ -253,7 +245,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
 
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = @sr.id
         session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
@@ -280,7 +271,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
           session[:sub_service_request_id] = ssr.id
 
           # previously_submitted_at is null so we get 2 emails
@@ -301,7 +291,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
         session[:identity_id]            = logged_in_user.id
-        session[:service_request_id]     = sr.id
         session[:sub_service_request_id] = ssr.id
 
         xhr :get, :confirmation, {
@@ -324,7 +313,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
         session[:identity_id]            = logged_in_user.id
-        session[:service_request_id]     = sr.id
         session[:sub_service_request_id] = ssr.id
 
         xhr :get, :confirmation, {
@@ -345,7 +333,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
           session[:sub_service_request_id] = ssr.id
           stub_const("USE_EPIC", true)
           stub_const("QUEUE_EPIC", true)
@@ -371,7 +358,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
           session[:sub_service_request_id] = ssr.id
           stub_const("USE_EPIC", true)
           setup_valid_study_answers(protocol)
@@ -397,7 +383,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                    create(:service_provider, identity: logged_in_user, organization: org)
 
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = sr.id
         time                         = Time.parse('2016-06-01 12:34:56')
         
         Timecop.freeze(time) do
@@ -418,7 +403,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                    create(:service_provider, identity: logged_in_user, organization: org)
 
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = sr.id
 
         xhr :get, :confirmation, {
           id: sr.id
@@ -441,7 +425,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                    create(:service_provider, identity: logged_in_user, organization: org)
 
         session[:identity_id]        = logged_in_user.id
-        session[:service_request_id] = sr.id
 
         # previously_submitted_at is null so we get 2 emails
         expect {
@@ -461,7 +444,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
           stub_const("USE_EPIC", true)
           stub_const("QUEUE_EPIC", true)
           setup_valid_study_answers(protocol)
@@ -486,7 +468,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
           session[:sub_service_request_id] = ssr.id
           stub_const("USE_EPIC", true)
           setup_valid_study_answers(protocol)
@@ -510,7 +491,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
       session[:identity_id]        = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :confirmation, {
         id: sr.id
@@ -528,7 +508,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
       session[:identity_id]        = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :confirmation, {
         id: sr.id

--- a/spec/controllers/service_requests/get_confirmation_spec.rb
+++ b/spec/controllers/service_requests/get_confirmation_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
           mailer = double('mail') 
@@ -89,6 +88,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
         end
 
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
 
@@ -98,7 +98,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       it 'should send request amendment email to admin' do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
           mailer = double('mail') 
@@ -106,6 +105,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
           mailer
         end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).to have_received(:notify_admin)
@@ -130,7 +130,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
           mailer = double('mail') 
@@ -138,6 +137,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
           mailer
         end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).to have_received(:notify_service_provider)
@@ -147,7 +147,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
 
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
             mailer = double('mail') 
@@ -155,6 +154,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
             mailer
           end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).to have_received(:notify_admin)
@@ -186,7 +186,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
             mailer = double('mail') 
@@ -194,6 +193,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
             mailer
           end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).to have_received(:notify_service_provider)
@@ -203,7 +203,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
 
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
             mailer = double('mail') 
@@ -211,6 +210,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
             mailer
           end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).to have_received(:notify_admin)
@@ -228,7 +228,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should NOT send request amendment email to service provider' do
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_service_provider) do
           mailer = double('mail') 
@@ -236,6 +235,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
           mailer
         end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).not_to have_received(:notify_service_provider)
@@ -245,7 +245,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         @org.submission_emails.create(email: 'hedwig@owlpost.com')
 
         session[:identity_id]        = logged_in_user.id
-        session[:sub_service_request_id] = @ssr.id
 
         allow(Notifier).to receive(:notify_admin) do
             mailer = double('mail') 
@@ -253,6 +252,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
             mailer
           end
         xhr :get, :confirmation, {
+          sub_service_request_id: @ssr.id,
           id: @sr.id
         }
         expect(Notifier).not_to have_received(:notify_admin)
@@ -271,11 +271,11 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:sub_service_request_id] = ssr.id
 
           # previously_submitted_at is null so we get 2 emails
           expect {
             xhr :get, :confirmation, {
+              sub_service_request_id: ssr.id,
               id: sr.id
             }
           }.to change(ActionMailer::Base.deliveries, :count).by(2)
@@ -291,9 +291,9 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
         session[:identity_id]            = logged_in_user.id
-        session[:sub_service_request_id] = ssr.id
 
         xhr :get, :confirmation, {
+          sub_service_request_id: ssr.id,
           id: sr.id
         }
 
@@ -313,9 +313,9 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
         session[:identity_id]            = logged_in_user.id
-        session[:sub_service_request_id] = ssr.id
 
         xhr :get, :confirmation, {
+          sub_service_request_id: ssr.id,
           id: sr.id
         }
 
@@ -333,12 +333,12 @@ RSpec.describe ServiceRequestsController, type: :controller do
           li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
           session[:identity_id]            = logged_in_user.id
-          session[:sub_service_request_id] = ssr.id
           stub_const("USE_EPIC", true)
           stub_const("QUEUE_EPIC", true)
           setup_valid_study_answers(protocol)
 
           xhr :get, :confirmation, {
+          sub_service_request_id: ssr.id,
             id: sr.id
           }
 
@@ -358,13 +358,13 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:sub_service_request_id] = ssr.id
           stub_const("USE_EPIC", true)
           setup_valid_study_answers(protocol)
 
           # previously_submitted_at is null so we get 2 emails
           expect {
             xhr :get, :confirmation, {
+              sub_service_request_id: ssr.id,
               id: sr.id
             }
           }.to change(ActionMailer::Base.deliveries, :count).by(3)
@@ -468,13 +468,13 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:sub_service_request_id] = ssr.id
           stub_const("USE_EPIC", true)
           setup_valid_study_answers(protocol)
 
           # previously_submitted_at is null so we get 2 emails
           expect {
             xhr :get, :confirmation, {
+              sub_service_request_id: ssr.id,
               id: sr.id
             }
           }.to change(ActionMailer::Base.deliveries, :count).by(3)

--- a/spec/controllers/service_requests/get_document_management_spec.rb
+++ b/spec/controllers/service_requests/get_document_management_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should call before_filter #authenticate_identity!' do
       expect(before_filters.include?(:authenticate_identity!)).to eq(true)
     end
@@ -59,8 +59,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
                  create(:subsidy, sub_service_request: ssr)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :document_management, {
         id: sr.id
@@ -82,8 +80,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :document_management, {
         id: sr.id
       }
@@ -99,8 +95,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-        session[:service_request_id] = sr.id
 
         xhr :get, :document_management, {
           id: sr.id
@@ -118,8 +112,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :document_management, {
         id: sr.id
       }
@@ -134,8 +126,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :document_management, {
         id: sr.id

--- a/spec/controllers/service_requests/get_obtain_research_pricing_spec.rb
+++ b/spec/controllers/service_requests/get_obtain_research_pricing_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should call before_filter #authenticate_identity!' do
       expect(before_filters.include?(:authenticate_identity!)).to eq(true)
     end
@@ -51,7 +51,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
       session[:identity_id]        = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :obtain_research_pricing, {
         id: sr.id
@@ -72,8 +71,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:service_provider, identity: logged_in_user, organization: org)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
-          session[:sub_service_request_id] = ssr.id
+
 
           # previously_submitted_at is null so we get 2 emails
           expect {
@@ -93,8 +91,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
         session[:identity_id]            = logged_in_user.id
-        session[:service_request_id]     = sr.id
-        session[:sub_service_request_id] = ssr.id
+
 
         xhr :get, :obtain_research_pricing, {
           id: sr.id
@@ -112,8 +109,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
         session[:identity_id]            = logged_in_user.id
-        session[:service_request_id]     = sr.id
-        session[:sub_service_request_id] = ssr.id
+
 
         xhr :get, :obtain_research_pricing, {
           id: sr.id
@@ -135,7 +131,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                    create(:service_provider, identity: logged_in_user, organization: org)
 
         session[:identity_id]            = logged_in_user.id
-        session[:service_request_id]     = sr.id
 
         xhr :get, :obtain_research_pricing, {
           id: sr.id
@@ -154,7 +149,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                    create(:service_provider, identity: logged_in_user, organization: org)
 
         session[:identity_id]            = logged_in_user.id
-        session[:service_request_id]     = sr.id
 
         # previously_submitted_at is null so we get 2 emails
         expect {
@@ -174,7 +168,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
       session[:identity_id]        = logged_in_user.id
-      session[:service_request_id] = sr.id
 
       xhr :get, :obtain_research_pricing, {
         id: sr.id
@@ -192,8 +185,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
       session[:identity_id]        = logged_in_user.id
-      session[:service_request_id] = sr.id
-      
+
       xhr :get, :obtain_research_pricing, {
         id: sr.id
       }

--- a/spec/controllers/service_requests/get_protocol_spec.rb
+++ b/spec/controllers/service_requests/get_protocol_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org, service_requester_id: nil)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
       session[:identity_id]        = logged_in_user.id
 
       xhr :get, :protocol, {
@@ -72,7 +71,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
       session[:identity_id]        = logged_in_user.id
 
       xhr :get, :protocol, {
@@ -90,7 +88,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
       session[:identity_id]        = logged_in_user.id
 
       xhr :get, :protocol, {

--- a/spec/controllers/service_requests/get_review_spec.rb
+++ b/spec/controllers/service_requests/get_review_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should call before_filter #authenticate_identity!' do
       expect(before_filters.include?(:authenticate_identity!)).to eq(true)
     end
@@ -53,8 +53,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :review, {
         id: sr.id
@@ -71,8 +69,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :review, {
         id: sr.id
       }
@@ -88,8 +84,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :review, {
         id: sr.id
       }
@@ -104,8 +98,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :review, {
         id: sr.id
@@ -125,8 +117,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       arm2     = create(:arm, protocol: protocol)
       pages    = { arm1.id => 1, arm2.id => 1 }
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :review, {
         id: sr.id
       }
@@ -142,8 +132,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :review, {
         id: sr.id
       }
@@ -158,8 +146,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :review, {
         id: sr.id

--- a/spec/controllers/service_requests/get_save_and_exit_spec.rb
+++ b/spec/controllers/service_requests/get_save_and_exit_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe ServiceRequestsController, type: :controller do
           ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                      create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-
           xhr :get, :save_and_exit, {
             id: sr.id,
+            sub_service_request_id: ssr.id,
             format: :html
           }
 
@@ -105,6 +105,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
           session[:identity_id]            = logged_in_user.id
 
           xhr :get, :save_and_exit, {
+            sub_service_request_id: ssr.id,
             id: sr.id,
             format: :html
           }

--- a/spec/controllers/service_requests/get_save_and_exit_spec.rb
+++ b/spec/controllers/service_requests/get_save_and_exit_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :save_and_exit, {
           id: sr.id
         }
@@ -67,8 +65,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-        session[:service_request_id] = sr.id
 
         xhr :get, :save_and_exit, {
           id: sr.id
@@ -88,8 +84,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                      create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-          session[:service_request_id]     = sr.id
-          session[:sub_service_request_id] = ssr.id
 
           xhr :get, :save_and_exit, {
             id: sr.id,
@@ -109,8 +103,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                      create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
           session[:identity_id]            = logged_in_user.id
-          session[:service_request_id]     = sr.id
-          session[:sub_service_request_id] = ssr.id
 
           xhr :get, :save_and_exit, {
             id: sr.id,
@@ -131,8 +123,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'first_draft')
                      create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-          session[:service_request_id] = sr.id
-          session[:identity_id]        = logged_in_user.id
 
           xhr :get, :save_and_exit, {
             id: sr.id,
@@ -152,8 +142,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-        session[:service_request_id] = sr.id
-
         xhr :get, :save_and_exit, {
           id: sr.id,
           format: :html
@@ -169,8 +157,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-        session[:service_request_id] = sr.id
 
         xhr :get, :save_and_exit, {
           id: sr.id,

--- a/spec/controllers/service_requests/get_service_calendar_spec.rb
+++ b/spec/controllers/service_requests/get_service_calendar_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should call before_filter #authenticate_identity!' do
       expect(before_filters.include?(:authenticate_identity!)).to eq(true)
     end
@@ -55,8 +55,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
       arm      = create(:arm, protocol: protocol)
       pages    = { arm.id => '3' }
-      
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_calendar, {
         id: sr.id,
@@ -75,8 +73,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                    create(:arm, protocol: protocol)
-
-        session[:service_request_id] = sr.id
 
         xhr :get, :service_calendar, {
           id: sr.id
@@ -101,8 +97,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           liv       = build(:line_items_visit, arm: arm, line_item: line_item, subject_count: 5)
           liv.save(validate: false)
 
-          session[:service_request_id] = sr.id
-
           xhr :get, :service_calendar, {
             id: sr.id
           }
@@ -123,8 +117,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
                       create(:line_items_visit, arm: arm, line_item: line_item)
                       create(:visit_group, arm: arm) # Create an extra Visit Group
 
-          session[:service_request_id] = sr.id
-
           xhr :get, :service_calendar, {
             id: sr.id
           }
@@ -143,15 +135,13 @@ RSpec.describe ServiceRequestsController, type: :controller do
           line_item = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
           arm       = create(:arm, protocol: protocol, visit_count: 1)
                       create(:line_items_visit, arm: arm, line_item: line_item)
-          
-          arm.update_attribute(:visit_count, 2) # Update Visit Count to force Mass Create Visit Group
 
-          session[:service_request_id] = sr.id
+          arm.update_attribute(:visit_count, 2) # Update Visit Count to force Mass Create Visit Group
 
           xhr :get, :service_calendar, {
             id: sr.id
           }
-          
+
           expect(arm.visit_groups.count).to eq(2)
         end
       end
@@ -165,8 +155,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                  create(:arm, protocol: protocol)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_calendar, {
         id: sr.id
@@ -183,8 +171,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                  create(:arm, protocol: protocol)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_calendar, {
         id: sr.id

--- a/spec/controllers/service_requests/get_service_details_spec.rb
+++ b/spec/controllers/service_requests/get_service_details_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should call before_filter #authenticate_identity!' do
       expect(before_filters.include?(:authenticate_identity!)).to eq(true)
     end
@@ -53,8 +53,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_details, {
         id: sr.id
@@ -72,8 +70,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :service_details, {
         id: sr.id
       }
@@ -88,8 +84,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_details, {
         id: sr.id

--- a/spec/controllers/service_requests/get_service_subsidy_spec.rb
+++ b/spec/controllers/service_requests/get_service_subsidy_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call before_filter #authorize_identity' do
       expect(before_filters.include?(:authorize_identity)).to eq(true)
     end
-    
+
     it 'should call before_filter #authenticate_identity!' do
       expect(before_filters.include?(:authenticate_identity!)).to eq(true)
     end
@@ -59,8 +59,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
                  create(:subsidy, sub_service_request: ssr)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_subsidy, {
         id: sr.id
@@ -82,8 +80,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :service_subsidy, {
         id: sr.id
       }
@@ -99,8 +95,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: org)
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-        session[:service_request_id] = sr.id
 
         xhr :get, :service_subsidy, {
           id: sr.id
@@ -119,8 +113,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       liv      = create(:line_items_visit, arm: arm, line_item: li)
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_subsidy, {
         id: sr.id
@@ -142,8 +134,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :service_subsidy, {
         id: sr.id
       }
@@ -163,8 +153,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       liv      = create(:line_items_visit, arm: arm, line_item: li)
       vg       = create(:visit_group, arm: arm, day: 1)
                  create(:visit, visit_group: vg, line_items_visit: liv)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :service_subsidy, {
         id: sr.id

--- a/spec/controllers/service_requests/get_show_spec.rb
+++ b/spec/controllers/service_requests/get_show_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe ServiceRequestsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :show, {
         id: sr.id
       }
@@ -50,8 +48,6 @@ RSpec.describe ServiceRequestsController do
     it 'should assign @admin_offset' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :show, {
         id: sr.id,
@@ -65,8 +61,6 @@ RSpec.describe ServiceRequestsController do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
 
-      session[:service_request_id] = sr.id
-
       xhr :get, :show, {
         id: sr.id
       }
@@ -77,8 +71,6 @@ RSpec.describe ServiceRequestsController do
     it 'should respond ok' do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
-
-      session[:service_request_id] = sr.id
 
       xhr :get, :show, {
         id: sr.id

--- a/spec/controllers/service_requests/post_add_service_spec.rb
+++ b/spec/controllers/service_requests/post_add_service_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :add_service, {
           id: sr.id,
           service_id: service.id
@@ -60,8 +58,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-        session[:service_request_id] = sr.id
 
         xhr :post, :add_service, {
           id: sr.id,
@@ -79,8 +75,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :add_service, {
           id: sr.id,
           service_id: service.id
@@ -96,8 +90,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
-
-        session[:service_request_id] = sr.id
 
         xhr :post, :add_service, {
           id: sr.id,
@@ -115,8 +107,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           service  = create(:service, organization: org)
           protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
           sr       = create(:service_request_without_validations, protocol: protocol)
-
-          session[:service_request_id] = sr.id
 
           xhr :post, :add_service, {
             id: sr.id,
@@ -137,8 +127,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
           li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-          session[:service_request_id] = sr.id
-
           xhr :post, :add_service, {
             id: sr.id,
             service_id: service2.id
@@ -153,8 +141,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         service  = create(:service, organization: org)
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
-
-        session[:service_request_id] = sr.id
 
         xhr :post, :add_service, {
           id: sr.id,
@@ -173,8 +159,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ServiceRelation.create(service_id: service.id, related_service_id: service2.id, optional: false)
 
-        session[:service_request_id] = sr.id
-        session[:identity_id]        = logged_in_user.id
 
         xhr :post, :add_service, {
           id: sr.id,
@@ -194,8 +178,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
           sr       = create(:service_request_without_validations, protocol: protocol, status: 'first_draft')
 
-          session[:service_request_id] = sr.id
-
           xhr :post, :add_service, {
             id: sr.id,
             service_id: service.id
@@ -213,8 +195,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
           sr       = create(:service_request_without_validations, protocol: protocol)
           ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
 
-          session[:service_request_id] = sr.id
-          session[:identity_id]        = logged_in_user.id
 
           xhr :post, :add_service, {
             id: sr.id,
@@ -230,8 +210,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :add_service, {
           id: sr.id,
           service_id: service.id
@@ -245,8 +223,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         service  = create(:service, organization: org)
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
-
-        session[:service_request_id] = sr.id
 
         xhr :post, :add_service, {
           id: sr.id,
@@ -262,8 +238,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :add_service, {
           id: sr.id,
           service_id: service.id
@@ -277,8 +251,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         service  = create(:service, organization: org)
         protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
         sr       = create(:service_request_without_validations, protocol: protocol)
-
-        session[:service_request_id] = sr.id
 
         xhr :post, :add_service, {
           id: sr.id,

--- a/spec/controllers/service_requests/post_add_service_spec.rb
+++ b/spec/controllers/service_requests/post_add_service_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         ServiceRelation.create(service_id: service.id, related_service_id: service2.id, optional: false)
 
+        session[:identity_id] = logged_in_user.id
 
         xhr :post, :add_service, {
           id: sr.id,
@@ -195,6 +196,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
           sr       = create(:service_request_without_validations, protocol: protocol)
           ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
 
+          session[:identity_id] = logged_in_user.id
 
           xhr :post, :add_service, {
             id: sr.id,

--- a/spec/controllers/service_requests/post_feedback_spec.rb
+++ b/spec/controllers/service_requests/post_feedback_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         feedback = { message: 'hi', email: 'asd123@musc.edu' }
 
-        session[:service_request_id] = sr.id
-
         expect {
           xhr :post, :feedback, {
             id: sr.id,
@@ -49,8 +47,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         sr       = create(:service_request_without_validations, protocol: protocol)
         feedback = { message: '', email: '' }
 
-        session[:service_request_id] = sr.id
-
         xhr :post, :feedback, {
           id: sr.id
         }
@@ -64,8 +60,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       sr       = create(:service_request_without_validations, protocol: protocol)
       feedback = { message: 'hi', email: 'asd123@musc.edu' }
 
-      session[:service_request_id] = sr.id
-
       xhr :post, :feedback, {
         id: sr.id
       }
@@ -77,8 +71,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       protocol = create(:protocol_without_validations, primary_pi: logged_in_user)
       sr       = create(:service_request_without_validations, protocol: protocol)
       feedback = { message: 'hi', email: 'asd123@musc.edu' }
-
-      session[:service_request_id] = sr.id
 
       xhr :post, :feedback, {
         id: sr.id

--- a/spec/controllers/service_requests/post_remove_service_spec.rb
+++ b/spec/controllers/service_requests/post_remove_service_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li2      = create(:line_item, service_request: sr, sub_service_request: ssr, service: service2)
       ServiceRelation.create(service_id: service.id, related_service_id: service2.id, optional: false)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -67,7 +66,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -85,7 +83,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr, status: 'complete')
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -105,7 +102,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-        session[:service_request_id] = sr.id
         stub_const("EDITABLE_STATUSES", { org.id => ['first_draft'] })
 
         xhr :post, :remove_service, {
@@ -127,7 +123,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-        session[:service_request_id] = sr.id
         session[:identity_id]        = logged_in_user.id
 
         xhr :post, :remove_service, {
@@ -147,7 +142,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-        session[:service_request_id] = sr.id
         session[:identity_id]        = logged_in_user.id
 
         xhr :post, :remove_service, {
@@ -170,7 +164,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-        session[:service_request_id] = sr.id
 
         xhr :post, :remove_service, {
           id: sr.id,
@@ -190,7 +183,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr, status: 'first_draft')
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-        session[:service_request_id] = sr.id
         session[:identity_id]        = logged_in_user.id
 
         xhr :post, :remove_service, {
@@ -211,7 +203,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -230,7 +221,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                  create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -248,7 +238,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -266,7 +255,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       ssr      = create(:sub_service_request_without_validations, organization: org, service_request: sr)
       li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
 
-      session[:service_request_id] = sr.id
 
       xhr :post, :remove_service, {
         id: sr.id,
@@ -295,14 +283,13 @@ RSpec.describe ServiceRequestsController, type: :controller do
       end
 
       context 'removed all services (line_item1 & line_item2) for SSR' do
- 
+
         it 'should send notifications to the service provider' do
           @li_1.destroy
-          session[:service_request_id] = @sr.id
           session[:identity_id]        = logged_in_user.id
 
           allow(Notifier).to receive(:notify_service_provider) do
-            mailer = double('mail') 
+            mailer = double('mail')
             expect(mailer).to receive(:deliver_now)
             mailer
           end
@@ -319,14 +306,13 @@ RSpec.describe ServiceRequestsController, type: :controller do
       end
 
       context 'removed one of two services for SSR' do
- 
+
         it 'should not send notifications to the service provider' do
           # expect(controller).not_to receive(:send_ssr_service_provider_notifications)
-          session[:service_request_id] = @sr.id
           session[:identity_id]        = logged_in_user.id
 
           allow(Notifier).to receive(:notify_service_provider) do
-            mailer = double('mail') 
+            mailer = double('mail')
             expect(mailer).to receive(:deliver_now)
             mailer
           end
@@ -341,7 +327,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
         end
 
         it 'should not delete SSR (ssr1)' do
-          session[:service_request_id] = @sr.id
           session[:identity_id]        = logged_in_user.id
 
           post :remove_service, {
@@ -371,11 +356,10 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
       it 'should send notifications to the service_provider' do
 
-        session[:service_request_id] = @sr.id
         session[:identity_id]        = logged_in_user.id
 
         allow(Notifier).to receive(:notify_service_provider) do
-          mailer = double('mail') 
+          mailer = double('mail')
           expect(mailer).to receive(:deliver_now)
           mailer
         end
@@ -391,7 +375,6 @@ RSpec.describe ServiceRequestsController, type: :controller do
       end
 
       it 'should delete SSR' do
-        session[:service_request_id] = @sr.id
         session[:identity_id]        = logged_in_user.id
 
         post :remove_service, {

--- a/spec/controllers/visit_groups/put_update_spec.rb
+++ b/spec/controllers/visit_groups/put_update_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe VisitGroupsController, type: :controller do
       vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
       vg_params = { day: 5 }
 
-      session[:service_request_id] = sr.id
-
       xhr :put, :update, {
         id: vg.id,
         visit_group: vg_params
@@ -59,8 +57,6 @@ RSpec.describe VisitGroupsController, type: :controller do
         vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
         vg_params = { day: 5 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: vg.id,
           visit_group: vg_params
@@ -76,14 +72,12 @@ RSpec.describe VisitGroupsController, type: :controller do
         vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
         vg_params = { day: 5 }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: vg.id,
           visit_group: vg_params
         }
 
-        expect(response.body).to be_blank        
+        expect(response.body).to be_blank
       end
 
       it 'should respond ok' do
@@ -92,8 +86,6 @@ RSpec.describe VisitGroupsController, type: :controller do
         arm       = create(:arm, protocol: protocol, name: "Armada")
         vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
         vg_params = { day: 5 }
-
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
           id: vg.id,
@@ -112,8 +104,6 @@ RSpec.describe VisitGroupsController, type: :controller do
         vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
         vg_params = { name: nil }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: vg.id,
           visit_group: vg_params
@@ -129,8 +119,6 @@ RSpec.describe VisitGroupsController, type: :controller do
         vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
         vg_params = { name: nil }
 
-        session[:service_request_id] = sr.id
-
         xhr :put, :update, {
           id: vg.id,
           visit_group: vg_params
@@ -145,8 +133,6 @@ RSpec.describe VisitGroupsController, type: :controller do
         arm       = create(:arm, protocol: protocol, name: "Armada")
         vg        = create(:visit_group, arm: arm, day: 1, name: "Visit Me Baby One More Time")
         vg_params = { name: nil }
-
-        session[:service_request_id] = sr.id
 
         xhr :put, :update, {
           id: vg.id,

--- a/spec/controllers/visit_groups/put_update_spec.rb
+++ b/spec/controllers/visit_groups/put_update_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
       xhr :put, :update, {
         id: vg.id,
+        service_request_id: sr.id,
         visit_group: vg_params
       }
 
@@ -59,6 +60,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
         xhr :put, :update, {
           id: vg.id,
+          service_request_id: sr.id,
           visit_group: vg_params
         }
 
@@ -74,6 +76,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
         xhr :put, :update, {
           id: vg.id,
+          service_request_id: sr.id,
           visit_group: vg_params
         }
 
@@ -89,6 +92,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
         xhr :put, :update, {
           id: vg.id,
+          service_request_id: sr.id,
           visit_group: vg_params
         }
 
@@ -106,6 +110,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
         xhr :put, :update, {
           id: vg.id,
+          service_request_id: sr.id,
           visit_group: vg_params
         }
 
@@ -121,6 +126,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
         xhr :put, :update, {
           id: vg.id,
+          service_request_id: sr.id,
           visit_group: vg_params
         }
 
@@ -136,6 +142,7 @@ RSpec.describe VisitGroupsController, type: :controller do
 
         xhr :put, :update, {
           id: vg.id,
+          service_request_id: sr.id,
           visit_group: vg_params
         }
 

--- a/spec/features/dashboard/epic_queues/index_spec.rb
+++ b/spec/features/dashboard/epic_queues/index_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Notifications index', js: true do
         protocol.principal_investigators.map(&:full_name).each do |pi|
           @pi = "#{pi}"
         end
-   
+
         expect(page).to have_epic_queues(text: @pi)
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe 'Notifications index', js: true do
         page = visit_epic_queues_index_page
         wait_for_javascript_to_finish
         date = protocol.last_epic_push_time.strftime("%m/%d/%Y %I:%M:%S %p")
-        
+
         expect(page).to have_epic_queues(text: "#{date}")
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe 'Notifications index', js: true do
         wait_for_javascript_to_finish
 
         status = protocol.last_epic_push_status.capitalize
-        
+
         expect(page).to have_epic_queues(text: "#{status}")
       end
     end

--- a/spec/features/dashboard/protocols/view_ssr_back_button_spec.rb
+++ b/spec/features/dashboard/protocols/view_ssr_back_button_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe 'view SSR back button', js: true do
       wait_for_javascript_to_finish
       click_button 'Back'
       wait_for_javascript_to_finish
-      save_and_open_screenshot
 
       expect(page).to have_selector(".modal-title", text: "#{@protocol.short_title}")
       end

--- a/spec/features/protocol/user_views_protocol_details_spec.rb
+++ b/spec/features/protocol/user_views_protocol_details_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'User views protocol details', js: true do
     scenario 'and sees the details modal' do
       visit protocol_service_request_path(@sr)
       wait_for_javascript_to_finish
-
       click_button 'View Study Details'
       wait_for_javascript_to_finish
 

--- a/spec/features/service_details/user_adds_arm_spec.rb
+++ b/spec/features/service_details/user_adds_arm_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe 'User creates an arm', js: true do
     scenario 'and sees the created arm' do
       visit service_details_service_request_path(@sr)
       wait_for_javascript_to_finish
-
       click_button 'Add Arm'
       wait_for_javascript_to_finish
 


### PR DESCRIPTION
This pull request removes `sub_service_request_id` and `service_request_id` from the session variable. 
I placed a disabled hidden field named `service_request_id` in the application template for JS event handlers to pull from when making AJAX requests, if needed, for convenience. The base `ApplicationController` still sets `@service_request` and `@sub_service_request` as before. 
From now on, we need to be sure to pass along `(sub_)service_request_id`, if the receiving controller needs it.
If you see errors like: ```ActiveRecord::RecordNotFound (Couldn't find ServiceRequest with 'id'=)```, then you should just tack on `service_request_id=whatever` to your AJAX request, and that should do it.