### PR TITLE
Jl - approved subsidy cost bug

### DIFF
--- a/app/models/approved_subsidy.rb
+++ b/app/models/approved_subsidy.rb
@@ -34,7 +34,12 @@ class ApprovedSubsidy < Subsidy
   def approved_cost
     # Calculates cost of subsidy (amount subsidized)
     # stored total - pi_contribution then convert from cents to dollars
-    ( total_at_approval - pi_contribution ) / 100.0
+    ( total_at_approval - approved_pi_contribution ) / 100.0
+  end
+
+  def approved_pi_contribution
+    # Calculates the pi contribution at the time of subsidy approval
+    total_at_approval.to_f - (total_at_approval.to_f * percent_subsidy) || total_at_approval.to_f
   end
 
   def log_approval_note

--- a/app/views/subsidies/_approved_subsidy.html.haml
+++ b/app/views/subsidies/_approved_subsidy.html.haml
@@ -72,7 +72,7 @@
           %td.subsidy-percent
             = display_as_percent(subsidy.percent_subsidy)
           %td.subsidy-contribution
-            = number_to_currency(subsidy.pi_contribution/100.0)
+            = number_to_currency(subsidy.approved_pi_contribution/100.0)
           %td.subsidy-effective-current-cost
             = number_to_currency(subsidy.approved_cost)
           %td.approved-by


### PR DESCRIPTION
When viewing an approved subsidy the calculation for pi_contribution was using the total cost, and not the cost at approval.
PR: https://www.pivotaltracker.com/n/projects/1918597/stories/149603327