### PR TITLE
KG - Remove EDITABLE_STATUSES from Initializer (AFTER #994 to Production)

### DIFF
--- a/config/initializers/01_obis_setup.rb
+++ b/config/initializers/01_obis_setup.rb
@@ -71,7 +71,6 @@ begin
   CONSTANTS_YML_OVERRIDE                    = application_config['constants_yml_override'] || ''
   SYSTEM_SATISFACTION_SURVEY                = application_config['system_satisfaction_survey'] || false
   NO_REPLY_FROM                             = application_config['no_reply_from']
-  EDITABLE_STATUSES                         = application_config['editable_statuses'] || {}
   UPDATABLE_STATUSES                        = application_config['updatable_statuses'] || []
   FINISHED_STATUSES                         = application_config['finished_statuses'] || []
   REMOTE_SERVICE_NOTIFIER_PROTOCOL          = application_config['remote_service_notifier_protocol']


### PR DESCRIPTION
**Pivotal:
https://www.pivotaltracker.com/story/show/147553581**

@Stuart-Johnson This story needs to happen after #994 has been run on production. #994 adds a migration to move existing editable_statuses to the database which requires this initializer to still be in place. Additionally, the application.yml constant can be removed when this story is added.

Also this will continue to fail on Travis until #994 is merged in. I didn't fork this branch off of it, so it doesn't have the updated specs.