### PR TITLE
KG/JW - Survey Response Email Link Broken

### DIFF
--- a/app/views/surveyor/responses/form/form_partials/_checkbox_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_checkbox_form_partial.html.haml
@@ -25,5 +25,5 @@
       = option.content
     - else
       .col-lg-1.text-center
-        = check_box_tag :content_checkbox, '', multiple_select_formatter(qr.object.content).include?(option.content), disabled: true, multiple: true
+        = check_box_tag :content_checkbox, '', multiple_select_formatter(qr.content).include?(option.content), disabled: true, multiple: true
       = option.content

--- a/app/views/surveyor/responses/form/form_partials/_country_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_country_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.country_select :content, { priority_countries: ['US'], include_blank: true }, { class: 'form-control selectpicker option' }
   - else
-    = country_select :content, :country, { priority_countries: ['US'], include_blank: true, selected: qr.object.content }, { class: 'form-control selectpicker option', disabled: true }
+    = country_select :content, :country, { priority_countries: ['US'], include_blank: true, selected: qr.content }, { class: 'form-control selectpicker option', disabled: true }

--- a/app/views/surveyor/responses/form/form_partials/_date_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_date_form_partial.html.haml
@@ -22,6 +22,6 @@
     - if ['new', 'edit', 'preview'].include?(action_name)
       = qr.text_field :content, class: 'form-control', maxlength: 255
     - else
-      = text_field_tag :content, qr.object.content, class: 'form-control', disabled: true
+      = text_field_tag :content, qr.content, class: 'form-control', disabled: true
     %span.input-group-addon
       %span.glyphicon.glyphicon-calendar

--- a/app/views/surveyor/responses/form/form_partials/_dropdown_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_dropdown_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.select :content, options_from_collection_for_select(question.options, 'content', 'content'), { include_blank: true }, { class: 'form-control selectpicker option' }
   - else
-    = select_tag :content, options_from_collection_for_select(qr.question.options, 'content', 'content', qr.object.content), include_blank: true, class: 'form-control selectpicker option', disabled: true
+    = select_tag :content, options_from_collection_for_select(qr.question.options, 'content', 'content', qr.content), include_blank: true, class: 'form-control selectpicker option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_email_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_email_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.email_field :content, class: 'form-control option'
   - else
-    = email_field_tag :content, qr.object.content, class: 'form-control option', disabled: true
+    = email_field_tag :content, qr.content, class: 'form-control option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_likert_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_likert_form_partial.html.haml
@@ -26,7 +26,7 @@
         - if ['new', 'edit', 'preview'].include?(action_name)
           = qr.radio_button :content, option.content
         - else
-          = radio_button_tag :content_likert, '', qr.object.content == option.content, disabled: true
+          = radio_button_tag :content_likert, '', qr.content == option.content, disabled: true
       .col-sm-12.text-center.no-padding
         - if ['new', 'edit', 'preview'].include?(action_name)
           = qr.label :content, option.content, class: "radio-inline option no-padding", data: { question_id: question.id, option_id: option.id }

--- a/app/views/surveyor/responses/form/form_partials/_multiple_dropdown_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_multiple_dropdown_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.select :content, options_from_collection_for_select(question.options, 'content', 'content'), { include_blank: true }, { class: 'form-control selectpicker option', multiple: true }
   - else
-    = select_tag :content, options_from_collection_for_select(qr.question.options, 'content', 'content', multiple_select_formatter(qr.object.content)), include_blank: true, class: 'form-control selectpicker option', disabled: true, multiple: true
+    = select_tag :content, options_from_collection_for_select(qr.question.options, 'content', 'content', multiple_select_formatter(qr.content)), include_blank: true, class: 'form-control selectpicker option', disabled: true, multiple: true

--- a/app/views/surveyor/responses/form/form_partials/_number_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_number_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.number_field :content, class: 'form-control option'
   - else
-    = number_field_tag :content, qr.object.content, class: 'form-control option', disabled: true
+    = number_field_tag :content, qr.content, class: 'form-control option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_phone_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_phone_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.telephone_field :content, class: 'form-control option'
   - else
-    = telephone_field_tag :content, qr.object.content, class: 'form-control option', disabled: true
+    = telephone_field_tag :content, qr.content, class: 'form-control option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_radio_button_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_radio_button_form_partial.html.haml
@@ -25,5 +25,5 @@
       = option.content
     - else
       .col-lg-1.text-center
-        = radio_button_tag :content_radio, '', qr.object.content == option.content, disabled: true
+        = radio_button_tag :content_radio, '', qr.content == option.content, disabled: true
       = option.content

--- a/app/views/surveyor/responses/form/form_partials/_state_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_state_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.select :content, options_for_select(us_states), { include_blank: true }, { class: 'form-control selectpicker option' }
   - else
-    = select_tag :content, options_for_select(us_states, qr.object.content), include_blank: true, class: 'form-control selectpicker option', disabled: true
+    = select_tag :content, options_for_select(us_states, qr.content), include_blank: true, class: 'form-control selectpicker option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_text_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_text_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.text_field :content, class: 'form-control option', maxlength: 255
   - else
-    = text_field_tag :content, qr.object.content, class: 'form-control option', disabled: true
+    = text_field_tag :content, qr.content, class: 'form-control option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_textarea_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_textarea_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.text_area :content, class: 'form-control option', maxlength: 255
   - else
-    = text_area_tag :content, qr.object.content, class: 'form-control option', disabled: true
+    = text_area_tag :content, qr.content, class: 'form-control option', disabled: true

--- a/app/views/surveyor/responses/form/form_partials/_time_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_time_form_partial.html.haml
@@ -22,6 +22,6 @@
     - if ['new', 'edit', 'preview'].include?(action_name)
       = qr.text_field :content, class: 'form-control', maxlength: 255
     - else
-      = text_field_tag :content, qr.object.content, class: 'form-control', disabled: true
+      = text_field_tag :content, qr.content, class: 'form-control', disabled: true
     %span.input-group-addon
       %span.glyphicon.glyphicon-time

--- a/app/views/surveyor/responses/form/form_partials/_yes_no_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_yes_no_form_partial.html.haml
@@ -26,5 +26,5 @@
         = option.content
       - else
         .col-lg-6.no-padding.text-center.option{ data: { question_id: question.id, option_id: option.id } }
-          = radio_button_tag :content_yes_no, option.content.downcase, qr.object.content == option.content.downcase, disabled: true
+          = radio_button_tag :content_yes_no, option.content.downcase, qr.content == option.content.downcase, disabled: true
         = option.content

--- a/app/views/surveyor/responses/form/form_partials/_zipcode_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_zipcode_form_partial.html.haml
@@ -21,4 +21,4 @@
   - if ['new', 'edit', 'preview'].include?(action_name)
     = qr.text_field :content, class: 'form-control option', maxlength: 255
   - else
-    = text_field_tag :content, qr.object.content, class: 'form-control option', disabled: true
+    = text_field_tag :content, qr.content, class: 'form-control option', disabled: true


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150405461

While in the middle of the pending responses development, I had run into an issue where `qr` was a form builder object from a `fields_for`, which is why I had added `qr.object.content`. However, I later added the `edit` action to the `if` condition in each of these partials which would have fixed that issue, but it went unnoticed.