### PR TITLE
wth - (SPARCDashboard) Add Milestone (Timeline) Section for Protocols

### DIFF
--- a/app/assets/javascripts/dashboard/milestone.js.coffee
+++ b/app/assets/javascripts/dashboard/milestone.js.coffee
@@ -1,0 +1,13 @@
+$ ->
+
+  $(document).on 'dp.change', '.start-date-picker', (e) ->
+    $('.start-date-setter').val(e.date)
+
+  $(document).on 'dp.change', '.end-date-picker', (e) ->
+    $('.end-date-setter').val(e.date)
+
+  $(document).on 'dp.change', '.recruitment-start-date-picker', (e) ->
+    $('.recruitment-start-date-setter').val(e.date)
+
+  $(document).on 'dp.change', '.recruitment-end-date-picker', (e) ->
+    $('.recruitment-end-date-setter').val(e.date)

--- a/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
+++ b/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
@@ -98,26 +98,6 @@ $(document).ready ->
   # STUDY SCHEDULE TAB END
   # TIMELINE LISTENERS BEGIN
 
-  $(document).on 'dp.hide', '#protocol_start_date_picker', ->
-    protocol_id = $(this).data('protocol_id')
-    ssr_id = $(this).data('sub_service_request_id')
-    start_date = $(this).val()
-    data = 'protocol' : {'start_date' : start_date}, 'sub_service_request' : {'id' : ssr_id}
-    $.ajax
-      type: 'PATCH'
-      url: "/dashboard/protocols/#{protocol_id}"
-      data: data
-
-  $(document).on 'dp.hide', '#protocol_end_date_picker', ->
-    protocol_id = $(this).data('protocol_id')
-    ssr_id = $(this).data('sub_service_request_id')
-    end_date = $(this).val()
-    data = 'protocol' : {'end_date' : end_date}, 'sub_service_request' : {'id' : ssr_id}
-    $.ajax
-      type: 'PATCH'
-      url: "/dashboard/protocols/#{protocol_id}"
-      data: data
-
   $(document).on 'dp.hide', '#sub_service_request_consult_arranged_date_picker', ->
     ssr_id = $(this).data('sub_service_request_id')
     consult_arranged_date = $(this).val()

--- a/app/controllers/dashboard/milestones_controller.rb
+++ b/app/controllers/dashboard/milestones_controller.rb
@@ -1,0 +1,22 @@
+class Dashboard::MilestonesController < Dashboard::BaseController
+
+  def update
+    @protocol = Protocol.find(params[:protocol_id])
+    @protocol.update_attributes(protocol_params)
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  private
+
+  def protocol_params
+    params.require(@protocol.type.downcase.to_sym).permit(
+      :start_date,
+      :end_date,
+      :recruitment_start_date,
+      :recruitment_end_date
+    )
+  end
+end
+

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -489,6 +489,10 @@ class Protocol < ApplicationRecord
       any?(&:has_ctrc_clinical_services?)
   end
 
+  def has_clinical_services?
+    service_requests.any?(&:has_per_patient_per_visit_services?)
+  end
+
   def find_sub_service_request_with_ctrc(service_request)
     service_request.sub_service_requests.find(&:ctrc?).try(:ssr_id)
   end

--- a/app/views/dashboard/milestones/update.js.coffee
+++ b/app/views/dashboard/milestones/update.js.coffee
@@ -1,0 +1,5 @@
+$('.milestones-panel').html("<%= j render 'dashboard/protocols/milestone', protocol: @protocol %>")
+$(".datetimepicker:not(.time)").datetimepicker(format: 'MM/DD/YYYY', allowInputToggle: true)
+$('.datetimepicker.time').datetimepicker(format: 'hh:mm A', allowInputToggle: true)
+$(".selectpicker").selectpicker()
+$('[data-toggle="tooltip"]').tooltip()

--- a/app/views/dashboard/protocols/_milestone.html.haml
+++ b/app/views/dashboard/protocols/_milestone.html.haml
@@ -1,0 +1,57 @@
+.panel.panel-default
+  .panel-heading
+    %h4.panel-title
+      = t(:dashboard)[:protocols][:milestones][:title]
+  .panel-body
+    .date-details
+      = form_for(protocol, url: dashboard_protocol_milestones_path(protocol), method: :patch, remote: true) do |f|
+        .form-group.col-lg-12
+          = f.label :start_date,
+            t('dashboard.protocols.milestones.start_date', type: protocol.type),
+            class: 'col-lg-2 control-label required',
+            data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' },
+            title: t('dashboard.protocols.milestones.tooltips.start_date', type: protocol.type)
+          .col-lg-10
+            = text_field_tag 'start_date', nil,
+              class: 'datetimepicker form-control start-date-picker',
+              value: (protocol.start_date.strftime('%_m/%d/%Y') rescue nil)
+            = f.hidden_field :start_date, class: 'start-date-setter'
+        .form-group.col-lg-12
+          = f.label :end_date,
+            t('dashboard.protocols.milestones.end_date', type: protocol.type),
+            class: 'col-lg-2 control-label required',
+            data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' },
+            title: t('dashboard.protocols.milestones.tooltips.end_date', type: protocol.type)
+          .col-lg-10
+            = text_field_tag 'end_date', nil,
+              class: 'datetimepicker form-control end-date-picker',
+              value: (protocol.end_date.strftime('%_m/%d/%Y') rescue nil)
+            = f.hidden_field :end_date, class: 'end-date-setter'
+
+        - if protocol.has_clinical_services?
+          .form-group.col-lg-12#recruitment-start
+            = f.label :recruitment_start_date,
+              t('dashboard.protocols.milestones.recruitment_start', type: protocol.type),
+              class: 'col-lg-2 control-label',
+              data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' },
+              title: t('dashboard.protocols.milestones.tooltips.recruitment_start_date', type: protocol.type)
+            .col-lg-10
+              = text_field_tag 'recruitment_start_date', nil,
+                class: 'datetimepicker form-control recruitment-start-date-picker',
+                value: (protocol.recruitment_start_date.strftime('%_m/%d/%Y') rescue nil)
+              = f.hidden_field :recruitment_start_date, value: nil, class: 'recruitment-start-date-setter'
+          .form-group.col-lg-12#recruitment-end
+            = f.label :recruitment_end_date,
+              t('dashboard.protocols.milestones.recruitment_end', type: protocol.type),
+              class: 'col-lg-2 control-label',
+              data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' },
+              title: t('dashboard.protocols.milestones.tooltips.recruitment_end_date', type: protocol.type)
+            .col-lg-10
+              = text_field_tag 'recruitment_end_date', nil,
+                class: 'datetimepicker form-control recruitment-end-date-picker',
+                value: (protocol.recruitment_end_date.strftime('%_m/%d/%Y') rescue nil)
+              = f.hidden_field :recruitment_end_date, value: nil,
+                class: 'recruitment-end-date-setter'
+        .form-group
+          .col-sm-offset-3.col-sm-6
+            = f.submit t('dashboard.protocols.milestones.update_button'), class: 'btn btn-primary btn-block'

--- a/app/views/dashboard/protocols/show.html.haml
+++ b/app/views/dashboard/protocols/show.html.haml
@@ -25,6 +25,8 @@
   = render 'dashboard/service_requests/service_requests', protocol: @protocol, super_user_orgs: @super_user_orgs, permission_to_edit: @permission_to_edit, user: @user, view_only: false, show_view_ssr_back: @show_view_ssr_back, statuses_hidden: %(first_draft)
   .additional-details-submissions-panel
     = render "additional_details/submissions/submissions_panel", protocol: @protocol, submissions: @submissions
+  .milestones-panel
+    = render "dashboard/protocols/milestone", protocol: @protocol
 
 = render 'additional_details/submissions/submission_modal'
 

--- a/app/views/dashboard/sub_service_requests/_request_details.html.haml
+++ b/app/views/dashboard/sub_service_requests/_request_details.html.haml
@@ -48,27 +48,17 @@
   .panel-body#timeline_table
     .row
       .col-xs-12
-        .col-xs-3
-          %label
-            = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:timeline][:start_date]
-        .col-xs-3
-          %label
-            = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:timeline][:end_date]
-        .col-xs-3
+        .col-xs-6
           %label
             = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:timeline][:arranged_date]
-        .col-xs-3
+        .col-xs-6
           %label
             = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:timeline][:contacted_date]
     .row
       .col-xs-12
-        .col-xs-3
-          = text_field_tag "protocol_start_date_picker", protocol.try(:start_date).try(:strftime, '%D'), class: 'date datetimepicker form-control', :'data-protocol_id' => sub_service_request.try(:protocol).try(:id), :'data-sub_service_request_id' => sub_service_request.try(:id)
-        .col-xs-3
-          = text_field_tag "protocol_end_date_picker", protocol.try(:end_date).try(:strftime, '%D'), class: 'date datetimepicker form-control', :'data-protocol_id' => sub_service_request.try(:protocol).try(:id), :'data-sub_service_request_id' => sub_service_request.try(:id)
-        .col-xs-3
+        .col-xs-6
           = text_field_tag "sub_service_request_consult_arranged_date_picker", sub_service_request.try(:consult_arranged_date).try(:strftime, '%D'), class: 'date datetimepicker form-control', :'data-sub_service_request_id' => sub_service_request.try(:id)
-        .col-xs-3
+        .col-xs-6
           = text_field_tag "sub_service_request_requester_contacted_date_picker", sub_service_request.try(:requester_contacted_date).try(:strftime, '%D'), class: 'date datetimepicker form-control', :'data-sub_service_request_id' => sub_service_request.try(:id)
 
 - if sub_service_request.eligible_for_subsidy?

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -210,6 +210,18 @@ en:
         coverage_report: 'Coverage Analysis Report'
         consolidated_all: "All"
         consolidated_exclude_drafts: "Exclude Drafts"
+      milestones:
+        title: 'Milestones (Timeline)'
+        start_date: "%{type} Start Date"
+        end_date: "%{type} End Date"
+        recruitment_start: "%{type} Estimated Recruitment Start Date"
+        recruitment_end: "%{type} Estimated Recruitment End Date"
+        update_button: 'Update Milestones'
+        tooltips:
+          start_date: "%{type} estimated start date (used by service providers to prioritize)"
+          end_date: "%{type} estimated end date (used by service providers to prioritize)"
+          recruitment_start_date: "When your %{type} is estimated to start recruiting participants"
+          recruitment_end_date: "When your %{type} is estimated to stop recruiting participants"
     #####################
     # SERVICE CALENDARS #
     #####################

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,7 @@ SparcRails::Application.routes.draw do
     resources :projects, controller: :protocols, except: [:destroy]
 
     resources :protocols, except: [:destroy] do
+      resource :milestones, only: [:update]
       resource :study_type_answers, only: [:edit]
       member do
         put :update_protocol_type


### PR DESCRIPTION
Background: There is currently no way for the users access from SPARCDashboard to view or edit the timeline information they entered on SPARCRequest Step 2A page.
Please
1). Add a "Milestone (Timeline)" section on SPARCDashboard inside a protocol, which displays and allows to edit the 4 time points on SPARCRequest Step 2A: Study/Project Start Date; Study/Project End Date; Estimated Recruitment Start Date; Estimated Recruitment End Date (see 1st screenshot below for a raw mockup).
2). Logic driving the display of the labels according to whether it's a study or project; and Only show the Estimated Recruitment Dates when there are clinical services on the protocol.
3). Allow authorized users, service providers, super users and overlords to edit the data.
4). Remove the "Proposed Start Date" and "Proposed End Date" from inside each Admin Edit section (shown in 2nd screenshot), because those will be duplicative data.

[#149694407]

Story - https://www.pivotaltracker.com/story/show/149694407