### PR TITLE
KG - OS Setting Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
+dist: precise
+
 before_install:
   - export TZ=America/New_York
 before_script:

--- a/app/lib/data_type_validator.rb
+++ b/app/lib/data_type_validator.rb
@@ -39,7 +39,7 @@ module DataTypeValidator
   end
 
   def is_url?(value)
-    value.match?(/^((ftp|http|https):\/\/)?[a-zA-Z0-9]+(.[a-zA-Z0-9])?(:[0-9]+)?/)
+    value.match?(/^((ftp|http|https):\/\/)?[a-zA-Z0-9]+((\.[a-zA-Z0-9]+)|(:[0-9]+)+)/)
   end
 
   def is_path?(value)

--- a/app/lib/data_type_validator.rb
+++ b/app/lib/data_type_validator.rb
@@ -39,10 +39,10 @@ module DataTypeValidator
   end
 
   def is_url?(value)
-    value.match?(/^((ftp|http|https):\/\/)?[a-zA-Z0-9]+((\.[a-zA-Z0-9]+)|(:[0-9]+)+)/)
+    value.match?(/^((ftp|http|https):\/\/)?[a-zA-Z0-9]+(((\.[a-zA-Z0-9]+)+(:[0-9]+)?)|(:[0-9]+))(\/\w+)*(\/)?(\?(\w+=[\w\d]+(&\w+=[\w\d]+)*)+)?$/)
   end
 
   def is_path?(value)
-    value.match?(/^(\/\w+)+(\/)?(\?(\w+=[\w\d]+(&\w+=[\w\d]+)+)+)*$/)
+    value.match?(/^(\/|(\/\w+)+\/?)(\?(\w+=[\w\d]+(&\w+=[\w\d]+)*)+)?$/)
   end
 end

--- a/app/lib/data_type_validator.rb
+++ b/app/lib/data_type_validator.rb
@@ -39,10 +39,10 @@ module DataTypeValidator
   end
 
   def is_url?(value)
-    value.match?(/^((ftp|http|https):\/\/)?[a-zA-Z0-9]+(((\.[a-zA-Z0-9]+)+(:[0-9]+)?)|(:[0-9]+))(\/\w+)*(\/)?(\?(\w+=[\w\d]+(&\w+=[\w\d]+)*)+)?$/)
+    value.match?(/^((ftp|http|https):\/\/)?[a-zA-Z0-9]+(((\.[a-zA-Z0-9]+)+(:\d+)?)|(:\d+))(\/\w+)*(\/)?(\?(\w+=\w+(&\w+=\w+)*)+)?$/)
   end
 
   def is_path?(value)
-    value.match?(/^(\/|(\/\w+)+\/?)(\?(\w+=[\w\d]+(&\w+=[\w\d]+)*)+)?$/)
+    value.match?(/^(\/|(\/\w+)+\/?)(\?(\w+=\w+(&\w+=\w+)*)+)?$/)
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -35,6 +35,8 @@ class Setting < ApplicationRecord
       read_attribute(:value) == 'true'
     when 'json'
       JSON.parse(read_attribute(:value))
+    else
+      read_attribute(:value)
     end
   end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -55,8 +55,8 @@ class Setting < ApplicationRecord
         is_url?(value)
       when 'path'
         is_path?(value)
-      else
-        false
+      else # Default type = string, no validation needed
+        true
       end
   end
 end

--- a/lib/tasks/populate_settings_table.rake
+++ b/lib/tasks/populate_settings_table.rake
@@ -5,17 +5,17 @@ task :populate_settings_table => :environment do
   hash = YAML.load_file('config/application.yml')
   ActiveRecord::Base.transaction do
     hash[environment].each do |key, value|
-      type = ""
-        if (value.class == TrueClass) || (value.class == FalseClass)
-          type = 'boolean'
-        elsif (value.class == Array) || (value.class == Hash)
-          type = 'json'
-        else
-          type = 'string'
-        end
+      if (value.class == TrueClass) || (value.class == FalseClass)
+        type = 'boolean'
+        value = value.to_s
+      elsif (value.class == Array) || (value.class == Hash)
+        type = 'json'
+      else
+        type = 'string'
+      end
 
       setting = Setting.new
-      setting.assign_attributes(key: key, value: value, data_type: type)
+      setting.assign_attributes(key: key, value: value, data_type: type, friendly_name: key.titleize, description: key.humanize)
       setting.save(validate: false)
     end
   end

--- a/lib/tasks/populate_settings_table.rake
+++ b/lib/tasks/populate_settings_table.rake
@@ -1,15 +1,23 @@
 desc "Temporary task to populate the settings table"
 task :populate_settings_table => :environment do
 
+  include DataTypeValidator
+
   environment = Rails.env
   hash = YAML.load_file('config/application.yml')
   ActiveRecord::Base.transaction do
     hash[environment].each do |key, value|
-      if (value.class == TrueClass) || (value.class == FalseClass)
+      if [TrueClass, FalseClass].include?(value.class)
         type = 'boolean'
         value = value.to_s
-      elsif (value.class == Array) || (value.class == Hash)
+      elsif [Array, Hash].include?(value.class)
         type = 'json'
+      elsif is_email?(value)
+        type = 'email'
+      elsif is_url?(value)
+        type = 'url'
+      elsif is_path?(value)
+        type = 'path'
       else
         type = 'string'
       end


### PR DESCRIPTION
1. The `#value` method on the Setting model was missing a default return. It returned nil unless the setting was a JSON or boolean type.
2. The `value` validation on the Setting model incorrectly used `false` as a default, but should use `true`. This prevents errors from being added for `string` type settings.
3. The rake task entered booleans as `'t'` and `'f'` instead of `'true'` and `'false'`.
4. Added a general `friendly_name` and `description` to each setting in the rake task.
5. Added missing types `email`, `url`, and `path` to rake task
6. Fixed url regex. Was incorrectly using `.` which matched any character instead of `\.` which matches only the `.` character. Also allows more flexible strings in the domain.
7. Updated path and URL regexes to be stricter and more complete