### PR TITLE
KG/JM/SW - Study Type Questions Fixes

### DIFF
--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -19,4 +19,12 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module ProtocolsHelper
+  def display_study_type_question?(protocol, study_type_answer)
+    to_display = 
+      if !USE_EPIC || protocol.selected_for_epic == false
+        ['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
+      else
+        !['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
+      end
+  end
 end

--- a/app/lib/study_type_finder.rb
+++ b/app/lib/study_type_finder.rb
@@ -43,6 +43,10 @@ class StudyTypeFinder
     case version
     when 3
       study_type_ans_constant = STUDY_TYPE_ANSWERS_VERSION_3
+      # Because we can't use a don't-care to check the value of the 2 non-epic questions,
+      # we have to replace their values with nil. They do not impact the study type.
+      answers[StudyTypeQuestion.joins(:study_type_question_group).where(study_type_question_groups: { version: 3 }).count - 1] = nil
+      answers[StudyTypeQuestion.joins(:study_type_question_group).where(study_type_question_groups: { version: 3 }).count - 2] = nil
     when 2
       study_type_ans_constant = STUDY_TYPE_ANSWERS_VERSION_2
     when 1

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -37,8 +37,7 @@ class Study < Protocol
   end
 
   def display_answers
-    answers = StudyTypeQuestion.joins(:study_type_question_group).where(study_type_question_groups: { version: version_type })
-    answers.map{ |ans| ans.study_type_answers.find_by_protocol_id(id) }
+    self.study_type_answers.joins(study_type_question: :study_type_question_group).where(study_type_question_groups: { version: version_type }).order('study_type_questions.order')
   end
 
   def populate_for_edit

--- a/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -31,7 +31,7 @@
         %label.radio-inline.btn.btn-default#study_selected_for_epic_true_button{ class: protocol.selected_for_epic? ? 'active' : ''}
           = form.radio_button :selected_for_epic, 'true', id: "study_selected_for_epic_true", class: 'hidden'
           = t(:constants)[:yes_select]
-        %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: !protocol.selected_for_epic || !USE_EPIC ? 'active': '' }
+        %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false || !USE_EPIC ? 'active': '' }
           = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
           = t(:constants)[:no_select]
 .form-group.row.selected_for_epic_dependent{ display_if(protocol.selected_for_epic) }

--- a/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -38,13 +38,13 @@
   = hidden_field_tag :updated_protocol_type, updated_protocol_type
   = form.label :study_type_questions,
     t(:protocols)[:studies][:information][:study_type_questions],
-    class: "col-lg-2 control-label question-label #{protocol.selected_for_epic ? 'required' : ''}",
+    class: "col-lg-2 control-label question-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}",
     data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' },
     title: t(:protocols)[:tooltips][:study_type_questions]
   .col-lg-10
     = form.fields_for :study_type_answers, protocol.study_type_answers do |answer_form|
       - if answer_form.object.study_type_question.study_type_question_group.active
-        .form-group.row{ id: "study_type_answer_#{answer_form.object.study_type_question.friendly_id}", style: "#{answer_form.object.answer != nil ? 'display:block' : 'display:none;'}" }
+        .form-group.row{ id: "study_type_answer_#{answer_form.object.study_type_question.friendly_id}", style: display_study_type_question?(protocol, answer_form.object) ? 'display:block;' : 'display:none;' }
           .col-lg-8
             = answer_form.hidden_field :study_type_question_id
             = answer_form.label :answer, break_before_parenthetical(answer_form.object.study_type_question.question), class: "long"

--- a/app/views/dashboard/protocols/form/study_form_sections/_readonly_answer_field.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_readonly_answer_field.html.haml
@@ -17,7 +17,7 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
-.form-group.row{id: "study_type_answer_#{answer.object.study_type_question.friendly_id}", style: (answer.object.answer != nil ? nil : "display:none;")}
+.form-group.row{id: "study_type_answer_#{answer.object.study_type_question.friendly_id}", style: display_study_type_question?(protocol, answer.object) ? 'display:block;' : 'display:none;'}
   .col-lg-8
     = answer.label :answer, answer.object.study_type_question.question, class: "long"
   .col-lg-4

--- a/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
@@ -18,16 +18,17 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .form-group.row
-  = form.label :selected_for_epic, t(:protocols)[:studies][:information][:push_to_epic], class: "col-lg-2 control-label required"
-  .col-lg-10
-    %span.epic_selected.display_epic_answers
-      = form.object.selected_for_epic ? t(:constants)[:yes_select] : t(:constants)[:no_select]
-      - if form.object.selected_for_epic
-        = form.hidden_field :selected_for_epic, value: true
-      - else
-        = form.hidden_field :selected_for_epic, value: false
+  - if USE_EPIC
+    = form.label :selected_for_epic, t(:protocols)[:studies][:information][:push_to_epic], class: "col-lg-2 control-label required"
+    .col-lg-10
+      %span.epic_selected.display_epic_answers
+        = form.object.selected_for_epic ? t(:constants)[:yes_select] : t(:constants)[:no_select]
+        - if form.object.selected_for_epic
+          = form.hidden_field :selected_for_epic, value: true
+        - else
+          = form.hidden_field :selected_for_epic, value: false
 .form-group.row.selected_for_epic_dependent#readonly
-  = form.label :study_type_questions, t(:study_form)[:study_type_questions], class: "col-lg-2 control-label "
+  = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label "
   .col-lg-10
     = form.fields_for :study_type_answers, protocol.display_answers do |answer|
       = render partial: 'dashboard/protocols/form/study_form_sections/readonly_answer_field', locals: { answer: answer }

--- a/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
@@ -31,4 +31,4 @@
   = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label "
   .col-lg-10
     = form.fields_for :study_type_answers, protocol.display_answers do |answer|
-      = render partial: 'dashboard/protocols/form/study_form_sections/readonly_answer_field', locals: { answer: answer }
+      = render partial: 'dashboard/protocols/form/study_form_sections/readonly_answer_field', locals: { answer: answer, protocol: protocol }

--- a/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -44,7 +44,7 @@
     - action_name == 'update_protocol_type' ? protocol.setup_study_type_answers : ''
     = form.fields_for :study_type_answers, protocol.study_type_answers do |answer_form|
       - if answer_form.object.study_type_question.study_type_question_group.active
-        .form-group.row{ id: "study_type_answer_#{answer_form.object.study_type_question.friendly_id}", style: "#{answer_form.object.answer != nil ? 'display:block' : 'display:none;'}" }
+        .form-group.row{ id: "study_type_answer_#{answer_form.object.study_type_question.friendly_id}", style: display_study_type_question?(protocol, answer_form.object) ? 'display:block;' : 'display:none;' }
           .col-lg-8
             = answer_form.hidden_field :study_type_question_id
             = answer_form.label :answer, break_before_parenthetical(answer_form.object.study_type_question.question), class: "long"

--- a/app/views/protocols/view_details/_study_information.html.haml
+++ b/app/views/protocols/view_details/_study_information.html.haml
@@ -103,12 +103,13 @@
             = t(:protocols)[:studies][:information][:sponsor]
           .col-lg-8
             = protocol.sponsor_name
-      %tr.row
-        %td
-          %label.col-lg-4
-            = t(:protocols)[:studies][:information][:push_to_epic]
-          .col-lg-8
-            = protocol.selected_for_epic ? t(:constants)[:yes_select] : t(:constants)[:no_select]
+      - if USE_EPIC
+        %tr.row
+          %td
+            %label.col-lg-4
+              = t(:protocols)[:studies][:information][:push_to_epic]
+            .col-lg-8
+              = protocol.selected_for_epic ? t(:constants)[:yes_select] : t(:constants)[:no_select]
 
       / Epic Questions
       %tr.row
@@ -120,8 +121,9 @@
                   %strong
                     = t(:protocols)[:studies][:information][:study_type_questions]
             - protocol.display_answers.each do |answer|
-              - if answer.study_type_question.study_type_question_group.active && protocol.active? && answer.answer != nil
+              - if answer.study_type_question.study_type_question_group.active && protocol.active? && display_study_type_question?(protocol, answer)
                 = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
-              - elsif !answer.study_type_question.study_type_question_group.active && !protocol.active? && answer.answer != nil
+              - elsif !answer.study_type_question.study_type_question_group.active && !protocol.active? && display_study_type_question?(protocol, answer)
                 = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
-          = render partial: 'protocols/view_details/study_type_note', locals: { protocol: protocol }         
+          - if USE_EPIC
+            = render partial: 'protocols/view_details/study_type_note', locals: { protocol: protocol }         

--- a/lib/tasks/study_type_question_3_fix.rake
+++ b/lib/tasks/study_type_question_3_fix.rake
@@ -25,7 +25,7 @@ task :study_type_question_3_fix => :environment do
     question = StudyTypeQuestion.where(study_type_question_group_id: 3).find_or_create_by(question: stq)
 
     unless StudyTypeAnswer.where(study_type_question: question).any?
-      Protocol.all.each do |protocol|
+      Protocol.joins(:study_type_question_group).where(study_type_question_groups: { version: 3 }).all.each do |protocol|
         protocol.study_type_answers.create(study_type_question: question)
       end
     end

--- a/lib/tasks/study_type_question_3_fix.rake
+++ b/lib/tasks/study_type_question_3_fix.rake
@@ -31,6 +31,6 @@ task :study_type_question_3_fix => :environment do
     end
   end
   
-  StudyTypeQuestion.where(question: STUDY_TYPE_QUESTIONS_VERSION_3[5]).update(order: 1, friendly_id: 'certificate_of_conf_no_epic')
-  StudyTypeQuestion.where(question: STUDY_TYPE_QUESTIONS_VERSION_3[6]).update(order: 2, friendly_id: 'higher_level_of_privacy_no_epic')
+  StudyTypeQuestion.where(question: STUDY_TYPE_QUESTIONS_VERSION_3[5]).update(order: 6, friendly_id: 'certificate_of_conf_no_epic')
+  StudyTypeQuestion.where(question: STUDY_TYPE_QUESTIONS_VERSION_3[6]).update(order: 7, friendly_id: 'higher_level_of_privacy_no_epic')
 end

--- a/spec/extensions/epic_interface_spec.rb
+++ b/spec/extensions/epic_interface_spec.rb
@@ -511,11 +511,6 @@ RSpec.describe EpicInterface do
 
         answers = [true, true, nil, nil, nil, nil]
         update_answers(1, answers)
-        question_id = [ stq_higher_level_of_privacy_version_1.id, stq_certificate_of_conf_version_1.id, stq_access_study_info_version_1.id, stq_epic_inbasket_version_1.id, stq_research_active_version_1.id, stq_restrict_sending_version_1.id]
-
-        answers.each_with_index do |ans, index|
-          StudyTypeAnswer.create(protocol_id: study.id, study_type_question_id: question_id[index], answer: ans)
-        end
 
         epic_interface.send_study_creation(study)
 
@@ -957,7 +952,6 @@ RSpec.describe EpicInterface do
     end
 
     it 'should return NO_COFC' do
-
       answers = [false, true, false, false, false, false]
       update_answers(2, answers)
 
@@ -982,7 +976,7 @@ RSpec.describe EpicInterface do
       'rpe' => 'urn:ihe:qrph:rpe:2009',
       'hl7' => 'urn:hl7-org:v3')
 
-      expect(node[0]).to be_equivalent_to(expected.root)
+      expect(node[1]).to be_equivalent_to(expected.root)
     end
 
     it 'return a study type of 1' do


### PR DESCRIPTION
Issues Fixed:
1. The `Selected for Epic` button defaulted to "No" because `!protocol.selected_for_epic` returns true if nil. Instead, use `protocol.selected_for_epic == false`
2. The order of answers was incorrect because the new answers were given orders 1 and 2. Instead, they needed to be 6 and 7 to come after the first 5 to match the constant.
3. Study Type Notes weren't showing up when clicking "Edit" because the Study type Answers weren't ordered correctly. Fixed by 2 and updating the query to take the `order` column into account.

Updated Changes:
1. Study Type Questions were shown if the answer was not nil. It needed to be displayed based on that AND the current epic configuration / whether the protocol was selected for epic. (See `protocols_helper.rb`)
2. Notes were displaying incorrectly in View Details. Updated to show conditionally similar to the questions.
3. In the study type finder, if the new "non-epic" questions had been answered but then the user decided to send the protocol to epic, the saved values were true/false, not nil, so they didn't match the Study Type version 3 constant. Because those 2 values don't affect the study type, we manually changed them to nil when determining the study type (See `study_type_finder.rb`. **Note: We tried to see if there was a "don't-care" equivalent, but couldn't find anything that would work with the Hash#key method.**
4. The "Selected for Epic" button was not conditionally hidden in Dashboard only, added `if USE_EPIC` condition.
5. Epic Interface Spec - Because of 3, the second failing spec now passes because it correctly sends a STUDYTYPE node. The first failing spec was failing because it created duplicate StudyTypeQuestions.