### PR TITLE
KG - Layout Overflow Bug

### DIFF
--- a/app/views/layouts/_header_logos.html.haml
+++ b/app/views/layouts/_header_logos.html.haml
@@ -18,7 +18,7 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-.row.text-center
+.row.no-margin.text-center
   .col-md-3
     %a{ href: HEADER_LINK_1, class: 'org-logo' }
       = image_tag 'sctr_header_sized.jpg', alt: 'org_logo', height: 140


### PR DESCRIPTION
The margins added by the new `.row` element in the header logos were causing horizontal overflow in-browser.