### PR TITLE
wth - (SPARCDashboard) Tie Editable Fields with RMID Configuration

### DIFF
--- a/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
@@ -44,7 +44,7 @@
       .col-lg-10
         = form.text_field :short_title,
           class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
-          disabled: @protocol.research_master_id
+          disabled: RESEARCH_MASTER_ENABLED
 
     .form-group.row
       = form.label :title,
@@ -55,7 +55,7 @@
       .col-lg-10
         = form.text_field :title,
           class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
-          disabled: @protocol.research_master_id
+          disabled: RESEARCH_MASTER_ENABLED
 
     .form-group.row#funding-status
       = form.label :funding_status,

--- a/app/views/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/protocols/form/study_form_sections/_study_information.html.haml
@@ -40,7 +40,7 @@
       .col-lg-10
         = form.text_field :short_title,
           class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
-          disabled: @protocol.research_master_id
+          disabled: RESEARCH_MASTER_ENABLED
 
     .form-group.row
       = form.label :title,
@@ -51,7 +51,7 @@
       .col-lg-10
         = form.text_field :title,
           class: [('form-control'), (RESEARCH_MASTER_ENABLED ? 'rm-id-dependent rm-locked-fields' : '')],
-          disabled: @protocol.research_master_id
+          disabled: RESEARCH_MASTER_ENABLED
 
     .form-group.row#funding-status
       = form.label :funding_status,

--- a/spec/features/protocol/user_creates_study_spec.rb
+++ b/spec/features/protocol/user_creates_study_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'User creates study', js: true do
                   create(:line_item, service_request: @sr, sub_service_request: ssr, service: service)
 
     StudyTypeQuestionGroup.create(active: true)
+    stub_const("RESEARCH_MASTER_ENABLED", false)
   end
 
   context 'and clicks \'New Research Study\'' do


### PR DESCRIPTION
When RMID configuration is turned on (RESEARCH_MASTER_ENABLED == false), and a protocol has a RMID previously, there is currently no way to edit the Short Title or the Long Title.
Please tie the editing functions with the RMID configuration, so that the fields become editable when the configuration is turned off.

[#150408490]

Story - https://www.pivotaltracker.com/story/show/150408490