### PR TITLE
wth - add breadcrumb to show path (additional details)

### DIFF
--- a/app/views/layouts/additional_details.html.haml
+++ b/app/views/layouts/additional_details.html.haml
@@ -29,6 +29,8 @@
 
   %body
     = render 'additional_details/shared/navbar'
+    %ol.breadcrumb
+      = display_organization_tree(@service.organization)
     .container
       .flash
         = render "shared/flash"

--- a/spec/features/additional_details/user_creates_an_additional_details_questionnaire_spec.rb
+++ b/spec/features/additional_details/user_creates_an_additional_details_questionnaire_spec.rb
@@ -23,7 +23,7 @@ require 'rails_helper'
 RSpec.describe 'User creates an additional details questionnaire', js: true do
   let_there_be_lane
   scenario 'successfully' do
-    service = create(:service)
+    service = create(:service, :with_ctrc_organization)
     visit new_service_additional_details_questionnaire_path(service)
     fill_in 'questionnaire_name', with: 'New Questionnaire'
     fill_in 'questionnaire_items_attributes_0_content', with: 'What is your favorite color?'

--- a/spec/features/additional_details/user_should_see_service_questionnaires_index_spec.rb
+++ b/spec/features/additional_details/user_should_see_service_questionnaires_index_spec.rb
@@ -23,7 +23,7 @@ require 'rails_helper'
 RSpec.describe 'User should see service questionnaire index', js: true do
   let_there_be_lane
   scenario 'successfully' do
-    service = create(:service)
+    service = create(:service, :with_ctrc_organization)
     questionnaire = create(:questionnaire,
                            name: 'Awesome Questionnaire',
                            service: service)


### PR DESCRIPTION
I added a breadcrumb to show the organization path of the service on the
additional details pages. [#136752809]