### PR TITLE
wth - (SPARCDashboard) Epic Queue Page Improvements

### DIFF
--- a/app/controllers/dashboard/epic_queue_records_controller.rb
+++ b/app/controllers/dashboard/epic_queue_records_controller.rb
@@ -22,6 +22,7 @@ class Dashboard::EpicQueueRecordsController < Dashboard::BaseController
 
   def index
     @epic_queue_records = EpicQueueRecord.with_valid_protocols
+      .order(created_at: :desc)
     respond_to do |format|
       format.json
     end

--- a/app/views/layouts/dashboard/_dashboard_header.html.haml
+++ b/app/views/layouts/dashboard/_dashboard_header.html.haml
@@ -35,7 +35,7 @@
           %li
             %button.btn.btn-info.navbar-btn#survey-btn{ type: 'button', title: t(:dashboard)[:navbar][:tooltips][:surveys], data: { toggle: 'tooltip', placement: 'bottom', delay: '{"show":"500"}' } }
               = t(:dashboard)[:navbar][:surveys]
-        - if EPIC_QUEUE_ACCESS.include?(user.ldap_uid)
+        - if USE_EPIC && EPIC_QUEUE_ACCESS.include?(user.ldap_uid)
           %li
             %button.btn.btn-info.navbar-btn#epic-queue-btn{ type: 'button', title: t(:dashboard)[:navbar][:tooltips][:epic_queue], data: { toggle: 'tooltip', placement: 'bottom', delay: '{"show":"500"}'} }
               = t(:dashboard)[:navbar][:epic_queue]


### PR DESCRIPTION
Background: The "Epic Queue" button on SPARCDashboard gives the authorized users a view of the current and past list of protocols that are awaiting to or already been sent to Epic from SPARC;
Please:
1). Tie the display of the "Epic Queue" button to the Epic configuration, because currently it is showing when Epic-related functions are turned off;
2). Please default the display of the "Past" tab to be showing the protocol with the most recent "Last Queue Date" first, for better usability.

[#150616151]

https://www.pivotaltracker.com/story/show/150616151