### PR TITLE
SAW - More Dashboard Subsidies Controller Specs

### DIFF
--- a/spec/controllers/dashboard/subsidies/delete_destroy_spec.rb
+++ b/spec/controllers/dashboard/subsidies/delete_destroy_spec.rb
@@ -18,55 +18,46 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Dashboard::SubsidiesController do
-  describe 'GET #edit' do
+  describe "DELETE #destroy" do
     before(:each) do
       @current_user = build_stubbed(:identity)
       log_in_dashboard_identity(obj: @current_user)
       @protocol        = create(:protocol_without_validations,
-                                primary_pi: @current_user)
+                                 primary_pi: @current_user)
       @organization    = create(:organization)
       @subsidy_map     = create(:subsidy_map,
-                                default_percentage: 5,
-                                organization: @organization)
+                                 default_percentage: 0,
+                                 organization: @organization)
       @service_request = create(:service_request_without_validations,
                                 protocol: @protocol)
       @ssr             = create(:sub_service_request_without_validations,
-                                service_request: @service_request,
-                                organization: @organization,
-                                status: 'draft')
-      @pending_subsidy = create(:pending_subsidy,
-                                sub_service_request_id: @ssr.id,
-                                percent_subsidy: 0.1)
-      xhr :get, :edit, admin: 'true', id: @pending_subsidy.id, format: :js
+                                 service_request: @service_request,
+                                 organization: @organization,
+                                 status: 'draft')
+      @subsidy         = create(:subsidy_without_validations,
+                                 sub_service_request: @ssr)
+      xhr :delete, :destroy, id: @subsidy.id, format: :js
     end
 
-    it { is_expected.to render_template "dashboard/subsidies/edit" }
+    it { is_expected.to render_template "dashboard/subsidies/destroy" }
 
     it 'should respond ok' do
       expect(controller).to respond_with(:ok)
     end
 
-    it 'should set @admin to params[:admin]' do
-      expect(assigns(:admin)).to eq(true)
+    it 'should assign @subsidy to the current subsidy' do
+      expect(assigns(:subsidy)).to eq(@subsidy)
     end
 
-    it 'should set @subsidy to the existing PendingSubsidy' do
-      expect(assigns(:subsidy)).to eq(PendingSubsidy.find(@pending_subsidy.id))
+    it 'should assign @sub_service_request' do
+      expect(assigns(:sub_service_request)).to eq(@ssr)
     end
 
-    it 'should set @path to the dashboard subsidy path for @subsidy' do
-      expect(assigns(:path)).to eq(dashboard_subsidy_path(assigns(:subsidy)))
-    end
-
-    it 'should assign header text' do
-      expect(assigns(:header_text)).to be
-    end
-
-    it 'should assign @action to edit' do
-      expect(assigns(:action)).to eq('edit')
+    it 'should destroy @subsidy' do
+      expect(Subsidy.count).to eq(0)
     end
   end
 end

--- a/spec/controllers/dashboard/subsidies/get_approve_spec.rb
+++ b/spec/controllers/dashboard/subsidies/get_approve_spec.rb
@@ -18,10 +18,10 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Dashboard::SubsidiesController do
-  describe 'GET #edit' do
+  describe "GET #approve" do
     before(:each) do
       @current_user = build_stubbed(:identity)
       log_in_dashboard_identity(obj: @current_user)
@@ -40,33 +40,29 @@ RSpec.describe Dashboard::SubsidiesController do
       @pending_subsidy = create(:pending_subsidy,
                                 sub_service_request_id: @ssr.id,
                                 percent_subsidy: 0.1)
-      xhr :get, :edit, admin: 'true', id: @pending_subsidy.id, format: :js
+      xhr :get, :approve, id: @pending_subsidy.id, format: :js
     end
 
-    it { is_expected.to render_template "dashboard/subsidies/edit" }
+    it { is_expected.to render_template "dashboard/subsidies/approve" }
 
     it 'should respond ok' do
       expect(controller).to respond_with(:ok)
     end
 
-    it 'should set @admin to params[:admin]' do
+    it 'should assign @sub_service_request' do
+      expect(assigns(:sub_service_request)).to be
+    end
+
+    it 'should assign @admin to true' do
       expect(assigns(:admin)).to eq(true)
     end
 
-    it 'should set @subsidy to the existing PendingSubsidy' do
-      expect(assigns(:subsidy)).to eq(PendingSubsidy.find(@pending_subsidy.id))
+    it 'should destroy the pending subsidy' do
+      expect(PendingSubsidy.count).to eq(0)
     end
 
-    it 'should set @path to the dashboard subsidy path for @subsidy' do
-      expect(assigns(:path)).to eq(dashboard_subsidy_path(assigns(:subsidy)))
-    end
-
-    it 'should assign header text' do
-      expect(assigns(:header_text)).to be
-    end
-
-    it 'should assign @action to edit' do
-      expect(assigns(:action)).to eq('edit')
+    it 'should create an approved subsidy' do
+      expect(ApprovedSubsidy.count).to eq(1)
     end
   end
 end

--- a/spec/controllers/dashboard/subsidies/get_new_spec.rb
+++ b/spec/controllers/dashboard/subsidies/get_new_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Dashboard::SubsidiesController do
 
     it { is_expected.to render_template "dashboard/subsidies/new" }
 
+    it 'should respond ok' do
+      expect(controller).to respond_with(:ok)
+    end
+
     it 'should set @admin to params[:admin]' do
       expect(assigns(:admin)).to eq(true)
     end

--- a/spec/controllers/dashboard/subsidies/post_create_spec.rb
+++ b/spec/controllers/dashboard/subsidies/post_create_spec.rb
@@ -1,0 +1,147 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+require "rails_helper"
+
+RSpec.describe Dashboard::SubsidiesController do
+  describe "POST #create" do
+    context 'User is an admin and percent subsidy is greater than 0' do
+      before(:each) do
+        @current_user = build_stubbed(:identity)
+        log_in_dashboard_identity(obj: @current_user)
+        @protocol        = create(:protocol_without_validations,
+                                  primary_pi: @current_user)
+        @organization    = create(:organization)
+        @subsidy_map     = create(:subsidy_map,
+                                  default_percentage: 0,
+                                  max_percentage: 10.0,
+                                  organization: @organization)
+        @service_request = create(:service_request_without_validations,
+                                  protocol: @protocol)
+        @ssr             = create(:sub_service_request_without_validations,
+                                  service_request: @service_request,
+                                  organization: @organization,
+                                  status: 'draft')
+        xhr :post, :create, admin: 'true', pending_subsidy: { sub_service_request_id: @ssr.id, percent_subsidy: "50.00", pi_contribution: "100.00" }, format: :js
+      end
+
+      it { is_expected.to render_template "dashboard/subsidies/create" }
+
+      it 'should respond ok' do
+        expect(controller).to respond_with(:ok)
+      end
+
+      it 'should assign @subsidy without pi contribution' do
+        expect(assigns(:subsidy).percent_subsidy).to eq(0.5)
+        expect(assigns(:subsidy).pi_contribution).to eq(0)
+      end
+
+      it 'should not assign @errors' do
+        expect(assigns(:errors)).to be_nil
+      end
+
+      it 'should save @subsidy without validations' do
+        expect(Subsidy.count).to eq(1)
+      end
+    end
+
+    context 'User is not an admin' do
+      context 'Subsidy is valid' do
+        before(:each) do
+          @current_user = build_stubbed(:identity)
+          @other_user = create(:identity)
+          log_in_dashboard_identity(obj: @current_user)
+          @protocol        = create(:protocol_without_validations,
+                                    primary_pi: @other_user)
+          @organization    = create(:organization)
+          @subsidy_map     = create(:subsidy_map,
+                                    default_percentage: 0,
+                                    max_percentage: 10.0,
+                                    organization: @organization)
+          @service_request = create(:service_request_without_validations,
+                                    protocol: @protocol)
+          @ssr             = create(:sub_service_request_without_validations,
+                                    service_request: @service_request,
+                                    organization: @organization,
+                                    status: 'draft')
+          xhr :post, :create, admin: 'false', pending_subsidy: { sub_service_request_id: @ssr.id, percent_subsidy: "9.00", pi_contribution: "100.00" }, format: :js
+        end
+
+        it 'should respond found' do
+          expect(controller).to respond_with(:found)
+        end
+
+        it 'should assign @subsidy without pi contribution' do
+          expect(assigns(:subsidy).percent_subsidy).to eq(0.09)
+          expect(assigns(:subsidy).pi_contribution).to eq(0)
+        end
+
+        it 'should not assign @errors' do
+          expect(assigns(:errors)).to be_nil
+        end
+
+        it 'should redirect to the dashboard SSR path for @ssr' do
+          expect(response).to redirect_to(dashboard_sub_service_request_path(@ssr, format: :js))
+        end
+
+        it 'should save @subsidy with validations' do
+          expect(Subsidy.count).to eq(1)
+          expect(assigns(:subsidy).valid?).to eq(true)
+        end
+      end
+
+      context 'Subsidy is not valid' do
+        before(:each) do
+          @current_user = build_stubbed(:identity)
+          @other_user = create(:identity)
+          log_in_dashboard_identity(obj: @current_user)
+          @protocol        = create(:protocol_without_validations,
+                                    primary_pi: @other_user)
+          @organization    = create(:organization)
+          @subsidy_map     = create(:subsidy_map,
+                                    default_percentage: 0,
+                                    max_percentage: 10.0,
+                                    organization: @organization)
+          @service_request = create(:service_request_without_validations,
+                                    protocol: @protocol)
+          @ssr             = create(:sub_service_request_without_validations,
+                                    service_request: @service_request,
+                                    organization: @organization,
+                                    status: 'draft')
+          xhr :post, :create, admin: 'false', pending_subsidy: { sub_service_request_id: @ssr.id, percent_subsidy: "50.00", pi_contribution: "100.00" }, format: :js
+        end
+
+        it { is_expected.to render_template "dashboard/subsidies/create" }
+
+        it 'should respond ok' do
+          expect(controller).to respond_with(:ok)
+        end
+
+        it 'should not save @subsidy' do
+          expect(Subsidy.count).to eq(0)
+        end
+
+        it 'should assign @errors' do
+          expect(assigns(:errors)).to be
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/dashboard/subsidies/put_update_spec.rb
+++ b/spec/controllers/dashboard/subsidies/put_update_spec.rb
@@ -1,0 +1,169 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+require "rails_helper"
+
+RSpec.describe Dashboard::SubsidiesController do
+  describe "PUT #update" do
+    context 'User is an admin and percent subsidy is greater than 0' do
+      before(:each) do
+        @current_user = build_stubbed(:identity)
+        log_in_dashboard_identity(obj: @current_user)
+        @protocol        = create(:protocol_without_validations,
+                                  primary_pi: @current_user)
+        @organization    = create(:organization)
+        @subsidy_map     = create(:subsidy_map,
+                                  default_percentage: 5,
+                                  max_percentage: 12.0,
+                                  organization: @organization)
+        @service_request = create(:service_request_without_validations,
+                                  protocol: @protocol)
+        @ssr             = create(:sub_service_request_without_validations,
+                                  service_request: @service_request,
+                                  organization: @organization,
+                                  status: 'draft')
+        @pending_subsidy = create(:pending_subsidy,
+                                  sub_service_request_id: @ssr.id,
+                                  percent_subsidy: 0.1)
+        xhr :put, :update, admin: 'true', id: @pending_subsidy.id, pending_subsidy: { percent_subsidy: '15.0' }, format: :js
+      end
+
+      it { is_expected.to render_template "dashboard/subsidies/update" }
+
+      it 'should respond ok' do
+        expect(controller).to respond_with(:ok)
+      end
+
+      it 'should assign @subsidy to the current pending subsidy' do
+        expect(assigns(:subsidy).id).to eq(@pending_subsidy.id)
+      end
+
+      it 'should assign @sub_service_request' do
+        expect(assigns(:sub_service_request)).to eq(@ssr)
+      end
+
+      it 'should not assign @errors' do
+        expect(assigns(:errors)).to be_nil
+      end
+
+      it 'should update the attributes on @subsidy without validations' do
+        expect(@pending_subsidy.reload.percent_subsidy).to eq(0.15)
+        expect(@pending_subsidy.valid?).to eq(false)
+      end
+    end
+
+    context 'User is not an admin' do
+      context 'Subsidy is valid' do
+        before(:each) do
+          @current_user = build_stubbed(:identity)
+          @other_user = create(:identity)
+          log_in_dashboard_identity(obj: @current_user)
+          @protocol        = create(:protocol_without_validations,
+                                    primary_pi: @other_user)
+          @organization    = create(:organization)
+          @subsidy_map     = create(:subsidy_map,
+                                    default_percentage: 0,
+                                    max_percentage: 12.0,
+                                    organization: @organization)
+          @service_request = create(:service_request_without_validations,
+                                    protocol: @protocol)
+          @ssr             = create(:sub_service_request_without_validations,
+                                    service_request: @service_request,
+                                    organization: @organization,
+                                    status: 'draft')
+          @pending_subsidy = create(:pending_subsidy,
+                                    sub_service_request_id: @ssr.id,
+                                    percent_subsidy: 0.1)
+          xhr :put, :update, admin: 'false', id: @pending_subsidy.id, pending_subsidy: { percent_subsidy: '11.0' }, format: :js
+        end
+
+        it 'should respond found' do
+          expect(controller).to respond_with(:found)
+        end
+
+        it 'should redirect to the dashboard SSR path for @ssr' do
+          expect(response).to redirect_to(dashboard_sub_service_request_path(@ssr, format: :js))
+        end
+
+        it 'should assign @subsidy to the current pending subsidy' do
+          expect(assigns(:subsidy).id).to eq(@pending_subsidy.id)
+        end
+
+        it 'should assign @sub_service_request' do
+          expect(assigns(:sub_service_request)).to eq(@ssr)
+        end
+
+        it 'should not assign @errors' do
+          expect(assigns(:errors)).to be_nil
+        end
+
+        it 'should update the attributes on @subsidy with validations' do
+          expect(@pending_subsidy.reload.percent_subsidy).to eq(0.11)
+          expect(@pending_subsidy.valid?).to eq(true)
+        end
+      end
+
+      context 'Subsidy is not valid' do
+        before(:each) do
+          @current_user = build_stubbed(:identity)
+          @other_user = create(:identity)
+          log_in_dashboard_identity(obj: @current_user)
+          @protocol        = create(:protocol_without_validations,
+                                    primary_pi: @other_user)
+          @organization    = create(:organization)
+          @subsidy_map     = create(:subsidy_map,
+                                    default_percentage: 0,
+                                    max_percentage: 12.0,
+                                    organization: @organization)
+          @service_request = create(:service_request_without_validations,
+                                    protocol: @protocol)
+          @ssr             = create(:sub_service_request_without_validations,
+                                    service_request: @service_request,
+                                    organization: @organization,
+                                    status: 'draft')
+          @pending_subsidy = create(:pending_subsidy,
+                                    sub_service_request_id: @ssr.id,
+                                    percent_subsidy: 0.1)
+          xhr :put, :update, admin: 'false', id: @pending_subsidy.id, pending_subsidy: { percent_subsidy: '15.0' }, format: :js
+        end
+
+        it 'should respond ok' do
+          expect(controller).to respond_with(:ok)
+        end
+
+        it 'should assign @subsidy to the current pending subsidy' do
+          expect(assigns(:subsidy).id).to eq(@pending_subsidy.id)
+        end
+
+        it 'should assign @sub_service_request' do
+          expect(assigns(:sub_service_request)).to eq(@ssr)
+        end
+
+        it 'should assign @errors' do
+          expect(assigns(:errors)).to be
+        end
+
+        it 'should not update the attributes on @subsidy' do
+          expect(@pending_subsidy.reload.percent_subsidy).to eq(0.1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added two specs to the `#new` and `#edit` specs and created specs for `#create`, `#update`, `#destroy`, `#approve` 