### PR TITLE
Removing editable_statuses from obis setup

### DIFF
--- a/config/initializers/01_obis_setup.rb
+++ b/config/initializers/01_obis_setup.rb
@@ -71,7 +71,6 @@ begin
   CONSTANTS_YML_OVERRIDE                    = application_config['constants_yml_override'] || ''
   SYSTEM_SATISFACTION_SURVEY                = application_config['system_satisfaction_survey'] || false
   NO_REPLY_FROM                             = application_config['no_reply_from']
-  EDITABLE_STATUSES                         = application_config['editable_statuses'] || {}
   UPDATABLE_STATUSES                        = application_config['updatable_statuses'] || []
   FINISHED_STATUSES                         = application_config['finished_statuses'] || []
   REMOTE_SERVICE_NOTIFIER_PROTOCOL          = application_config['remote_service_notifier_protocol']


### PR DESCRIPTION
This was accidentally merged in early, I'm recreating the original in this pull request, but pointed at v3.0.0b.