### PR TITLE
JM - removed pointer-events for disabled steps [#150022135]

### DIFF
--- a/app/assets/stylesheets/proper/steps.sass
+++ b/app/assets/stylesheets/proper/steps.sass
@@ -106,6 +106,9 @@
   .step-text:hover, .right-arrow:hover
     cursor: pointer
 
+.disabled_steps
+  pointer-events: none
+
 .step-btn:focus
   outline: 0
 

--- a/app/helpers/service_requests_helper.rb
+++ b/app/helpers/service_requests_helper.rb
@@ -90,7 +90,7 @@ module ServiceRequestsHelper
       content_tag(:div,
         content_tag(:div, raw(text), class: "btn step-text")+
         content_tag(:div, '', class: "right-arrow"),
-        class: "step-btn step-btn-#{color}"
+        class: "step-btn step-btn-#{color} disabled_steps"
       )
     else
       link_to(


### PR DESCRIPTION
On the confirmation page, hover effect was removed to indicate that steps are disabled and not "clickable"