### PR TITLE
wth - (SPARCRequest-Database)Extract data changes from Create Editabl…

### DIFF
--- a/db/migrate/20170622132807_create_editable_statuses.rb
+++ b/db/migrate/20170622132807_create_editable_statuses.rb
@@ -6,27 +6,6 @@ class CreateEditableStatuses < ActiveRecord::Migration[5.0]
 
       t.timestamps                  null: false
     end
-
-    if defined?(EDITABLE_STATUSES)
-      EDITABLE_STATUSES.each do |org_id, statuses|
-        organization = Organization.find(org_id)
-        (statuses << 'first_draft').each do |status|
-          organization.editable_statuses.create(status: status)
-        end
-      end
-
-      Organization.where.not(id: EDITABLE_STATUSES.keys).each do |org|
-        (AVAILABLE_STATUSES.keys << 'first_draft').each do |status|
-          org.editable_statuses.create(status: status)
-        end
-      end
-    else
-      Organization.all.each do |org|
-        (AVAILABLE_STATUSES.keys << 'first_draft').each do |status|
-          org.editable_statuses.create(status: status)
-        end
-      end
-    end
   end
 
   def down

--- a/lib/tasks/create_editable_statuses.rake
+++ b/lib/tasks/create_editable_statuses.rake
@@ -1,0 +1,25 @@
+namespace :data do
+  task create_editable_statuses_data: :environment do
+    if defined?(EDITABLE_STATUSES)
+      EDITABLE_STATUSES.each do |org_id, statuses|
+        organization = Organization.find(org_id)
+        (statuses << 'first_draft').each do |status|
+          organization.editable_statuses.create(status: status)
+        end
+      end
+
+      Organization.where.not(id: EDITABLE_STATUSES.keys).each do |org|
+        (AVAILABLE_STATUSES.keys << 'first_draft').each do |status|
+          org.editable_statuses.create(status: status)
+        end
+      end
+    else
+      Organization.all.each do |org|
+        (AVAILABLE_STATUSES.keys << 'first_draft').each do |status|
+          org.editable_statuses.create(status: status)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
…e Statuses db migration

Extract the loops and data changes from db/migrate/20170622132807_create_editable_statuses.rb into a rake task.

This migration will fail unless you have the necessary data already in your db.

Generally, you should only use migrations to change db schema and rake tasks for migrating data.

http://www.urbanbound.com/make/migrating-data-rails-migrations-or-a-rake-task

[#149933062]

Story - https://www.pivotaltracker.com/story/show/149933062