### PR TITLE
fixed bug with sponsor name

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -140,9 +140,10 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
   end
 
   def update
-    @protocol = @protocol.becomes(params[:protocol][:type].constantize) unless @protocol_type.nil?
-    if params[:updated_protocol_type] == 'true' && params[:protocol][:type] == 'Study'
-      @protocol.update_attribute(:type, params[:protocol][:type])
+    protocol_type = params[:protocol][:type]
+    @protocol = @protocol.becomes(params[:protocol][:type].constantize) unless protocol_type.nil?
+    if params[:updated_protocol_type] == 'true' && protocol_type == 'Study'
+      @protocol.update_attribute(:type, protocol_type)
       @protocol.activate
       @protocol = Protocol.find(params[:id]) #Protocol reload
     end

--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -145,9 +145,9 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
     if params[:updated_protocol_type] == 'true' && protocol_type == 'Study'
       @protocol.update_attribute(:type, protocol_type)
       @protocol.activate
-      @protocol = Protocol.find(params[:id]) #Protocol reload
+      @protocol.reload
     end
-    
+
     attrs               = fix_date_params
     permission_to_edit  = @authorization.present? ? @authorization.can_edit? : false
     # admin is not able to activate study_type_question_group

--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -141,7 +141,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
 
   def update
     protocol_type = params[:protocol][:type]
-    @protocol = @protocol.becomes(params[:protocol][:type].constantize) unless protocol_type.nil?
+    @protocol = @protocol.becomes(protocol_type.constantize) unless protocol_type.nil?
     if params[:updated_protocol_type] == 'true' && protocol_type == 'Study'
       @protocol.update_attribute(:type, protocol_type)
       @protocol.activate

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -82,7 +82,7 @@ class ProtocolsController < ApplicationController
 
   def update
     protocol_type = params[:protocol][:type]
-    @protocol = @protocol.becomes(params[:protocol][:type].constantize) unless protocol_type.nil?
+    @protocol = @protocol.becomes(protocol_type.constantize) unless protocol_type.nil?
     if params[:updated_protocol_type] == 'true' && protocol_type == 'Study'
       @protocol.update_attribute(:type, protocol_type)
       @protocol.activate

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -81,9 +81,10 @@ class ProtocolsController < ApplicationController
   end
 
   def update
-    @protocol = @protocol.becomes(params[:protocol][:type].constantize) unless @protocol_type.nil?
-    if params[:updated_protocol_type] == 'true' && params[:protocol][:type] == 'Study'
-      @protocol.update_attribute(:type, params[:protocol][:type])
+    protocol_type = params[:protocol][:type]
+    @protocol = @protocol.becomes(params[:protocol][:type].constantize) unless protocol_type.nil?
+    if params[:updated_protocol_type] == 'true' && protocol_type == 'Study'
+      @protocol.update_attribute(:type, protocol_type)
       @protocol.activate
       @protocol = Protocol.find(params[:id]) #Protocol reload
     end

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -86,13 +86,14 @@ class ProtocolsController < ApplicationController
     if params[:updated_protocol_type] == 'true' && protocol_type == 'Study'
       @protocol.update_attribute(:type, protocol_type)
       @protocol.activate
-      @protocol = Protocol.find(params[:id]) #Protocol reload
+      @protocol.reload
     end
 
     attrs            = fix_date_params
     @service_request = ServiceRequest.find(params[:srid])
 
     if @protocol.update_attributes(attrs.merge(study_type_question_group_id: StudyTypeQuestionGroup.active_id))
+
       flash[:success] = I18n.t('protocols.updated', protocol_type: @protocol.type)
     else
       @errors = @protocol.errors


### PR DESCRIPTION
When a user edits a study that has no sponsor name and is not selected for epic (example: protocol 3421) and changes protocol type to "project" and then saves, an error is thrown that "sponsor name can't be blank" for project.  This is an irrelevant error for a protocol of type project.