### PR TITLE
KG - Study Type Question Version 3 Fix Rake Fix

### DIFF
--- a/lib/tasks/study_type_question_3_fix.rake
+++ b/lib/tasks/study_type_question_3_fix.rake
@@ -22,8 +22,15 @@ desc "change data in version 3 of epic questions"
 task :study_type_question_3_fix => :environment do
   
   STUDY_TYPE_QUESTIONS_VERSION_3.each_with_index do |stq, index|
-    StudyTypeQuestion.where(study_type_question_group_id: 3).find_or_create_by(question: stq)
+    question = StudyTypeQuestion.where(study_type_question_group_id: 3).find_or_create_by(question: stq)
+
+    unless StudyTypeAnswer.where(study_type_question: question).any?
+      Protocol.all.each do |protocol|
+        protocol.study_type_answers.create(study_type_question: question)
+      end
+    end
   end
+  
   StudyTypeQuestion.where(question: STUDY_TYPE_QUESTIONS_VERSION_3[5]).update(order: 1, friendly_id: 'certificate_of_conf_no_epic')
   StudyTypeQuestion.where(question: STUDY_TYPE_QUESTIONS_VERSION_3[6]).update(order: 2, friendly_id: 'higher_level_of_privacy_no_epic')
 end


### PR DESCRIPTION
The rake task `rake study_type_question_3_fix` created questions without corresponding answers, causing answers to be returned as nil values.

For each question, check if answers exist for it. if not, create those answers on all existing protocols.