### PR TITLE
KG - Reply to Notification Not Sending Emails

### DIFF
--- a/app/controllers/dashboard/messages_controller.rb
+++ b/app/controllers/dashboard/messages_controller.rb
@@ -39,7 +39,10 @@ class Dashboard::MessagesController < Dashboard::BaseController
     @notification = Notification.find(params[:message][:notification_id])
     if message_params[:body].present? # don't create empty messages
       @message = Message.create(message_params)
-      @notification.set_read_by(Identity.find(@message.to), false)
+      @recipient = @message.recipient
+      @notification.set_read_by(@recipient, false)
+
+      UserMailer.notification_received(@recipient, @notification.sub_service_request).deliver unless @recipient.email.blank?
     end
     @messages = @notification.messages
   end

--- a/db/migrate/20170817141100_add_to_and_from_index_to_message.rb
+++ b/db/migrate/20170817141100_add_to_and_from_index_to_message.rb
@@ -1,0 +1,6 @@
+class AddToAndFromIndexToMessage < ActiveRecord::Migration[5.1]
+  def change
+    add_index :messages, :to
+    add_index :messages, :from
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170707153553) do
+ActiveRecord::Schema.define(version: 20170817141100) do
 
   create_table "admin_rates", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer "line_item_id"
@@ -175,7 +175,7 @@ ActiveRecord::Schema.define(version: 20170707153553) do
     t.integer "sub_service_request_id"
   end
 
-  create_table "editable_statuses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "editable_statuses", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "organization_id"
     t.string "status", null: false
     t.datetime "created_at", null: false
@@ -381,7 +381,9 @@ ActiveRecord::Schema.define(version: 20170707153553) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["from"], name: "index_messages_on_from"
     t.index ["notification_id"], name: "index_messages_on_notification_id"
+    t.index ["to"], name: "index_messages_on_to"
   end
 
   create_table "notes", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/spec/controllers/dashboard/messages/post_create_spec.rb
+++ b/spec/controllers/dashboard/messages/post_create_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Dashboard::MessagesController do
         allow(@notification).to receive(:messages).and_return("MyMessages")
         allow(@notification).to receive(:set_read_by)
 
-        @to_identity = findable_stub(Identity) { build_stubbed(:identity) }
-        @from_identity = build_stubbed(:identity)
+        @to_identity = create(:identity)
+        @from_identity = create(:identity)
         @new_message_attr = {
           notification_id: @notification.id.to_s,
           to: @to_identity.id.to_s,

--- a/spec/controllers/dashboard/messages/post_create_spec.rb
+++ b/spec/controllers/dashboard/messages/post_create_spec.rb
@@ -24,8 +24,13 @@ RSpec.describe Dashboard::MessagesController do
   describe "POST #create" do
     context "params[:message][:body] not empty" do
       before(:each) do
+        ssr = build_stubbed(
+          :sub_service_request,
+          protocol: build_stubbed(:protocol),
+          organization: build_stubbed(:organization)
+        )
         @notification = findable_stub(Notification) do
-          build_stubbed(:notification)
+          build_stubbed(:notification, sub_service_request: ssr)
         end
         allow(@notification).to receive(:messages).and_return("MyMessages")
         allow(@notification).to receive(:set_read_by)
@@ -67,8 +72,13 @@ RSpec.describe Dashboard::MessagesController do
 
     context "params[:message][:body] empty" do
       before(:each) do
+        ssr = build_stubbed(
+          :sub_service_request,
+          protocol: build_stubbed(:protocol),
+          organization: build_stubbed(:organization)
+        )
         @notification = findable_stub(Notification) do
-          build_stubbed(:notification)
+          build_stubbed(:notification, sub_service_request: ssr)
         end
         allow(@notification).to receive(:messages).and_return("MyMessages")
 


### PR DESCRIPTION
Pivotal:
https://www.pivotaltracker.com/story/show/150044144

Notifications use 2 different controllers. 
When sending a message initially, it uses the NotificationsController#create action to create a Notification (like an email chain) and then a message inside that. That controller action already had the email logic.

When replying to a message, it uses the MessagesController#create action to create a Message. That controller action did not have email logic.

Also added indexes to the `to` and `from` columns on the Messages table.