### PR TITLE
SAW - document_type constant calls replaced

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,7 +31,7 @@ class Document < ApplicationRecord
   validates :doc_type_other, presence: true, if: Proc.new { |doc| doc.doc_type == 'other' }
 
   def display_document_type
-    self.doc_type == "other" ? self.doc_type_other : DOCUMENT_TYPES.key(self.doc_type)
+    self.doc_type == "other" ? self.doc_type_other : PermissibleValue.get_value('document_type', self.doc_type)
   end
 
   def all_organizations

--- a/app/views/dashboard/documents/_document_form.html.haml
+++ b/app/views/dashboard/documents/_document_form.html.haml
@@ -34,7 +34,7 @@
             .form-group
               = form.label :doc_type, t(:documents)[:form_fields][:document_type], class: 'col-sm-4 control-label required'
               .col-sm-7
-                = form.select :doc_type, options_for_select(DOCUMENT_TYPES, document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
+                = form.select :doc_type, options_for_select(PermissibleValue.get_value_list('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
             .form-group#doc-type-other-field{ display_if(document.doc_type == 'other') }
               = form.label :doc_type_other, t(:documents)[:form_fields][:specify_doc_type], class: 'col-sm-4 control-label required'
               .col-sm-7

--- a/app/views/documents/_document_form.html.haml
+++ b/app/views/documents/_document_form.html.haml
@@ -35,7 +35,7 @@
             .form-group
               = form.label :doc_type, t(:documents)[:form_fields][:document_type], class: 'col-sm-4 control-label required'
               .col-sm-7
-                = form.select :doc_type, options_for_select(DOCUMENT_TYPES, document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
+                = form.select :doc_type, options_for_select(PermissibleValue.get_value_list('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
             .form-group#doc-type-other-field{ display_if(document.doc_type == 'other') }
               = form.label :doc_type_other, t(:documents)[:form_fields][:specify_doc_type], class: 'col-sm-4 control-label required'
               .col-sm-7

--- a/app/views/service_requests/show.xlsx.axlsx
+++ b/app/views/service_requests/show.xlsx.axlsx
@@ -97,7 +97,7 @@ wb.add_worksheet(name: "Review") do |sheet|
 
   @service_request.protocol.documents.each do |doc|
     next unless @sub_service_request.nil? or doc.sub_service_requests.map{|ssr| ssr.id}.include?(@sub_service_request.id)
-    sheet.add_row [doc.document_file_name, DOCUMENT_TYPES.key(doc.doc_type), "", "", doc.updated_at.strftime('%m/%d/%y')], :style => default
+    sheet.add_row [doc.document_file_name, PermissibleValue.get_value('document_type', doc.doc_type), "", "", doc.updated_at.strftime('%m/%d/%y')], :style => default
   end
 
   sheet.add_row

--- a/spec/features/dashboard/protocols/show/documents/add_document_spec.rb
+++ b/spec/features/dashboard/protocols/show/documents/add_document_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'User wants to add a document', js: true do
     before :each do
       @protocol = create(:unarchived_study_without_validations, primary_pi: logged_in_user)
 
+      create(:permissible_value, key: 'protocol', value: 'Protocol', category: 'document_type')
       @page = Dashboard::Protocols::ShowPage.new
       @page.load(id: @protocol.id)
       wait_for_javascript_to_finish

--- a/spec/features/dashboard/protocols/show/documents/edit_document_spec.rb
+++ b/spec/features/dashboard/protocols/show/documents/edit_document_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'User wants to edit a document', js: true do
     @protocol = create(:unarchived_study_without_validations, primary_pi: logged_in_user)
                 create(:document, protocol: @protocol, doc_type: 'Protocol')
 
+    create(:permissible_value, key: 'consent', value: 'Consent', category: 'document_type')
     @page = Dashboard::Protocols::ShowPage.new
     @page.load(id: @protocol.id)
     wait_for_javascript_to_finish

--- a/spec/features/document_management/user_adds_document_spec.rb
+++ b/spec/features/document_management/user_adds_document_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'User adds a new document', js: true do
     ssr         = create(:sub_service_request_without_validations, service_request: @sr, organization: program, status: 'first_draft')
                   create(:line_item, service_request: @sr, sub_service_request: ssr, service: service)
                   create(:arm, protocol: @protocol, visit_count: 1)
+                  create(:permissible_value, key: 'protocol', value: 'Protocol', category: 'document_type')
   end
 
   context 'and clicks \'Add a Document\'' do

--- a/spec/features/document_management/user_edits_document_spec.rb
+++ b/spec/features/document_management/user_edits_document_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'User edits an existing document', js: true do
                   create(:line_item, service_request: @sr, sub_service_request: ssr, service: service)
                   create(:arm, protocol: @protocol, visit_count: 1)
     @document   = create(:document, doc_type: 'Protocol', protocol: @protocol)
+                  create(:permissible_value, key: 'consent', value: 'Consent', category: 'document_type')
   end
 
   context 'and clicks the edit button' do
@@ -62,7 +63,7 @@ RSpec.describe 'User edits an existing document', js: true do
         click_button 'Upload'
         wait_for_javascript_to_finish
 
-        expect(@document.reload.doc_type).to eq('consent')
+        expect(@document.reload.doc_type).to eq('Consent')
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -30,15 +30,18 @@ RSpec.describe Document do
   end
 
   describe 'display_document_type' do
-    let!(:document1) { create(:document, doc_type: 'other', doc_type_other: 'support') }
-    let!(:document2) { create(:document, doc_type: 'hipaa') }
+    before :each do
+      @document1 = create(:document, doc_type: 'other', doc_type_other: 'support')
+      @document2 = create(:document, doc_type: 'hipaa')
+                   create(:permissible_value, key: 'hipaa', value: 'HIPAA', category: 'document_type')
+    end
 
     it 'should display correctly for doc type other' do
-      expect(document1.display_document_type).to eq('support')
+      expect(@document1.display_document_type).to eq('support')
     end
 
     it 'should display correctly for typical doc type' do
-      expect(document2.display_document_type).to eq('HIPAA')
+      expect(@document2.display_document_type).to eq('HIPAA')
     end
   end
 


### PR DESCRIPTION
[#147708807](https://www.pivotaltracker.com/story/show/147708807)
This is part of a story to replace constants.yml constant calls with PermissibleValue database calls.