### PR TITLE
wth - (SPARCCatalog) Add Order Code In Epic Interface Box

### DIFF
--- a/app/controllers/catalog_manager/services_controller.rb
+++ b/app/controllers/catalog_manager/services_controller.rb
@@ -251,6 +251,7 @@ class CatalogManager::ServicesController < CatalogManager::AppController
         :cpt_code,
         :eap_id,
         :charge_code,
+        :order_code,
         :revenue_code,
         :organization_id,
         :send_to_epic,

--- a/app/views/catalog_manager/services/_form.html.haml
+++ b/app/views/catalog_manager/services/_form.html.haml
@@ -135,6 +135,9 @@
               %th= f.label :revenue_code, t(:organization_form)[:revenue_code]
               %td= f.text_field :revenue_code
             %tr
+              %th= f.label :order_code, t(:organization_form)[:order_code]
+              %td= f.text_field :order_code
+            %tr
               %th= f.label :send_to_epic, t(:organization_form)[:send_to_epic]
               %td= f.check_box :send_to_epic
         %br

--- a/app/views/catalog_manager/services/_new_form.html.haml
+++ b/app/views/catalog_manager/services/_new_form.html.haml
@@ -115,6 +115,9 @@
                 %th= f.label :revenue_code, t(:organization_form)[:revenue_code]
                 %td= f.text_field :revenue_code
               %tr
+                %th= f.label :order_code, t(:organization_form)[:order_code]
+                %td= f.text_field :order_code
+              %tr
                 %th= f.label :send_to_epic, t(:organization_form)[:send_to_epic]
                 %td= f.check_box :send_to_epic
 

--- a/app/views/service_requests/show.xlsx.axlsx
+++ b/app/views/service_requests/show.xlsx.axlsx
@@ -191,7 +191,7 @@ wb.add_worksheet(name: "Review") do |sheet|
           next if value[:line_items].exclude?(line_item) || (@sub_service_request.present? && line_item.sub_service_request_id != @sub_service_request.id)
 
           totals_hash = line_items_visit.try(:per_subject_rt_indicated)
-          service_row = [line_item.service.name, line_item.service.cpt_code, ""]
+          service_row = [line_item.service.name, line_item.service.cpt_code, line_item.service.order_code]
 
           if line_items_visit.notes.empty?
             service_row += [""]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,6 +879,7 @@ en:
     new_sp: "New Service Provider"
     one_time_fee: "Non-clinical (Non-Per </br> Patient/Visit) Services"
     order: "Order"
+    order_code: "Order Code"
     otf_field_errors: "If the Pricing Map is a non-clinical service (the box is checked), Quantity Type, Quantity Minimum, Unit Type, and Unit Maximum are required."
     per_patient_errors: "Clinical Quantity Type, Unit Factor, and Units Per Qty Maximum are required on all Per Patient Pricing Maps."
     pricing_maps: "Pricing Maps"

--- a/db/migrate/20170922153853_add_order_code_to_services.rb
+++ b/db/migrate/20170922153853_add_order_code_to_services.rb
@@ -1,0 +1,5 @@
+class AddOrderCodeToServices < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :order_code, :string, after: :organization_id
+  end
+end

--- a/spec/api/v1/services/get_service_spec.rb
+++ b/spec/api/v1/services/get_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'order_code'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'process_ssrs_organization').
                                 sort
 
@@ -79,7 +79,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'order_code'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'process_ssrs_organization', 'line_items').
                                 sort
 

--- a/spec/api/v1/services/get_services_spec.rb
+++ b/spec/api/v1/services/get_services_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'order_code'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'process_ssrs_organization').
                                 sort
 
@@ -87,7 +87,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'order_code'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'process_ssrs_organization', 'line_items').
                                 sort
 

--- a/spec/api/v1/services/get_services_with_ids_spec.rb
+++ b/spec/api/v1/services/get_services_with_ids_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'order_code'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'process_ssrs_organization').
                                 sort
 
@@ -91,7 +91,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:service).attributes.
                                 keys.
-                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at'].include?(key) }.
+                                reject { |key| ['id', 'created_at', 'updated_at', 'deleted_at', 'order_code'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'process_ssrs_organization', 'line_items').
                                 sort
 


### PR DESCRIPTION
Background: The order codes are used for lab orders in Epic as unique identifiers. We have previously added the "Order Code" column into the SPARCDashboard Coverage Analysis report, without a place to enter the codes into the system.

Please:
1). Add a order_code column into the services table;
2). In SPARCCatalog services "Epic Interface" box, add the "Order Code" field for users to enter the codes;
3). Link the SPARCDashboard Coverage Analysis report "Order Code" column to pull in corresponding data.

[#151065150]

Story - https://www.pivotaltracker.com/story/show/151065150