### PR TITLE
KG - Catalog Editable Statuses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -214,13 +214,9 @@ class ApplicationController < ActionController::Base
     @locked_org_ids = []
     if @service_request.protocol.present?
       @service_request.sub_service_requests.each do |ssr|
-        organization = ssr.organization
-        if organization.has_editable_statuses?
-          self_or_parent_id = ssr.find_editable_id
-          if !EDITABLE_STATUSES[self_or_parent_id].include?(ssr.status)
-            @locked_org_ids << self_or_parent_id
-            @locked_org_ids << organization.all_children(Organization.all).map(&:id)
-          end
+        if ssr.is_locked?
+          @locked_org_ids << ssr.organization_id
+          @locked_org_ids << ssr.organization.all_children(Organization.all).map(&:id)
         end
       end
 

--- a/app/controllers/catalog_manager/organizations_controller.rb
+++ b/app/controllers/catalog_manager/organizations_controller.rb
@@ -82,6 +82,10 @@ class CatalogManager::OrganizationsController < CatalogManager::AppController
         :status,
         :new,
         :position,
+        :_destroy],
+      editable_statuses_attributes: [:organization_id,
+        :status,
+        :new,
         :_destroy])
   end
 

--- a/app/lib/organization_updater.rb
+++ b/app/lib/organization_updater.rb
@@ -25,7 +25,8 @@ class OrganizationUpdater
                        else
                          true
                        end
-    @organization.update_attribute(:available_statuses, AvailableStatus.none)
+    @organization.available_statuses.destroy_all
+    @organization.editable_statuses.destroy_all
     if services_updated && @organization.update_attributes(@attributes)
       @organization.update_ssr_org_name if name_change
       @organization.update_descendants_availability(@attributes[:is_available])

--- a/app/models/editable_status.rb
+++ b/app/models/editable_status.rb
@@ -19,11 +19,13 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class EditableStatus < ApplicationRecord
+  TYPES = (AVAILABLE_STATUSES.keys << 'first_draft')
+
   audited
 
   belongs_to :organization
 
-  attr_accessor :new
+  validates :status, inclusion: { in: TYPES }, presence: true
 
-  validates :status, inclusion: { in: AVAILABLE_STATUSES.keys }, presence: true
+  attr_accessor :new
 end

--- a/app/models/editable_status.rb
+++ b/app/models/editable_status.rb
@@ -1,0 +1,29 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class EditableStatus < ApplicationRecord
+  audited
+
+  belongs_to :organization
+
+  attr_accessor :new
+
+  validates :status, inclusion: { in: AVAILABLE_STATUSES.keys }, presence: true
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -378,7 +378,7 @@ class Organization < ApplicationRecord
   end
 
   def setup_editable_statuses
-    AVAILABLE_STATUSES.keys.each do |status|
+    EditableStatus::TYPES.each do |status|
       self.editable_statuses.build(status: status, new: true) unless self.editable_statuses.where(status: status).any?
     end
   end
@@ -396,7 +396,7 @@ class Organization < ApplicationRecord
   private
 
   def create_past_statuses
-    AVAILABLE_STATUSES.keys.each do |status|
+    EditableStatus::TYPES.each do |status|
       self.editable_statuses.create(status: status)
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -44,6 +44,7 @@ class Organization < ApplicationRecord
   has_many :sub_service_requests, :dependent => :destroy
   has_many :protocols, through: :sub_service_requests
   has_many :available_statuses, :dependent => :destroy
+  has_many :editable_statuses, :dependent => :destroy
   has_many :org_children, class_name: "Organization", foreign_key: :parent_id
   
   accepts_nested_attributes_for :subsidy_map

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -90,7 +90,7 @@ class Organization < ApplicationRecord
     if self.process_ssrs
       return self
     else
-      return self.parents.select {|x| x.process_ssrs}.first
+      return self.parents.detect {|x| x.process_ssrs} || self
     end
   end
 
@@ -115,15 +115,8 @@ class Organization < ApplicationRecord
     end
   end
 
-  # If an organization or one of it's parents is defined as lockable in the application.yml, return true
-  def has_editable_statuses?
-    EDITABLE_STATUSES.keys.each do |org_id|
-      if parents(true).include?(org_id) || (org_id == id)
-        return true
-      end
-    end
-
-    false
+  def has_editable_status?(status)
+    self.editable_statuses.where(status: status).any?
   end
 
   # Returns the immediate children of this organization (shallow search)

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -262,7 +262,7 @@ class SubServiceRequest < ApplicationRecord
     to_notify = []
     if can_be_edited?
       available = AVAILABLE_STATUSES.keys
-      editable = EDITABLE_STATUSES[organization_id] || available
+      editable = self.is_locked? || available
       changeable = available & editable
       if changeable.include?(new_status)
         #  See Pivotal Stories: #133049647 & #135639799
@@ -295,30 +295,16 @@ class SubServiceRequest < ApplicationRecord
 
   #A request is locked if the organization it's in isn't editable
   def is_locked?
-    if organization.has_editable_statuses?
-      return !EDITABLE_STATUSES[find_editable_id].include?(self.status)
-    end
-    false
+    !self.organization.process_ssrs_parent.has_editable_status?(status)
   end
 
   # Can't edit a request if it's placed in an uneditable status
   def can_be_edited?
-    if organization.has_editable_statuses?
-      EDITABLE_STATUSES[find_editable_id].include?(self.status) && !is_complete?
-    else
-      !is_complete?
-    end
+    self.organization.process_ssrs_parent.has_editable_status?(status) && !is_complete?
   end
 
   def is_complete?
-    return FINISHED_STATUSES.include?(status)
-  end
-
-  def find_editable_id
-    parent_ids = self.organization.parents.map(&:id)
-    EDITABLE_STATUSES.keys.each do |org_id|
-      return org_id if (org_id == self.organization_id) || parent_ids.include?(org_id)
-    end
+    FINISHED_STATUSES.include?(self.status)
   end
 
   def set_to_draft

--- a/app/views/catalog_manager/shared/_available_statuses.html.haml
+++ b/app/views/catalog_manager/shared/_available_statuses.html.haml
@@ -46,9 +46,9 @@
             %br
             %legend= t(:organization_form)[:editable_statuses]
             %table
-              = f.fields_for :editable_statuses, @organization.editable_statuses.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]} do |es|
+              = f.fields_for :editable_statuses, @organization.editable_statuses.sort{|x, y| EditableStatus::TYPES[x.status] <=> EditableStatus::TYPES[y.status]} do |es|
                 %tr
-                  %th= es.label :status, "#{AVAILABLE_STATUSES[es.object.status].gsub('CTRC', 'Nexus')}:"
+                  %th= es.label :status, "#{EditableStatus::TYPES[es.object.status].gsub('CTRC', 'Nexus')}:"
                   %td= es.check_box "_destroy", {:checked => !es.object.new_record?}, false, true
                   = es.hidden_field :status, :value => es.object.status
           %td
@@ -56,7 +56,7 @@
             %legend= t(:organization_form)[:selected_statuses]
             %table
               %tr
-                - @organization.editable_statuses.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]}.each do |es|
+                - @organization.editable_statuses.sort{|x, y| EditableStatus::TYPES[x.status] <=> EditableStatus::TYPES[y.status]}.each do |es|
                   - unless es.id.nil?
                     %tr
-                      %th= AVAILABLE_STATUSES[es.status]
+                      %th= EditableStatus::TYPES[es.status]

--- a/app/views/catalog_manager/shared/_available_statuses.html.haml
+++ b/app/views/catalog_manager/shared/_available_statuses.html.haml
@@ -46,9 +46,9 @@
             %br
             %legend= t(:organization_form)[:editable_statuses]
             %table
-              = f.fields_for :editable_statuses, @organization.editable_statuses.sort{|x, y| EditableStatus::TYPES[x.status] <=> EditableStatus::TYPES[y.status]} do |es|
+              = f.fields_for :editable_statuses, @organization.editable_statuses.select{ |es| es.status != 'first_draft'}.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]} do |es|
                 %tr
-                  %th= es.label :status, "#{EditableStatus::TYPES[es.object.status].gsub('CTRC', 'Nexus')}:"
+                  %th= es.label :status, "#{AVAILABLE_STATUSES[es.object.status].gsub('CTRC', 'Nexus')}:"
                   %td= es.check_box "_destroy", {:checked => !es.object.new_record?}, false, true
                   = es.hidden_field :status, :value => es.object.status
           %td
@@ -56,7 +56,7 @@
             %legend= t(:organization_form)[:selected_statuses]
             %table
               %tr
-                - @organization.editable_statuses.sort{|x, y| EditableStatus::TYPES[x.status] <=> EditableStatus::TYPES[y.status]}.each do |es|
+                - @organization.editable_statuses.select{ |es| es.status != 'first_draft'}.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]}.each do |es|
                   - unless es.id.nil?
                     %tr
-                      %th= EditableStatus::TYPES[es.status]
+                      %th= AVAILABLE_STATUSES[es.status]

--- a/app/views/catalog_manager/shared/_available_statuses.html.haml
+++ b/app/views/catalog_manager/shared/_available_statuses.html.haml
@@ -35,10 +35,28 @@
           %legend= t(:organization_form)[:selected_statuses]
           %table
             %tr
-            %tr
-            %tr
               - @organization.available_statuses.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]}.each do |as|
                 -if !as.id.nil?
                   %tr
                     %th= AVAILABLE_STATUSES[as.status]
 
+      - if current_user.is_overlord?
+        %tr
+          %td
+            %br
+            %legend= t(:organization_form)[:editable_statuses]
+            %table
+              = f.fields_for :editable_statuses, @organization.editable_statuses.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]} do |es|
+                %tr
+                  %th= es.label :status, "#{AVAILABLE_STATUSES[es.object.status].gsub('CTRC', 'Nexus')}:"
+                  %td= es.check_box "_destroy", {:checked => !es.object.new_record?}, false, true
+                  = es.hidden_field :status, :value => es.object.status
+          %td
+            %br
+            %legend= t(:organization_form)[:selected_statuses]
+            %table
+              %tr
+                - @organization.editable_statuses.sort{|x, y| AVAILABLE_STATUSES[x.status] <=> AVAILABLE_STATUSES[y.status]}.each do |es|
+                  - unless es.id.nil?
+                    %tr
+                      %th= AVAILABLE_STATUSES[es.status]

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -66,8 +66,6 @@ development:
   no_reply_from: "no-reply@musc.edu"
   use_separate_audit_database: false # needs to be false at outset since new institutions may not use a separate audit database
   system_satisfaction_survey: false
-  editable_statuses: { 14: ['first_draft', 'draft', 'submitted', nil, 'get_a_cost_estimate', 'awaiting_pi_approval', 'complete'],
-                     48: ['draft', 'submitted', 'complete'] }
   updatable_statuses: [ 'first_draft', 'draft', 'get_a_cost_estimate', 'awaiting_pi_approval']
   finished_statuses: ['complete', 'withdrawn']
   navbar_links: { sparc_request:              ['SPARCRequest', 'http://localhost:3000/'],
@@ -114,8 +112,6 @@ test:
   header_link_2_proper: http://localhost:3000/
   header_link_2_dashboard: http://localhost:3000/dashboard
   header_link_3: http://www.musc.edu
-  editable_statuses: { 14: ['first_draft', 'draft', 'submitted', nil, 'get_a_cost_estimate', 'awaiting_pi_approval'],
-                     48: ['draft', 'submitted'] }
   updatable_statuses: [ 'first_draft', 'draft', 'get_a_cost_estimate', 'awaiting_pi_approval']
   finished_statuses: ['complete', 'withdrawn']
   navbar_links: { sparc_request:              ['SPARCRequest', 'http://localhost:3000/'],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -841,6 +841,7 @@ en:
     disabled_all_services: "Disable All Services"
     disabled_at: "Disabled at: %{disabled_parent}"
     eap_id: 'EAP ID'
+    editable_statuses: 'Editable Statuses'
     enable_all_services: "Enable All Services"
     epic_info: "Epic Interface"
     errors: "Effective Date, Display Dates, Percent of Fee, and Rates are required on all pricing setups."

--- a/db/migrate/20170622132807_create_editable_statuses.rb
+++ b/db/migrate/20170622132807_create_editable_statuses.rb
@@ -1,0 +1,35 @@
+class CreateEditableStatuses < ActiveRecord::Migration[5.0]
+  def up
+    create_table :editable_statuses do |t|
+      t.references  :organization,  index: true, foreign_key: true
+      t.string      :status,        null: false
+
+      t.timestamps                  null: false
+    end
+
+    if defined?(EDITABLE_STATUSES)
+      EDITABLE_STATUSES.each do |org_id, statuses|
+        organization = Organization.find(org_id)
+        statuses.each do |status|
+          organization.editable_statuses.create(status: status)
+        end
+      end
+
+      Organization.where.not(id: EDITABLE_STATUSES.keys).each do |org|
+        AVAILABLE_STATUSES.keys.each do |status|
+          org.editable_statuses.create(status: status)
+        end
+      end
+    else
+      Organization.all.each do |org|
+        AVAILABLE_STATUSES.keys.each do |status|
+          org.editable_statuses.create(status: status)
+        end
+      end
+    end
+  end
+
+  def down
+    drop_table :editable_statuses
+  end
+end

--- a/db/migrate/20170622132807_create_editable_statuses.rb
+++ b/db/migrate/20170622132807_create_editable_statuses.rb
@@ -10,19 +10,19 @@ class CreateEditableStatuses < ActiveRecord::Migration[5.0]
     if defined?(EDITABLE_STATUSES)
       EDITABLE_STATUSES.each do |org_id, statuses|
         organization = Organization.find(org_id)
-        statuses.each do |status|
+        (statuses << 'first_draft').each do |status|
           organization.editable_statuses.create(status: status)
         end
       end
 
       Organization.where.not(id: EDITABLE_STATUSES.keys).each do |org|
-        AVAILABLE_STATUSES.keys.each do |status|
+        (AVAILABLE_STATUSES.keys << 'first_draft').each do |status|
           org.editable_statuses.create(status: status)
         end
       end
     else
       Organization.all.each do |org|
-        AVAILABLE_STATUSES.keys.each do |status|
+        (AVAILABLE_STATUSES.keys << 'first_draft').each do |status|
           org.editable_statuses.create(status: status)
         end
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517143845) do
+ActiveRecord::Schema.define(version: 20170622132807) do
 
   create_table "admin_rates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer  "line_item_id"
@@ -173,6 +173,14 @@ ActiveRecord::Schema.define(version: 20170517143845) do
   create_table "documents_sub_service_requests", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer "document_id"
     t.integer "sub_service_request_id"
+  end
+
+  create_table "editable_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "organization_id"
+    t.string   "status",          null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["organization_id"], name: "index_editable_statuses_on_organization_id", using: :btree
   end
 
   create_table "epic_queue_records", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
@@ -1016,6 +1024,7 @@ ActiveRecord::Schema.define(version: 20170517143845) do
     t.index ["visit_group_id"], name: "index_visits_on_visit_group_id", using: :btree
   end
 
+  add_foreign_key "editable_statuses", "organizations"
   add_foreign_key "item_options", "items"
   add_foreign_key "items", "questionnaires"
   add_foreign_key "options", "questions"

--- a/spec/controllers/search/get_services_spec.rb
+++ b/spec/controllers/search/get_services_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe SearchController do
       s1    = create(:service, organization: org, name: 'Service 123')
       s2    = create(:service, organization: org2, name: 'Service 321')
 
-      stub_const("EDITABLE_STATUSES", { org.id => ['draft'] })
+      org.editable_statuses.where(status: 'on_hold').destroy_all
 
       xhr :get, :services, {
         service_request_id: sr.id,

--- a/spec/controllers/service_requests/get_obtain_research_pricing_spec.rb
+++ b/spec/controllers/service_requests/get_obtain_research_pricing_spec.rb
@@ -197,11 +197,11 @@ RSpec.describe ServiceRequestsController, type: :controller do
           service  = create(:service, organization: @org, one_time_fee: true)
           protocol = create(:protocol_federally_funded, primary_pi: logged_in_user, type: 'Study')
           @sr      = create(:service_request_without_validations, protocol: protocol, original_submitted_date: Time.now.yesterday)
-          @ssr     = create(:sub_service_request_without_validations, service_request: @sr, organization: @org, status: 'locked_status', submitted_at: Time.now.yesterday, protocol_id: protocol.id)
+          @ssr     = create(:sub_service_request_without_validations, service_request: @sr, organization: @org, status: 'on_hold', submitted_at: Time.now.yesterday, protocol_id: protocol.id)
           li       = create(:line_item, service_request: @sr, sub_service_request: @ssr, service: service)
 
           session[:identity_id] = logged_in_user.id
-          stub_const('EDITABLE_STATUSES', {@org.id => ["draft"]})
+          @org.editable_statuses.where(status: 'on_hold').destroy_all
         end
 
         it 'should not update status to "get_a_cost_estimate"' do
@@ -210,7 +210,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
             id: @sr.id
           }
 
-          expect(@ssr.reload.status).to eq('locked_status')
+          expect(@ssr.reload.status).to eq('on_hold')
         end
 
         context 'with an authorized_user' do

--- a/spec/controllers/service_requests/post_remove_service_spec.rb
+++ b/spec/controllers/service_requests/post_remove_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
         li       = create(:line_item, service_request: sr, sub_service_request: ssr, service: service)
                    create(:line_item, service_request: sr, sub_service_request: ssr, service: create(:service, organization: org))
 
-        stub_const("EDITABLE_STATUSES", { org.id => ['first_draft'] })
+        org.editable_statuses.where(status: 'on_hold').destroy_all
 
         xhr :post, :remove_service, {
           id: sr.id,

--- a/spec/factories/editable_status.rb
+++ b/spec/factories/editable_status.rb
@@ -1,0 +1,26 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FactoryGirl.define do
+
+  factory :editable_status do
+    status { AVAILABLE_STATUSES.keys.sample || 'active' }
+  end
+end

--- a/spec/features/catalog/user_begins_request_spec.rb
+++ b/spec/features/catalog/user_begins_request_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'User begins Service Request', js: true do
 
     protocol = create(:protocol_without_validations, primary_pi: jug2)
     @sr      = create(:service_request_without_validations, status: "first_draft", protocol_id: protocol.id)
-    @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "first-draft", protocol_id: protocol.id)
-    ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "first-draft", protocol_id: protocol.id)
+    @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "first_draft", protocol_id: protocol.id)
+    ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "first_draft", protocol_id: protocol.id)
     create(:line_item, service_request: @sr, sub_service_request: @ssr1, service: service1)
     create(:line_item, service_request: @sr, sub_service_request: ssr2, service: service2)
   end

--- a/spec/features/catalog/user_views_catalog_spec.rb
+++ b/spec/features/catalog/user_views_catalog_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'User views the catalog', js: true do
 
     protocol = create(:protocol_without_validations, primary_pi: jug2)
     @sr      = create(:service_request_without_validations, status: "first_draft", protocol_id: protocol.id)
-    @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "first-draft", protocol_id: protocol.id)
-    ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "first-draft", protocol_id: protocol.id)
+    @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "first_draft", protocol_id: protocol.id)
+    ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "first_draft", protocol_id: protocol.id)
     create(:line_item, service_request: @sr, sub_service_request: @ssr1, service: service1)
     create(:line_item, service_request: @sr, sub_service_request: ssr2, service: service2)
   end

--- a/spec/features/dashboard/admin_edit/admin_edits_service_calendar_fields_spec.rb
+++ b/spec/features/dashboard/admin_edit/admin_edits_service_calendar_fields_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe 'User sets each Service Calendar field', js: true do
     @liv      = @arm.line_items_visits.first
     visit     = create(:visit, line_items_visit: @liv, visit_group: @vg, research_billing_qty: 1)
 
-    stub_const('EDITABLE_STATUSES', { })
-
     visit dashboard_sub_service_request_path(ssr)
     wait_for_javascript_to_finish
 

--- a/spec/features/dashboard/service_requests/user_views_ssrs_spec.rb
+++ b/spec/features/dashboard/service_requests/user_views_ssrs_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "User views SSR table", js: true do
         let!(:organization)         { create(:organization,type: 'Institution', name: 'Megacorp', admin: bob, service_provider: bob) }
 
         scenario 'and sees View but not Edit' do
-          stub_const("EDITABLE_STATUSES", { organization.id => ['draft'] })
+          organization.editable_statuses.where(status: 'on_hold').destroy_all
 
           sub_service_request.update_attribute(:status, 'on_hold')
 

--- a/spec/features/document_management/user_returns_to_catalog_spec.rb
+++ b/spec/features/document_management/user_returns_to_catalog_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe 'User returns to catalog', js: true do
     protocol = create(:protocol_without_validations, primary_pi: jug2)
     @sr      = create(:service_request_without_validations, status: "first_draft", protocol_id: protocol.id)
     @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "draft", protocol: protocol)
-    stub_const("EDITABLE_STATUSES", { @ssr1.organization_id => [@ssr1.status] })
     ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "draft", protocol: protocol)
     create(:line_item, service_request: @sr, sub_service_request: @ssr1, service: service1)
     create(:line_item, service_request: @sr, sub_service_request: ssr2, service: service2)

--- a/spec/features/protocol/user_returns_to_catalog_spec.rb
+++ b/spec/features/protocol/user_returns_to_catalog_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe 'User returns to catalog', js: true do
     protocol = create(:protocol_without_validations, primary_pi: jug2)
     @sr      = create(:service_request_without_validations, status: "first_draft", protocol_id: protocol.id)
     @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "draft", protocol: protocol)
-    stub_const("EDITABLE_STATUSES", { @ssr1.organization_id => [@ssr1.status] })
     ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "draft", protocol: protocol)
     create(:line_item, service_request: @sr, sub_service_request: @ssr1, service: service1)
     create(:line_item, service_request: @sr, sub_service_request: ssr2, service: service2)

--- a/spec/features/service_calendar/user_checks_unchecks_column_spec.rb
+++ b/spec/features/service_calendar/user_checks_unchecks_column_spec.rb
@@ -44,10 +44,6 @@ RSpec.describe 'User checks and unchecks calendar columns', js: true do
   end
 
   context 'for SSRs which aren\'t locked' do
-    before :each do
-      stub_const('EDITABLE_STATUSES', { })
-    end
-
     context 'check:' do
       scenario 'and sees all visits checked' do
         visit service_calendar_service_request_path(@sr)
@@ -74,7 +70,7 @@ RSpec.describe 'User checks and unchecks calendar columns', js: true do
 
   context 'for locked SSRs' do
     before :each do
-      stub_const('EDITABLE_STATUSES', { @ssr2.organization.id => ['first_draft'] })
+      @ssr2.organization.editable_statuses.where(status: @ssr2.status).destroy_all
     end
 
     context 'check:' do

--- a/spec/features/service_calendar/user_checks_unchecks_row_spec.rb
+++ b/spec/features/service_calendar/user_checks_unchecks_row_spec.rb
@@ -39,10 +39,6 @@ RSpec.describe 'User checks and unchecks calendar rows', js: true do
   end
 
   context 'for SSRs which aren\'t locked' do
-    before :each do
-      stub_const('EDITABLE_STATUSES', { })
-    end
-
     context 'check:' do
       scenario 'and sees all visits checked' do
         visit service_calendar_service_request_path(@sr)
@@ -76,7 +72,7 @@ RSpec.describe 'User checks and unchecks calendar rows', js: true do
 
   context 'for locked SSRs' do
     before :each do
-      stub_const('EDITABLE_STATUSES', { @ssr.organization.id => ['first_draft'] })
+      @ssr.organization.editable_statuses.where(status: @ssr.status).destroy_all
     end
 
     context 'check:' do

--- a/spec/features/service_calendar/user_edits_service_calendar_fields_spec.rb
+++ b/spec/features/service_calendar/user_edits_service_calendar_fields_spec.rb
@@ -42,8 +42,6 @@ RSpec.describe 'User sets each Service Calendar field', js: true do
     @vg       = @arm.visit_groups.first
     @liv      = @arm.line_items_visits.first
 
-    stub_const('EDITABLE_STATUSES', { })
-
     visit service_calendar_service_request_path(sr)
     wait_for_javascript_to_finish
   end

--- a/spec/features/service_calendar/user_views_locked_ssr_spec.rb
+++ b/spec/features/service_calendar/user_views_locked_ssr_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'User views a locked SSR', js: true do
     vg        = create(:visit_group, arm: arm)
                 create(:visit, visit_group: vg, line_items_visit: liv, research_billing_qty: 5, insurance_billing_qty: 5, effort_billing_qty: 5)
 
-    stub_const('EDITABLE_STATUSES', { org.id => ['first_draft'] })
+    org.editable_statuses.where(status: [ssr1.status, ssr2.status]).destroy_all
 
     visit service_calendar_service_request_path(@sr)
     wait_for_javascript_to_finish

--- a/spec/features/service_details/user_returns_to_catalog_spec.rb
+++ b/spec/features/service_details/user_returns_to_catalog_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe 'User returns to catalog', js: true do
     protocol = create(:protocol_without_validations, primary_pi: jug2)
     @sr      = create(:service_request_without_validations, status: "first_draft", protocol_id: protocol.id)
     @ssr1    = create(:sub_service_request_without_validations, service_request: @sr, organization: program1, status: "draft", protocol: protocol)
-    stub_const("EDITABLE_STATUSES", { @ssr1.organization_id => [@ssr1.status] })
     ssr2     = create(:sub_service_request_without_validations, service_request: @sr, organization: program2, status: "draft", protocol: protocol)
     create(:line_item, service_request: @sr, sub_service_request: @ssr1, service: service1)
     create(:line_item, service_request: @sr, sub_service_request: ssr2, service: service2)

--- a/spec/models/editable_status_spec.rb
+++ b/spec/models/editable_status_spec.rb
@@ -1,0 +1,31 @@
+# Copyright © 2011-2016 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rails_helper'
+
+RSpec.describe EditableStatus, type: :model do
+  it 'should have a valid factory' do
+    expect(build(:editable_status)).to be_valid
+  end
+
+  it { is_expected.to belong_to(:organization) }
+  it { is_expected.to validate_inclusion_of(:status).in_array(AVAILABLE_STATUSES.keys) }
+  it { is_expected.to validate_presence_of(:status) }
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -458,7 +458,6 @@ RSpec.describe 'organization' do
       it 'should return true if the current organization or its parent have editable statuses' do
         organization1 = Organization.create
         organization2 = Organization.create(parent_id: organization1.id)
-        EDITABLE_STATUSES[organization1.id] = ['draft']
         expect(organization2.has_editable_statuses?).to eq(true)
         expect(organization1.has_editable_statuses?).to eq(true)
       end
@@ -466,7 +465,7 @@ RSpec.describe 'organization' do
       it 'should return false otherwise' do
         organization1 = Organization.create
         organization2 = Organization.create
-        EDITABLE_STATUSES[organization1.id] = ['draft']
+        organization2.editable_statuses.destroy_all
         expect(organization2.has_editable_statuses?).to eq(false)
       end
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -453,20 +453,20 @@ RSpec.describe 'organization' do
       end
     end
 
-    describe 'has editable statuses?' do
+    describe 'has_editable_status?' do
 
       it 'should return true if the current organization or its parent have editable statuses' do
         organization1 = Organization.create
         organization2 = Organization.create(parent_id: organization1.id)
-        expect(organization2.has_editable_statuses?).to eq(true)
-        expect(organization1.has_editable_statuses?).to eq(true)
+        expect(organization2.has_editable_status?('draft')).to eq(true)
+        expect(organization1.has_editable_status?('draft')).to eq(true)
       end
 
       it 'should return false otherwise' do
         organization1 = Organization.create
         organization2 = Organization.create
         organization2.editable_statuses.destroy_all
-        expect(organization2.has_editable_statuses?).to eq(false)
+        expect(organization2.has_editable_status?('draft')).to eq(false)
       end
     end
   end

--- a/spec/models/service_request/update_status_spec.rb
+++ b/spec/models/service_request/update_status_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe ServiceRequest, type: :model do
           service     = create(:service, organization: @org, one_time_fee: true)
           protocol    = create(:protocol_federally_funded, primary_pi: identity, type: 'Study')
           @sr          = create(:service_request_without_validations, protocol: protocol, submitted_at: Time.now.yesterday.utc)
-          @ssr_un_updatable_status   = create(:sub_service_request_without_validations, service_request: @sr, organization: @org, status: 'un_updatable_status', submitted_at: nil, nursing_nutrition_approved: nil, lab_approved: nil, imaging_approved: nil, committee_approved: nil)
+          @ssr_un_updatable_status   = create(:sub_service_request_without_validations, service_request: @sr, organization: @org, status: 'on_hold', submitted_at: nil, nursing_nutrition_approved: nil, lab_approved: nil, imaging_approved: nil, committee_approved: nil)
           @sr.reload
         end
 
@@ -218,7 +218,7 @@ RSpec.describe ServiceRequest, type: :model do
 
           it "should not update the status of the SSR to submitted" do
             @sr.update_status('submitted')
-            expect(@ssr_un_updatable_status.reload.status).to eq('un_updatable_status')
+            expect(@ssr_un_updatable_status.reload.status).to eq('on_hold')
           end
 
           it "should update the status of the SR to submitted" do

--- a/spec/models/sub_service_request/sub_service_request_spec.rb
+++ b/spec/models/sub_service_request/sub_service_request_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe 'SubServiceRequest' do
       let!(:line_item2) { create(:line_item, sub_service_request_id: ssr2.id, service_request_id: service_request.id, service_id: service2.id) }
 
       before :each do
-        EDITABLE_STATUSES[sub_service_request.organization.id] = ['first_draft', 'draft', 'submitted', nil, 'get_a_cost_estimate', 'awaiting_pi_approval']
+        sub_service_request.organization.editable_statuses.where(status: 'on_hold').destroy_all
       end
 
       context "can be edited" do
@@ -228,11 +228,6 @@ RSpec.describe 'SubServiceRequest' do
           expect(sub_service_request.can_be_edited?).to eq(true)
         end
 
-        it "should return true if the status is nil" do
-          sub_service_request.update_attributes(status: nil)
-          expect(sub_service_request.can_be_edited?).to eq(true)
-        end
-
         it "should return true if the status is get a cost estimate" do
           sub_service_request.update_attributes(status: 'get_a_cost_estimate')
           expect(sub_service_request.can_be_edited?).to eq(true)
@@ -244,6 +239,7 @@ RSpec.describe 'SubServiceRequest' do
         end
 
         it 'should should return false if the status is complete' do
+          stub_const("FINISHED_STATUSES", ['complete'])
           sub_service_request.update_attributes(status: 'complete')
           expect(sub_service_request.can_be_edited?).to eq(false)
         end


### PR DESCRIPTION
**Pivotal:
https://www.pivotaltracker.com/story/show/147553581**

I'm not particularly fond of doing the statuses this way, but I wanted to keep it consistent with how we do available statuses. In the future Bootstrap Catalog update, both types of statuses should be reconfigured so that there isn't large quantities of deleting occurring.

**Note: This is a big pull request, mostly with spec changes. Use the commit history to review it.**