### PR TITLE
wth & jm - Change datatype DelayedJob Handler from Text to LongText

### DIFF
--- a/db/migrate/20170707153553_change_columns_on_delayed_jobs.rb
+++ b/db/migrate/20170707153553_change_columns_on_delayed_jobs.rb
@@ -1,0 +1,6 @@
+class ChangeColumnsOnDelayedJobs < ActiveRecord::Migration[5.0]
+  def change
+    change_column :delayed_jobs, :handler, :text, limit: 4294967295
+    change_column :delayed_jobs, :last_error, :text, limit: 4294967295
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517143845) do
+ActiveRecord::Schema.define(version: 20170707153553) do
 
   create_table "admin_rates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer  "line_item_id"
@@ -142,17 +142,17 @@ ActiveRecord::Schema.define(version: 20170517143845) do
   end
 
   create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
-    t.integer  "priority",                 default: 0, null: false
-    t.integer  "attempts",                 default: 0, null: false
-    t.text     "handler",    limit: 65535,             null: false
-    t.text     "last_error", limit: 65535
+    t.integer  "priority",                      default: 0, null: false
+    t.integer  "attempts",                      default: 0, null: false
+    t.text     "handler",    limit: 4294967295,             null: false
+    t.text     "last_error", limit: 4294967295
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
     t.string   "locked_by"
     t.string   "queue"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 


### PR DESCRIPTION
Some exceptions received by Delayed Job can be quite lengthy. If you are using MySQL, the handler and last_error fields may not be long enough. Change their datatype to longtext to avoid this issue. If you are using PostgreSQL, this will not be a problem.

https://www.sitepoint.com/delayed-jobs-best-practices/
https://stackoverflow.com/questions/4443477/rails-3-migration-with-longtext

[#148490549]

Story - https://www.pivotaltracker.com/story/show/148490549