### PR TITLE
wth - (SPARCDashboard) Allow Overlord Users Access to Documents on Al…

### DIFF
--- a/app/views/dashboard/documents/index.json.jbuilder
+++ b/app/views/dashboard/documents/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.(@documents) do |doc|
-  has_access_to_doc = @permission_to_edit || (@admin_orgs & doc.all_organizations).any?
+  has_access_to_doc = @user.catalog_overlord || @permission_to_edit || (@admin_orgs & doc.all_organizations).any?
 
 	json.id doc.id
 	json.type doc.display_document_type


### PR DESCRIPTION
…l Protocols

Background: The overlord users currently have access to all the "Add/Modify Request" buttons to all the protocols on SPARCDashboard. That functionality was built for institutional high-level centralized users (such as OCR) to be able to make necessary updates to protocols without adding themselves onto each protocol. However, the documents are still not accessible to overlords, although they could use Modify Request route and make changes to documents on SPARCRequest Step 3 page.

Please make documents on all protocols on SPARCDashboard accessible (view/edit/delete all enabled) to the overlord users (identities.catalog_overlord = 1).

[#149179951]

Story - https://www.pivotaltracker.com/story/show/149179951