### PR TITLE
SAW - changed affiliation types constant call to query

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -25,5 +25,5 @@ class Affiliation < ApplicationRecord
   attr_accessor :position
 
   belongs_to :protocol
-  TYPES = AFFILIATION_TYPES
+  TYPES = PermissibleValue.get_value_list('affiliation_type')
 end


### PR DESCRIPTION
[#147708807](https://www.pivotaltracker.com/story/show/147708807)

Changed constant call for AFFILIATION_TYPES to a PermissibleValue query