### PR TITLE
wth - (SPARCCatalog) Form Functionality Bugs

### DIFF
--- a/app/views/additional_details/submissions/_edit_form.html.haml
+++ b/app/views/additional_details/submissions/_edit_form.html.haml
@@ -6,5 +6,7 @@
     = qr.hidden_field :required, value: true
   = qr.hidden_field :item_id, value: item.id
   %div{ class: "form-group item-#{item.id}" }
-    = qr.label item.content
+    = qr.label :item_content, item.content
     = render "additional_details/submissions/form_partials/#{item.item_type}_form_partial", item: item, qr: qr
+    %span.help-block
+      = item.description

--- a/app/views/additional_details/submissions/_new_form.html.haml
+++ b/app/views/additional_details/submissions/_new_form.html.haml
@@ -7,8 +7,10 @@
       = qr.hidden_field :required, value: true
     = qr.hidden_field :item_id, value: item.id
     %div{ class: "form-group item-#{item.id}" }
-      = qr.label item.content
+      = qr.label :item_content, item.content
       = render "additional_details/submissions/form_partials/#{item.item_type}_form_partial", item: item, qr: qr
+      %span.help-block
+        = item.description
       - if qr.object.errors.any?
         .alert.alert-danger
           %ul.list-unstyled


### PR DESCRIPTION
Inside of the form builder, the description(s) (when added) are not displaying to the user.
Secondly, the sentence structure does not allow caps to be displayed to the user, although letters are capitalized in the form builder (i.e. FOA, TIN, etc).
Lastly, question numbering does not display on the questionnaire side when being entered on the form builder. Allow numbering to display so questions can be numbered.

[#149884606]

Story - https://www.pivotaltracker.com/story/show/149884606