### PR TITLE
ml-dashboard_archive_refresh_fix

### DIFF
--- a/app/views/dashboard/protocols/archive.js.coffee
+++ b/app/views/dashboard/protocols/archive.js.coffee
@@ -17,4 +17,4 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$('#summary-panel').replaceWith("<%= j render 'summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit %>")
+$('#summary-panel').replaceWith("<%= j render 'summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit || @admin %>")


### PR DESCRIPTION
I believe there is an archive refresh issue going on. Once you Archive a study (screenshot 2) there are no buttons available on the dashboard until refreshing the browser (screenshot 3). Please look into this.

https://www.pivotaltracker.com/story/show/148239925