### PR TITLE
JM- edge case

### DIFF
--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -19,12 +19,19 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module ProtocolsHelper
-  def display_study_type_question?(protocol, study_type_answer)
-    to_display = 
-      if !USE_EPIC || protocol.selected_for_epic == false
+  def display_study_type_question?(protocol, study_type_answer, view_protocol=false)
+    if !USE_EPIC || protocol.selected_for_epic == false
+      if view_protocol
         ['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
       else
-        !['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
+        if study_type_answer.study_type_question.friendly_id == 'certificate_of_conf_no_epic'
+          true
+        else
+          ['higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
+        end
       end
+    else
+      !['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
+    end
   end
 end

--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -21,12 +21,13 @@
 module ProtocolsHelper
   def display_study_type_question?(protocol, study_type_answer, view_protocol=false)
     if !USE_EPIC || protocol.selected_for_epic == false
+      # If read-only (Dashboard--> 'Edit Study Information' or 'View Study Details') do not show the first CofC question if unanswered
       if view_protocol
         ['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
-      else
+      else # Else we want to always display the first CofC question regardless of whether it's been answered or needs to be answered
         if study_type_answer.study_type_question.friendly_id == 'certificate_of_conf_no_epic'
           true
-        else
+        else # We want to see the second CofC question if it's been answered
           ['higher_level_of_privacy_no_epic'].include?(study_type_answer.study_type_question.friendly_id) && study_type_answer.answer != nil
         end
       end

--- a/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -38,7 +38,7 @@
         = link_to 'Cancel Edit',
           edit_dashboard_protocol_study_type_answers_path(protocol),
           class: 'btn btn-danger cancel-edit', remote: true
-.form-group.row.selected_for_epic_dependent{ display_if(protocol.selected_for_epic) }
+.form-group.row.selected_for_epic_dependent{ style: protocol.selected_for_epic || action_name == 'update_protocol_type' ? 'display:block;' : 'display:none;' }
   = hidden_field_tag :updated_protocol_type, updated_protocol_type
   = form.label :study_type_questions,
     t(:protocols)[:studies][:information][:study_type_questions],
@@ -58,9 +58,3 @@
               = link_to 'Cancel Edit',
                 edit_dashboard_protocol_study_type_answers_path(protocol),
                 class: 'btn btn-danger cancel-edit', remote: true
-.answer-questions{ display_if(!protocol.selected_for_epic) }
-  = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}"
-  .col-lg-10
-    .form-group.row
-      .col-lg-8
-        = label_tag 'answer', STUDY_TYPE_QUESTIONS_VERSION_3[5], class: 'long'

--- a/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -58,3 +58,9 @@
               = link_to 'Cancel Edit',
                 edit_dashboard_protocol_study_type_answers_path(protocol),
                 class: 'btn btn-danger cancel-edit', remote: true
+.answer-questions{ display_if(!protocol.selected_for_epic) }
+  = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}"
+  .col-lg-10
+    .form-group.row
+      .col-lg-8
+        = label_tag 'answer', STUDY_TYPE_QUESTIONS_VERSION_3[5], class: 'long'

--- a/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -18,7 +18,6 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 .form-group.row
   - if USE_EPIC
     = form.label :selected_for_epic,
@@ -38,11 +37,12 @@
         = link_to 'Cancel Edit',
           edit_dashboard_protocol_study_type_answers_path(protocol),
           class: 'btn btn-danger cancel-edit', remote: true
-.form-group.row.selected_for_epic_dependent{ style: protocol.selected_for_epic || action_name == 'update_protocol_type' ? 'display:block;' : 'display:none;' }
+
+.form-group.row.selected_for_epic_dependent{ style: protocol.selected_for_epic || (!USE_EPIC && action_name == 'update_protocol_type') ? 'display:block;' : 'display:none;' }
   = hidden_field_tag :updated_protocol_type, updated_protocol_type
   = form.label :study_type_questions,
     t(:protocols)[:studies][:information][:study_type_questions],
-    class: "col-lg-2 control-label question-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}",
+    class: "col-lg-2 control-label question-label #{ USE_EPIC && protocol.selected_for_epic ? 'required' : '' }",
     data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' },
     title: t(:protocols)[:tooltips][:study_type_questions]
   .col-lg-10

--- a/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
@@ -31,7 +31,7 @@
           edit_dashboard_protocol_study_type_answers_path(protocol, edit_answers: true),
           class: 'btn btn-warning edit-answers', remote: true
 .form-group.row.selected_for_epic_dependent#readonly
-  - if protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
+  - if protocol.display_answers.map(&:answer).any? && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as, true) }
     = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}"
     .col-lg-10
       = form.fields_for :study_type_answers, protocol.display_answers do |answer|

--- a/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_readonly_form.html.haml
@@ -31,11 +31,12 @@
           edit_dashboard_protocol_study_type_answers_path(protocol, edit_answers: true),
           class: 'btn btn-warning edit-answers', remote: true
 .form-group.row.selected_for_epic_dependent#readonly
-  - if protocol.display_answers.map(&:answer).any? && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as, true) }
-    = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}"
-    .col-lg-10
-      = form.fields_for :study_type_answers, protocol.display_answers do |answer|
-        = render partial: 'dashboard/protocols/form/study_form_sections/readonly_answer_field', locals: { answer: answer, protocol: protocol }
+  - if (USE_EPIC && protocol.display_answers.map(&:answer).compact.present?) || (!USE_EPIC && protocol.active? && protocol.display_answers.last(2).map(&:answer).compact.present?)
+    - if protocol.display_answers{ |as| display_study_type_question?(protocol, as, true) }
+      = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}"
+      .col-lg-10
+        = form.fields_for :study_type_answers, protocol.display_answers do |answer|
+          = render partial: 'dashboard/protocols/form/study_form_sections/readonly_answer_field', locals: { answer: answer, protocol: protocol }
   - else
     = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}"
     .col-lg-10

--- a/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -32,7 +32,7 @@
         %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false || !USE_EPIC ? 'active': ''}
           = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
           = t(:constants)[:no_select]
-.form-group.row.selected_for_epic_dependent{ style: protocol.selected_for_epic || action_name == 'update_protocol_type' ? 'display:block;' : 'display:none;' }
+.form-group.row.selected_for_epic_dependent{ style: protocol.selected_for_epic || (!USE_EPIC && action_name == 'update_protocol_type') ? 'display:block;' : 'display:none;' }
   = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label question-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}", data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' }, title: t(:protocols)[:tooltips][:study_type_questions]
   .col-lg-10
     - action_name == 'update_protocol_type' ? protocol.setup_study_type_answers : ''

--- a/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
+++ b/app/views/protocols/form/study_form_sections/_interactive_form.html.haml
@@ -32,7 +32,7 @@
         %label.radio-inline.btn.btn-default#study_selected_for_epic_false_button{ class: protocol.selected_for_epic == false || !USE_EPIC ? 'active': ''}
           = form.radio_button :selected_for_epic, 'false', id: "study_selected_for_epic_false", class: 'hidden'
           = t(:constants)[:no_select]
-.form-group.row.selected_for_epic_dependent{ display_if(protocol.selected_for_epic) }
+.form-group.row.selected_for_epic_dependent{ style: protocol.selected_for_epic || action_name == 'update_protocol_type' ? 'display:block;' : 'display:none;' }
   = form.label :study_type_questions, t(:protocols)[:studies][:information][:study_type_questions], class: "col-lg-2 control-label question-label #{USE_EPIC && protocol.selected_for_epic ? 'required' : ''}", data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' }, title: t(:protocols)[:tooltips][:study_type_questions]
   .col-lg-10
     - action_name == 'update_protocol_type' ? protocol.setup_study_type_answers : ''

--- a/app/views/protocols/view_details/_study_information.html.haml
+++ b/app/views/protocols/view_details/_study_information.html.haml
@@ -110,21 +110,23 @@
               = t(:protocols)[:studies][:information][:push_to_epic]
             .col-lg-8
               = protocol.selected_for_epic ? t(:constants)[:yes_select] : t(:constants)[:no_select]
-      - if (!USE_EPIC && protocol.display_answers.last(2).map(&:answer).any?) && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
-        / Epic Questions
-        %tr.row
-          %td.row
-            %table.table.table-bordered
-              %thead.default-header
-                %th
-                  %h5.col-lg-12
-                    %strong
-                      = t(:protocols)[:studies][:information][:study_type_questions]
+      / If USE_EPIC is false and any of the CofC questions have been answered, display them OR
+      / If USE_EPIC is true and any of the Epic questions have been answered, display them
+      - if (USE_EPIC && protocol.display_answers.map(&:answer).compact.present?) || (!USE_EPIC && protocol.active? && protocol.display_answers.last(2).map(&:answer).compact.present?)
+        - if protocol.display_answers{ |as| display_study_type_question?(protocol, as) }
+          %tr.row
+            %td.row
+              %table.table.table-bordered
+                %thead.default-header
+                  %th
+                    %h5.col-lg-12
+                      %strong
+                        = t(:protocols)[:studies][:information][:study_type_questions]
 
-              - protocol.display_answers.each do |answer|
-                - if answer.study_type_question.study_type_question_group.active && protocol.active? && display_study_type_question?(protocol, answer, true)
-                  = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
-                - elsif !answer.study_type_question.study_type_question_group.active && !protocol.active? && display_study_type_question?(protocol, answer, true)
-                  = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
-            - if USE_EPIC && protocol.selected_for_epic
-              = render partial: 'protocols/view_details/study_type_note', locals: { protocol: protocol }         
+                - protocol.display_answers.each do |answer|
+                  - if answer.study_type_question.study_type_question_group.active && protocol.active? && display_study_type_question?(protocol, answer, true)
+                    = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
+                  - elsif !answer.study_type_question.study_type_question_group.active && !protocol.active? && display_study_type_question?(protocol, answer, true)
+                    = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
+              - if USE_EPIC && protocol.selected_for_epic
+                = render partial: 'protocols/view_details/study_type_note', locals: { protocol: protocol }         

--- a/app/views/protocols/view_details/_study_information.html.haml
+++ b/app/views/protocols/view_details/_study_information.html.haml
@@ -110,8 +110,7 @@
               = t(:protocols)[:studies][:information][:push_to_epic]
             .col-lg-8
               = protocol.selected_for_epic ? t(:constants)[:yes_select] : t(:constants)[:no_select]
-
-      - if protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
+      - if (!USE_EPIC && protocol.display_answers.last(2).map(&:answer).any?) && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
         / Epic Questions
         %tr.row
           %td.row
@@ -121,10 +120,11 @@
                   %h5.col-lg-12
                     %strong
                       = t(:protocols)[:studies][:information][:study_type_questions]
+
               - protocol.display_answers.each do |answer|
-                - if answer.study_type_question.study_type_question_group.active && protocol.active? && display_study_type_question?(protocol, answer)
+                - if answer.study_type_question.study_type_question_group.active && protocol.active? && display_study_type_question?(protocol, answer, true)
                   = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
-                - elsif !answer.study_type_question.study_type_question_group.active && !protocol.active? && display_study_type_question?(protocol, answer)
+                - elsif !answer.study_type_question.study_type_question_group.active && !protocol.active? && display_study_type_question?(protocol, answer, true)
                   = render partial: 'protocols/view_details/epic_questions_answers', locals: { answer: answer }
             - if USE_EPIC && protocol.selected_for_epic
               = render partial: 'protocols/view_details/study_type_note', locals: { protocol: protocol }         


### PR DESCRIPTION
Various bug fixes for this edge case:

USE_EPIC = false
When you are editing a study in Dashboard and have not answered the CofC questions. If the user has not answered these questions before, show the first CofC question with a “Answer” button beside it. When clicking the answer button, the user should be able to fill out one or both depending on the answers. If a user HAS filled out the questions, all of the answered questions should be displayed and an “Edit” button should appear beside them.