### PR TITLE
JL - add service bug

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -58,7 +58,9 @@ class ProtocolsController < ApplicationController
       @service_request.update_attribute(:status, 'draft')
       @service_request.sub_service_requests.update_all(status: 'draft')
 
-      @protocol.update_attribute(:next_ssr_id, @service_request.sub_service_requests.count + 1)
+      last_ssr_id = @service_request.sub_service_requests.sort_by(&:ssr_id).last.ssr_id.to_i
+
+      @protocol.update_attribute(:next_ssr_id, last_ssr_id + 1)
 
       if USE_EPIC && @protocol.selected_for_epic
         @protocol.ensure_epic_user


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/151189804

When assigning a next_ssr_id to a protocol for the first time, using the sub service request count is problematic. The user could have deleted an ssr while setting up their services, which would throw using the count off. 

For example: we initially have 0001 and 0002, then we delete 0001. When we then go to create the protocol, the controller is going to assign it the next_ssr_id of 2 instead of 3.