### PR TITLE
wth - (SPARCDashboard) Service Requests Table Simplification

### DIFF
--- a/app/helpers/dashboard/service_requests_helper.rb
+++ b/app/helpers/dashboard/service_requests_helper.rb
@@ -26,9 +26,9 @@ module Dashboard::ServiceRequestsHelper
 
   def protocol_panel_header_line service_request
     if service_request.status == "submitted"
-      "Service Request: #{service_request.id} - Submitted - #{format_date(service_request.submitted_at)}"
+      "Submitted - #{format_date(service_request.submitted_at)}"
     else
-      "Service Request: #{service_request.id} - #{AVAILABLE_STATUSES[service_request.status]} - #{format_date(service_request.updated_at)}"
+      "#{AVAILABLE_STATUSES[service_request.status]} - #{format_date(service_request.updated_at)}"
     end
   end
 

--- a/app/views/dashboard/service_requests/_protocol_service_request_show.html.haml
+++ b/app/views/dashboard/service_requests/_protocol_service_request_show.html.haml
@@ -17,36 +17,28 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.panel.panel-primary.service-request-info
-  .panel-heading
-    %h4.panel-title.pull-left
-      = protocol_panel_header_line(service_request)
-    .pull-right
-      - permission_to_edit = permission_to_edit || user.catalog_overlord
-      - if permission_to_edit
-        %div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'left', delay: '{"show":"500"}' }, title: t(:dashboard)[:service_requests][:tooltips][:modify_request] }
-          %button.btn.btn-warning.btn-sm.edit-service-request{ class: permission_to_edit ? '' : 'disabled', type: 'button', data: { permission: permission_to_edit.to_s, url: modify_request_button_url(service_request) } }
-            = t(:dashboard)[:service_requests][:modify_request]
-        %div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'bottom', delay: '{"show":"500"}' }, title: t(:dashboard)[:service_requests][:tooltips][:coverage_report] }
-          = link_to t(:dashboard)[:protocols][:service_requests][:coverage_report], service_request_path(service_request, format: :xlsx, show_signature_section: 1), class: 'btn btn-sm btn-success'
-    .clearfix
-  .panel-body
-    .bootstrap-table-dropdown-overflow
-      %div{ class: "service-requests-custom-toolbar-#{service_request.id}" }
-      %table.service-requests-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_sub_service_requests_path(format: :json, srid: service_request.id, show_view_ssr_back: show_view_ssr_back, sr_table: true), striped: 'true', toolbar: ".service-requests-custom-toolbar-#{service_request.id}", sort_name: 'srid', sort_order: 'ASC' } }
-        %thead.primary-header
-          %tr
-            %th.col-md-1{ data: { field: 'srid', align: 'left', sortable: 'true' } }
-              = t(:dashboard)[:service_requests][:srid]
-            %th.col-md-3{ data: { field: 'organization', align: 'left', sortable: 'true' } }
-              = t(:dashboard)[:service_requests][:organization]
-            %th.col-md-2{ data: { field: 'owner', align: 'left', sortable: 'true' } }
-              = t(:dashboard)[:service_requests][:owner]
-            %th.col-md-1{ data: { field: 'status', align: 'left', sortable: 'true' } }
-              = t(:dashboard)[:service_requests][:status]
-            %th.col-md-1{ data: {field: 'notifications', align: 'center' } }
-              = t(:dashboard)[:service_requests][:notifications]
-            %th.col-md-3{ data: { field: 'actions', align: 'center' } }
-              = t(:dashboard)[:service_requests][:actions][:header]
-            %th.col-md-1{ data: { field: 'surveys', align: 'center', visible: protocol.has_incomplete_additional_details?.to_s, switchable: 'false' } }
-              = t(:dashboard)[:service_requests][:additional_details][:header]
+
+.bootstrap-table-dropdown-overflow
+  %div{ class: "service-requests-custom-toolbar-#{service_request.id}" }
+    - permission_to_edit = permission_to_edit || user.catalog_overlord
+    - if permission_to_edit
+      %div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' }, title: t(:dashboard)[:service_requests][:tooltips][:modify_request] }
+        %button.btn.btn-warning.btn-sm.edit-service-request{ class: permission_to_edit ? '' : 'disabled', type: 'button', data: { permission: permission_to_edit.to_s, url: modify_request_button_url(service_request) } }
+          = t(:dashboard)[:service_requests][:modify_request]
+  %table.service-requests-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_sub_service_requests_path(format: :json, srid: service_request.id, show_view_ssr_back: show_view_ssr_back), striped: 'true', toolbar: ".service-requests-custom-toolbar-#{service_request.id}", sort_name: 'srid', sort_order: 'ASC' } }
+    %thead.primary-header
+      %tr
+        %th.col-md-1{ data: { field: 'srid', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:service_requests][:srid]
+        %th.col-md-3{ data: { field: 'organization', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:service_requests][:organization]
+        %th.col-md-2{ data: { field: 'owner', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:service_requests][:owner]
+        %th.col-md-1{ data: { field: 'status', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:service_requests][:status]
+        %th.col-md-1{ data: {field: 'notifications', align: 'center' } }
+          = t(:dashboard)[:service_requests][:notifications]
+        %th.col-md-3{ data: { field: 'actions', align: 'center' } }
+          = t(:dashboard)[:service_requests][:actions][:header]
+        %th.col-md-1{ data: { field: 'surveys', align: 'center', visible: protocol.has_incomplete_additional_details?.to_s, switchable: 'false' } }
+          = t(:dashboard)[:service_requests][:additional_details][:header]

--- a/app/views/dashboard/service_requests/_service_requests.html.haml
+++ b/app/views/dashboard/service_requests/_service_requests.html.haml
@@ -17,34 +17,47 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- protocol.service_requests.each do |sr|
+  .panel.panel-default#service-requests-panel
+    .panel-heading
+      %h4.panel-title.pull-left
+        = "#{t(:dashboard)[:protocols][:service_requests][:header]} - #{protocol_panel_header_line(sr)}"
+      .pull-right
+        .export-consolidated-request
+          .dropdown
+            %button.btn.btn-primary.btn-sm.dropdown-toggle.view-consolidated{ data: { placement: 'top', delay: '{"show":"500"}', toggle: 'dropdown' }, title: t(:dashboard)[:protocols][:service_requests][:tooltips][:consolidated_request] }
+              = t(:dashboard)[:protocols][:service_requests][:view_consolidated]
+            %ul.dropdown-menu
+              %li
+                %a.view-full-calendar-button{ data: { protocol_id: protocol.id, statuses_hidden: ['first_draft'] } }
+                  = t(:dashboard)[:protocols][:service_requests][:consolidated_all]
+              %li
+                %a.view-full-calendar-button{ data: { protocol_id: protocol.id, statuses_hidden: %w(draft first_draft) } }
+                  = t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts]
+          .dropdown
+            %button.btn.btn-primary.btn-sm.dropdown-toggle.export-consolidated{ data: { protocol_id: protocol.id, toggle: 'dropdown', placement: 'top', delay: '{"show":"500"}' }, title: t(:dashboard)[:protocols][:service_requests][:tooltips][:export_consolidated_request] }
+              = t(:dashboard)[:protocols][:service_requests][:export_consolidated]
+            %ul.dropdown-menu
+              %li
+                = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_all],
+                  dashboard_protocol_path(protocol, statuses_hidden: ['first_draft'], format: :xlsx)
+              %li
+                = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts],
+                  dashboard_protocol_path(protocol, statuses_hidden: %w(draft first_draft), format: :xlsx)
 
-.panel.panel-default#service-requests-panel
-  .panel-heading
-    %h4.panel-title.pull-left
-      = t(:dashboard)[:protocols][:service_requests][:header]
-    .pull-right
-      .export-consolidated-request
-        .dropdown
-          %button.btn.btn-primary.btn-sm.dropdown-toggle.view-consolidated{ data: { placement: 'top', delay: '{"show":"500"}', toggle: 'dropdown' }, title: t(:dashboard)[:protocols][:service_requests][:tooltips][:consolidated_request] }
-            = t(:dashboard)[:protocols][:service_requests][:view_consolidated]
-          %ul.dropdown-menu
-            %li
-              %a.view-full-calendar-button{ data: { protocol_id: protocol.id, statuses_hidden: ['first_draft'] } }= t(:dashboard)[:protocols][:service_requests][:consolidated_all]
-            %li
-              %a.view-full-calendar-button{ data: { protocol_id: protocol.id, statuses_hidden: %w(draft first_draft) } }= t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts]
-        .dropdown
-          %button.btn.btn-primary.btn-sm.dropdown-toggle.export-consolidated{ data: { protocol_id: protocol.id, toggle: 'dropdown', placement: 'top', delay: '{"show":"500"}' }, title: t(:dashboard)[:protocols][:service_requests][:tooltips][:export_consolidated_request] }
-            = t(:dashboard)[:protocols][:service_requests][:export_consolidated]
-          %ul.dropdown-menu
-            %li
-              = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_all], dashboard_protocol_path(protocol, statuses_hidden: ['first_draft'], format: :xlsx)
-            %li
-              = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts], dashboard_protocol_path(protocol, statuses_hidden: %w(draft first_draft), format: :xlsx)
-    .clearfix
-  .panel-body
-    - protocol.service_requests.each do |sr|
-      = render 'dashboard/service_requests/protocol_service_request_show', service_request: sr, protocol: protocol, user: user, permission_to_edit: permission_to_edit, view_only: view_only, show_view_ssr_back: show_view_ssr_back
-
+          = link_to t(:dashboard)[:protocols][:service_requests][:coverage_report],
+            service_request_path(sr, format: :xlsx, show_signature_section: 1),
+            class: 'btn btn-sm btn-success', data: { toggle: 'tooltip', placement: 'top', delay: '{"show":"500"}' },
+            title: t(:dashboard)[:service_requests][:tooltips][:coverage_report]
+      .clearfix
+    .panel-body
+      = render 'dashboard/service_requests/protocol_service_request_show',
+        service_request: sr,
+        protocol: protocol,
+        user: user,
+        permission_to_edit: permission_to_edit,
+        view_only: view_only,
+        show_view_ssr_back: show_view_ssr_back
 :javascript
   $('.view-consolidated').tooltip();
   $('.export-consolidated').tooltip();

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -221,7 +221,7 @@ en:
         add_document: "Add Document"
 
       service_requests:
-        header: "Service Requests"
+        header: "Requests"
         view_consolidated: "View Consolidated Request"
         export_consolidated: "Export Consolidated Request"
         coverage_report: 'Coverage Analysis Report'

--- a/spec/features/dashboard/protocols/index/requests_modal_spec.rb
+++ b/spec/features/dashboard/protocols/index/requests_modal_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'requests modal', js: true do
       page = visit_protocols_index_page
       page.search_results.protocols.first.requests_button.click
       expect(page).to have_requests_modal
-      page.requests_modal.service_requests.first.modify_request_button.click
+      page.requests_modal.modify_request_button.click
       wait_for_javascript_to_finish
 
       expect(URI.parse(current_url).path).to eq "/service_requests/#{service_request.id}/catalog"
@@ -78,7 +78,7 @@ RSpec.describe 'requests modal', js: true do
 
       expect(page).to have_requests_modal
 
-      page.requests_modal.service_requests.first.sub_service_requests.first.view_button.click
+      page.requests_modal.sub_service_requests.first.view_button.click
       wait_for_javascript_to_finish
 
       expect(page).to have_selector ".modal-dialog.user-view-ssr-modal"
@@ -93,7 +93,7 @@ RSpec.describe 'requests modal', js: true do
 
       expect(page).to have_requests_modal
 
-      page.requests_modal.service_requests.first.sub_service_requests.first.edit_button.click
+      page.requests_modal.sub_service_requests.first.edit_button.click
       wait_for_javascript_to_finish
 
       expect(URI.parse(current_url).path).to eq "/service_requests/#{service_request.id}/catalog"
@@ -107,7 +107,7 @@ RSpec.describe 'requests modal', js: true do
       wait_for_javascript_to_finish
       expect(page).to have_requests_modal
 
-      page.requests_modal.service_requests.first.sub_service_requests.first.admin_edit_button.click
+      page.requests_modal.sub_service_requests.first.admin_edit_button.click
       wait_for_javascript_to_finish
 
       expect(URI.parse(current_url).path).to eq '/dashboard/sub_service_requests/9999'

--- a/spec/features/dashboard/protocols/show/authorized_users/add_authorized_user_spec.rb
+++ b/spec/features/dashboard/protocols/show/authorized_users/add_authorized_user_spec.rb
@@ -218,7 +218,7 @@ RSpec.feature 'User wants to add an authorized user', js: true do
       end
 
       scenario 'and sees the Modify Request button for all SRs' do
-        expect(@page).to have_selector('.panel-heading .edit-service-request')
+        expect(@page).to have_selector('.panel-body .edit-service-request')
       end
     end
   end

--- a/spec/support/pages/dashboard/protocols/index_page.rb
+++ b/spec/support/pages/dashboard/protocols/index_page.rb
@@ -119,15 +119,13 @@ module Dashboard
       # appears after clicking Requests button in Search Results table
       section :requests_modal, "#requests-modal" do
         # the collection of all blue-header'd tables titled by 'Service Request: <digits>''
-        sections :service_requests, ".panel", text: /Service Request: [\d]+/ do
-          element :notes_button, :button, "Notes"
-          element :modify_request_button, :button, "Modify Request"
+        element :notes_button, :button, "Notes"
+        element :modify_request_button, :button, "Modify Request"
 
-          sections :sub_service_requests, "tbody tr" do
-            element :view_button, :button, "View"
-            element :edit_button, :button, "Edit"
-            element :admin_edit_button, :button, "Admin Edit"
-          end
+        sections :sub_service_requests, "tbody tr" do
+          element :view_button, :button, "View"
+          element :edit_button, :button, "Edit"
+          element :admin_edit_button, :button, "Admin Edit"
         end
       end
 

--- a/spec/support/pages/dashboard/protocols/show_page.rb
+++ b/spec/support/pages/dashboard/protocols/show_page.rb
@@ -105,7 +105,7 @@ module Dashboard
       element :consolidated_request_exclude_draft, "a", text: /Exclude Draft/
 
       # actual service request panels
-      sections :service_requests, '.panel-primary', text: /Service Request: \d+/ do
+      sections :service_requests, '#service-requests-panel' do
         element :modify_request_button, :button, text: "Modify Request"
 
         sections :ssrs, 'tbody tr' do

--- a/spec/views/dashboard/service_requests/_protocol_service_request_show.html.haml_spec.rb
+++ b/spec/views/dashboard/service_requests/_protocol_service_request_show.html.haml_spec.rb
@@ -53,43 +53,6 @@ RSpec.describe 'dashboard/service_requests/protocol_service_request_show', type:
       show_view_ssr_back: false)
   end
 
-  describe 'header' do
-    context 'submitted ServiceRequest' do
-      it 'should display id, status, and submitted date' do
-        service_request = create(:service_request_without_validations,
-          id: 9999,
-          protocol: protocol,
-          status: 'submitted',
-          submitted_at: DateTime.now)
-        create(:sub_service_request,
-          ssr_id: '0001',
-          service_request: service_request,
-          organization: organization)
-
-        render_protocol_service_request_show service_request
-
-        expect(response).to have_content "Service Request: 9999 - Submitted - #{service_request.submitted_at.strftime('%D')}"
-      end
-    end
-
-    context 'unsubmitted ServiceRequest' do
-      it 'should display id, status, and last modified date' do
-        service_request = create(:service_request_without_validations,
-          id: 9999,
-          protocol: protocol,
-          status: 'draft')
-        create(:sub_service_request,
-          ssr_id: '0001',
-          service_request: service_request,
-          organization: organization)
-
-        render_protocol_service_request_show service_request
-
-        expect(response).to have_content "Service Request: 9999 - Draft - #{service_request.updated_at.strftime('%D')}"
-      end
-    end
-  end
-
   describe '"Modify Request" button' do
     let!(:service_request) do
       create(:service_request_without_validations,


### PR DESCRIPTION
Background: Previously, a protocol could have multiple service requests underneath, which then have multiple sub-service-requests, so the Service Requests section has nested bootstrap tables. We have merged the multiple Service Requests, so that each protocol only have 1  Service Request.

To simplify the user interface, please;
1). Remove the middle layer of the "Service Request" table;
2). Move the "Add / Modify Request" button and "Coverage Analysis Report" button to the corresponding locations to simplify the user interface and consistent with the other locales;
3). Delete the Service Request # that was shown in the middle layer, but move the SR status and date to be on the higher "Requests" table.

See the mockup below for more details.

[#150236071]

Story - https://www.pivotaltracker.com/story/show/150236071

<img width="1267" alt="screen shot 2017-08-22 at 11 20 38 am" src="https://user-images.githubusercontent.com/8355974/29573067-f81b90ce-872b-11e7-817b-b5e0241e951a.png">
