### PR TITLE
KG - Revert #992 for v3.0.0 Refactors

### DIFF
--- a/app/views/service_calendars/table.js.coffee
+++ b/app/views/service_calendars/table.js.coffee
@@ -25,15 +25,7 @@ $(".arm-calendar-container-<%= @arm.id %>").replaceWith("<%= escape_javascript(r
 <% end %>
 
 <% if @portal %>
-# Admin Edit
-<% if @admin %>
 $("#sub_service_request_header").html("<%= escape_javascript(render( 'dashboard/sub_service_requests/header', sub_service_request: @sub_service_request )) %>")
-# View Consolidated Request -- All
-<% else %>
-<% @protocol.sub_service_requests.each do |ssr| %>
-$("#sub_service_request_header").html("<%= escape_javascript(render( 'dashboard/sub_service_requests/header', sub_service_request: ssr )) %>")
-<% end %>
-<% end %>
 <% end %>
 
 $('.selectpicker').selectpicker()


### PR DESCRIPTION
**#992 Pivotal:
https://www.pivotaltracker.com/story/show/148590319**

#962 merged for v3.0.0 fixes an issue which caused the visits select dropdown to always render `ServiceCalendarsController#table.js` by adding conditional logic to determine which JS route to use, corresponding to the calendar's original route. In other words, `#table` should rerender `#table`, `#merged_calendar` should rerender `#merged_calendar` and `#view_full_calendar` should rerender `#view_full_calendar`.

The referenced code change in #962:
`app/views/service_calendars/master_calendar/pppv/_visit_group_page_select.html.haml`
Original
```
- path_method = method(:table_service_calendars_path)
```
Updated
```
- if consolidated
  - path_method = method(:view_full_calendar_service_calendars_path)
- elsif merged
  - path_method = method(:merged_calendar_service_calendars_path)
- else
  - path_method = method(:table_service_calendars_path)
```
