### PR TITLE
wth-SPARCCatalog Link shows Active Form Name

### DIFF
--- a/app/views/catalog_manager/services/_form.html.haml
+++ b/app/views/catalog_manager/services/_form.html.haml
@@ -74,9 +74,14 @@
 
             %tr
               %th
-                = t(:additional_details)[:add]
+                = t(:additional_details)[:label]
               %td
-                = link_to t(:additional_details)[:add], service_additional_details_questionnaires_path(@service)
+                - if @service.questionnaires.active.present?
+                  = link_to "#{@service.questionnaires.active.first.name}(active)", service_additional_details_questionnaires_path(@service)
+                - elsif @service.questionnaires.present?
+                  = link_to "#{@service.questionnaires.first.name}(inactive)", service_additional_details_questionnaires_path(@service)
+                - else
+                  = link_to t(:additional_details)[:add], service_additional_details_questionnaires_path(@service)
             %tr
               %th= t(:organization_form)[:tag_list]
               %td

--- a/config/locales/additional_details.en.yml
+++ b/config/locales/additional_details.en.yml
@@ -22,7 +22,8 @@ en:
   additional_details:
     additional_details_title: 'Additional Details'
     document_page_header: 'Additional Detail Submissions'
-    add: 'Add Additional Details'
+    label: 'Form Functionality'
+    add: 'Add New Form'
     preview_title: 'Additional Detail Survey Preview'
     close_preview: 'Close'
     form_builder_title: 'Additional Details Form Builder'


### PR DESCRIPTION
In SPARCCatalog Additional Details section on a service, to better
indicate whether there are existing forms built, I changed the label to
be 'Form Functionality', display name of form if active or first
inactive. If no forms exist for a service, show 'Add New
Form'.[#136754033]