### PR TITLE
KG - (SPARCReport) Survey Report Bug

### DIFF
--- a/app/lib/reporting_module.rb
+++ b/app/lib/reporting_module.rb
@@ -87,7 +87,7 @@ class ReportingModule
 private
 
   def report_params
-    self.params.except("type").map{|k,v| [k.titleize, v]}
+    self.params.permit!.except("type").to_h.map{|k,v| [k.titleize, v]}
   end
 
   def create_report obj


### PR DESCRIPTION
Pivotal:
https://www.pivotaltracker.com/story/show/149581139

`ActionController::Parameters` no longer supports the `#map` method. We have to permit parameters, then call `to_h` in order to map the parameters.