### PR TITLE
Header logos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
-site_name=development
 institution_logo=/assets/institution_logo2017.png
 org_logo=/assets/org_logo2017.png

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+site_name=development
+SPARC_VERSION=v3.0.0
+institution_logo=/assets/institution_logo2017.png
+org_logo=/assets/org_logo2017.png

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 site_name=development
-SPARC_VERSION=v3.0.0
 institution_logo=/assets/institution_logo2017.png
 org_logo=/assets/org_logo2017.png

--- a/app/views/layouts/_header_logos.html.haml
+++ b/app/views/layouts/_header_logos.html.haml
@@ -21,7 +21,7 @@
 .row.no-margin.text-center
   .col-md-3
     %a{ href: HEADER_LINK_1, class: 'org-logo' }
-      = image_tag 'sctr_header_sized.jpg', alt: 'org_logo', height: 140
+      = image_tag ENV['org_logo'] || 'sctr_header_sized.jpg', alt: 'org_logo', height: 140
   .col-md-6
     - if location == "proper"
       %a{ href: HEADER_LINK_2_PROPER, class: 'sparc-request-header' }
@@ -31,4 +31,4 @@
         = image_tag 'dashboard/logos/dashboard_logo.jpg', alt: 'dashboard_logo', height: 110
   .col-md-3
     %a{ href: HEADER_LINK_3, target: '_blank', class: 'institution-logo' }
-      = image_tag 'musc_header.jpg', alt: 'institution_logo', height: 140
+      = image_tag ENV['institution_logo'] || 'musc_header.jpg', alt: 'institution_logo', height: 140

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
 
 set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/setup_load_paths.rb', 'config/application.yml', 'config/ldap.yml', 'config/epic.yml')
 
-set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system')
+set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'public/assets')
 
 namespace :survey do
   desc "load/update a survey"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
 
 set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/setup_load_paths.rb', 'config/application.yml', 'config/ldap.yml', 'config/epic.yml')
 
-set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'public/assets')
+set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'public/assets', 'public/images')
 
 namespace :survey do
   desc "load/update a survey"


### PR DESCRIPTION
manage logos images with environment variables.
1. Usage:

add 
```
institution_logo=/assets/uuhsc_logo_stacked-retina-color-trans.png
org_logo=/assets/uofu_logo_retina-color-trans.png
```

to `.env` file in root directory of deploy directory.

`.env` can be managed by capistrano.

2. create a directory `assets` under `public` directory and add images in `assets` directory.

This can be done with capistrano.

to create symlink, just add this to cap deploy.rb
```
set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'public/assets', 'public/images')
``` 
