### PR TITLE
wth - (SPARCDashboard) Admin Edit Non-clinical Services Tab Missing H…

### DIFF
--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -306,6 +306,8 @@ en:
       destroyed: "Non-clinical Services Destroyed!"
       table:
         service: "Service"
+        unit_requested: "Unit Requested"
+        unit_type: "Unit Type"
         quantity_requested: "Qty Requested"
         quantity_type: "Qty Type"
         cost: "Cost"


### PR DESCRIPTION
…eaders

On SPARCDashboard "Admin Edit" section Non-clinical Services tab, the "Unit Requested" and "Unit Type" columns are missing labels both on the column selector and on the column header.

[#150852869]

https://www.pivotaltracker.com/story/show/150852869