### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Tie Display of Indirect Cost Ra…

### DIFF
--- a/app/views/dashboard/protocols/form/study_form_sections/_optional_information.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_optional_information.html.haml
@@ -30,10 +30,11 @@
       .col-lg-10
         = form.text_field :udak_project_number, class: 'form-control'
 
-    .form-group.row
-      = form.label :indirect_cost_rate, t(:protocols)[:studies][:optional_information][:rate], class: 'col-lg-2 control-label'
-      .col-lg-10
-        = form.text_field :indirect_cost_rate, class: 'form-control'
+    - if USE_INDIRECT_COST
+      .form-group.row
+        = form.label :indirect_cost_rate, t(:protocols)[:studies][:optional_information][:rate], class: 'col-lg-2 control-label'
+        .col-lg-10
+          = form.text_field :indirect_cost_rate, class: 'form-control'
 
     .form-group.row.funding_status_dependent.pending_funding{ display_if(protocol.funding_status, "pending_funding") }
       = form.label :funding_rfa, t(:protocols)[:studies][:optional_information][:rfa], class: 'col-lg-2 control-label'

--- a/app/views/protocols/form/study_form_sections/_optional_information.html.haml
+++ b/app/views/protocols/form/study_form_sections/_optional_information.html.haml
@@ -30,10 +30,11 @@
       .col-lg-10
         = form.text_field :udak_project_number, class: 'form-control'
 
-    .form-group.row
-      = form.label :indirect_cost_rate, t(:protocols)[:studies][:optional_information][:rate], class: 'col-lg-2 control-label'
-      .col-lg-10
-        = form.text_field :indirect_cost_rate, class: 'form-control'
+    - if USE_INDIRECT_COST
+      .form-group.row
+        = form.label :indirect_cost_rate, t(:protocols)[:studies][:optional_information][:rate], class: 'col-lg-2 control-label'
+        .col-lg-10
+          = form.text_field :indirect_cost_rate, class: 'form-control'
 
     .form-group.row.funding_status_dependent.pending_funding{ display_if(protocol.funding_status, "pending_funding") }
       = form.label :funding_rfa, t(:protocols)[:studies][:optional_information][:rfa], class: 'col-lg-2 control-label'


### PR DESCRIPTION
…te with Configuration

Background: The indirect cost calculations have been tied with the configuration, so that when the configuration is turned off, the rows of indirect calculations don't show up. However, in the Protocol information section, the "Indirect Cost Rate" field (not-required) is still showing up for users to fill in, which is confusing and seems.

Please tie the display of the Indirect Cost Rate with configuration (use_indirect_cost), too; So that when use_indirect_cost: false, the field doesn't display on SPARCRequest Step 2 and SPARCDashboard Protocol Information section. See attached screenshot for more details.

[#151174598]

Story - https://www.pivotaltracker.com/story/show/151174598