### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Update/Pull Pro# for Validated …

### DIFF
--- a/app/views/protocols/view_details/_research_involving.html.haml
+++ b/app/views/protocols/view_details/_research_involving.html.haml
@@ -57,6 +57,8 @@
                   = t(:protocols)[:studies][:research_involving][:humans][:pro_number]
                 .col-lg-8
                   = human_info.pro_number
+                  = display_rmid_validated_protocol(human_info.protocol, 'Pro Number')
+
             %tr
               %td
                 %label.col-lg-4

--- a/lib/tasks/update_protocol_with_validated_rm.rake
+++ b/lib/tasks/update_protocol_with_validated_rm.rake
@@ -49,6 +49,11 @@ namespace :data do
           title: vrm['long_title'],
           rmid_validated: true
         )
+        if protocol_to_update.has_human_subject_info?
+          protocol_to_update
+            .human_subjects_info
+            .update_attribute(:pro_number, vrm['pro_number'])
+        end
       end
       progress_bar.increment!
     end


### PR DESCRIPTION
…Protocols

Background: Once a protocol has a RMID associated, and that RMID is validated (because its eIRB record is one of the validated states), the short title and long title has now being updated via a cronjob, and the "Updated to corresponding Research Master ID record...." label next to the fields to indicate.

Please add the functionality of updating Pro# according to the eIRB Pro# associated with a validated eIRB record via RMID of the protocol, and display the validation visual cue.

[#151209478]

Story - https://www.pivotaltracker.com/story/show/151209478

<img width="960" alt="screen shot 2017-09-22 at 10 39 29 am" src="https://user-images.githubusercontent.com/8355974/30749757-5be6cdc6-9f82-11e7-86ef-56370ec34604.png">
