### PR TITLE
wth - Admin edit sending SSR back to Draft bug

### DIFF
--- a/app/controllers/dashboard/line_items_visits_controller.rb
+++ b/app/controllers/dashboard/line_items_visits_controller.rb
@@ -27,8 +27,10 @@ class Dashboard::LineItemsVisitsController < Dashboard::BaseController
     @service_request  = ServiceRequest.find( params[:srid] )
 
     if @line_items_visit.update_attributes( params[:line_items_visit] )
-      @service_request.update_attributes(status: 'draft')
-      @line_items_visit.sub_service_request.update_attributes(status: 'draft')
+      unless params[:portal] == 'true'
+        @service_request.update_attributes(status: 'draft')
+        @line_items_visit.sub_service_request.update_attributes(status: 'draft')
+      end
       render json: { success: true }
     else
       render json: @line_items_visit.errors, status: :unprocessable_entity

--- a/app/controllers/dashboard/visits_controller.rb
+++ b/app/controllers/dashboard/visits_controller.rb
@@ -27,7 +27,9 @@ class Dashboard::VisitsController < Dashboard::BaseController
     admin = params[:service_request_id] ? false : true
 
     if @visit.update_attributes( params[:visit] )
-      @visit.line_items_visit.sub_service_request.set_to_draft(@admin)
+      unless params[:portal] == 'true'
+        @visit.line_items_visit.sub_service_request.set_to_draft(@admin)
+      end
       render nothing: true
     else
       render json: @visit.errors, status: :unprocessable_entity

--- a/app/views/service_calendars/master_calendar/pppv/_billing_strategy_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_billing_strategy_line_items.html.haml
@@ -65,7 +65,7 @@
         - if locked
           = liv.subject_count
         - else
-          %a.edit-subject-count{ href: 'javascript:void(0)', data: { arm_id: arm.id, name: 'subject_count', title: t(:calendars)[:pppv][:editable_fields][:subject_count], value: liv.subject_count, url: dashboard_line_items_visit_path(liv, srid: service_request.id) } }
+          %a.edit-subject-count{ href: 'javascript:void(0)', data: { arm_id: arm.id, name: 'subject_count', title: t(:calendars)[:pppv][:editable_fields][:subject_count], value: liv.subject_count, url: dashboard_line_items_visit_path(liv, srid: service_request.id, portal: @portal) } }
       - visits      = liv.visits.paginate(page: page.to_i, per_page: 5)
       - totals_hash = liv.try(:per_subject_subtotals, visits)
       - visits.each_with_index do |v, index|

--- a/app/views/service_calendars/master_calendar/pppv/_line_item_visit_input.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_line_item_visit_input.html.haml
@@ -34,10 +34,10 @@
           = visit.effort_billing_qty
     - else
       .col-xs-4.text-center.no-padding
-        %a.edit-research-billing-qty{ href: 'javascript:void(0)', data: { arm_id: arm.id, name: 'research_qty', title: t(:calendars)[:pppv][:editable_fields][:research], value: visit.research_billing_qty, url: dashboard_visit_path(visit) } }
+        %a.edit-research-billing-qty{ href: 'javascript:void(0)', data: { arm_id: arm.id, name: 'research_qty', title: t(:calendars)[:pppv][:editable_fields][:research], value: visit.research_billing_qty, url: dashboard_visit_path(visit, portal: @portal) } }
       .col-xs-4.text-center.no-padding
-        %a.edit-insurance-billing-qty{ href: 'javascript:void(0)', data: { name: 'third_party_qty', title: t(:calendars)[:pppv][:editable_fields][:third_party], value: visit.insurance_billing_qty, url: dashboard_visit_path(visit) } }
+        %a.edit-insurance-billing-qty{ href: 'javascript:void(0)', data: { name: 'third_party_qty', title: t(:calendars)[:pppv][:editable_fields][:third_party], value: visit.insurance_billing_qty, url: dashboard_visit_path(visit, portal: @portal) } }
       .col-xs-4.text-center.no-padding
-        %a.edit-effort-billing-qty{ href: 'javascript:void(0)', data: { name: 'percent_effort_qty', title: t(:calendars)[:pppv][:editable_fields][:percent], value: visit.effort_billing_qty, url: dashboard_visit_path(visit) } }
+        %a.edit-effort-billing-qty{ href: 'javascript:void(0)', data: { name: 'percent_effort_qty', title: t(:calendars)[:pppv][:editable_fields][:percent], value: visit.effort_billing_qty, url: dashboard_visit_path(visit, portal: @portal) } }
 - when 'calendar'
   = label_tag nil, qty_cost_label(visit.research_billing_qty + visit.insurance_billing_qty, currency_converter(totals_hash["#{visit.id}"])) || "0 - $0.00", class: 'line_item_visit_pricing'

--- a/app/views/service_calendars/master_calendar/pppv/_template_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_template_line_items.html.haml
@@ -51,7 +51,7 @@
         - if locked
           = liv.subject_count
         - else
-          %a.edit-subject-count{ class: locked ? 'locked' : '', href: 'javascript:void(0)', data: { arm_id: arm.id, name: 'subject_count', title: t(:calendars)[:pppv][:editable_fields][:subject_count], value: liv.subject_count, url: dashboard_line_items_visit_path(liv, srid: service_request.id) } }
+          %a.edit-subject-count{ class: locked ? 'locked' : '', href: 'javascript:void(0)', data: { arm_id: arm.id, name: 'subject_count', title: t(:calendars)[:pppv][:editable_fields][:subject_count], value: liv.subject_count, url: dashboard_line_items_visit_path(liv, srid: service_request.id, portal: @portal) } }
       %td.text-center
         = Dashboard::ServiceCalendars.select_row(liv, sub_service_request, portal, locked)
       - visits      = liv.visits.paginate(page: page.to_i, per_page: 5)


### PR DESCRIPTION
When altering figures in the service calendar tables, the statuses were
being changed back to draft status. This is proper functionality for
proper, but not for Dashboard. I added a parameter to the update actions
for Visits and Line Items Visits that checks if the update is happening
in Dashboard. [#136778033]