### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Tie Display of Indirect Cost Ra…

### DIFF
--- a/app/views/protocols/view_details/_optional_information.html.haml
+++ b/app/views/protocols/view_details/_optional_information.html.haml
@@ -30,12 +30,13 @@
             = t(:protocols)[:studies][:optional_information][:udak_project_number]
           .col-lg-8
             = protocol.udak_project_number
-      %tr.row
-        %td
-          %label.col-lg-4
-            = t(:protocols)[:studies][:optional_information][:rate]
-          .col-lg-8
-            = protocol.indirect_cost_rate
+      - if USE_INDIRECT_COST
+        %tr.row
+          %td
+            %label.col-lg-4
+              = t(:protocols)[:studies][:optional_information][:rate]
+            .col-lg-8
+              = protocol.indirect_cost_rate
       %tr.row
         %td
           %label.col-lg-4


### PR DESCRIPTION
…te with Configuration

Background: The indirect cost calculations have been tied with the configuration, so that when the configuration is turned off, the rows of indirect calculations don't show up. However, in the Protocol information section, the "Indirect Cost Rate" field (not-required) is still showing up for users to fill in, which is confusing and seems.
Please tie the display of the Indirect Cost Rate with configuration (use_indirect_cost), too; So that when use_indirect_cost: false, the field doesn't display on SPARCRequest Step 2 and SPARCDashboard Protocol Information section. See attached screenshot for more details.

Forgot view details :(

[#151174598]

Story - https://www.pivotaltracker.com/story/show/151174598