### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Epic User Update New Feature

### DIFF
--- a/app/controllers/dashboard/epic_queues_controller.rb
+++ b/app/controllers/dashboard/epic_queues_controller.rb
@@ -26,7 +26,13 @@ class Dashboard::EpicQueuesController < Dashboard::BaseController
   def index
     respond_to do |format|
       format.json do
-        @epic_queues = EpicQueue.where(attempted_push: false)
+        if params[:user_change]
+          @epic_queues = EpicQueue.where(
+            user_change: true
+          )
+        else
+          @epic_queues = EpicQueue.where(attempted_push: false)
+        end
 
         render
       end

--- a/app/lib/associated_user_creator.rb
+++ b/app/lib/associated_user_creator.rb
@@ -24,6 +24,7 @@ class AssociatedUserCreator
   def initialize(params)
     protocol = Protocol.find(params[:protocol_id])
     @protocol_role = protocol.project_roles.build(params)
+    eqm = EpicQueueManager.new(protocol, @protocol_role)
 
     if @protocol_role.unique_to_protocol? && @protocol_role.fully_valid?
       @successful = true
@@ -33,12 +34,15 @@ class AssociatedUserCreator
         end
       end
       @protocol_role.save
-      
+
       protocol.email_about_change_in_authorized_user(@protocol_role, "add")
 
       if USE_EPIC && protocol.selected_for_epic && !QUEUE_EPIC
         Notifier.notify_for_epic_user_approval(protocol).deliver
       end
+
+      eqm.create_epic_queue
+
     else
       @successful = false
     end
@@ -48,3 +52,4 @@ class AssociatedUserCreator
     @successful
   end
 end
+

--- a/app/lib/associated_user_updater.rb
+++ b/app/lib/associated_user_updater.rb
@@ -24,6 +24,7 @@ class AssociatedUserUpdater
   def initialize(params)
     @protocol_role = ProjectRole.find(params[:id])
     protocol = @protocol_role.protocol
+    eqm = EpicQueueManager.new(protocol, @protocol_role)
 
     epic_rights = @protocol_role.epic_rights.to_a # use to_a to eval ActiveRecord::Relation
     @protocol_role.assign_attributes(params[:project_role])
@@ -53,9 +54,12 @@ class AssociatedUserUpdater
           Notifier.notify_for_epic_rights_changes(protocol, @protocol_role, epic_rights).deliver
         end
       end
+
+      eqm.create_epic_queue
     else
       @success = false
     end
+
   end
 
   def successful?
@@ -66,3 +70,4 @@ class AssociatedUserUpdater
     @protocol_role
   end
 end
+

--- a/app/lib/epic_queue_manager.rb
+++ b/app/lib/epic_queue_manager.rb
@@ -1,0 +1,31 @@
+class EpicQueueManager
+
+  def initialize(protocol, protocol_role)
+    @protocol = protocol
+    @protocol_role = protocol_role
+  end
+
+  def create_epic_queue
+    if USE_EPIC && withheld_from_epic?(@protocol) && @protocol_role.epic_access
+      unless withheld_epic_queue?(@protocol)
+        EpicQueue.create(
+          protocol_id: @protocol.id,
+          identity_id: @protocol_role.identity_id,
+          user_change: true
+        )
+      end
+    end
+  end
+
+
+  private
+
+  def withheld_from_epic?(protocol)
+    protocol.selected_for_epic && !protocol.last_epic_push_time.nil?
+  end
+
+  def withheld_epic_queue?(protocol)
+    EpicQueue.where(protocol_id: protocol.id, attempted_push: false).present?
+  end
+end
+

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -416,14 +416,14 @@ class Protocol < ApplicationRecord
   # Note: this method is called inside a child thread by the service
   # requests controller.  Be careful adding code here that might not be
   # thread-safe.
-  def push_to_epic(epic_interface, origin, identity_id=nil)
+  def push_to_epic(epic_interface, origin, identity_id=nil, withhold_calendar=false)
     begin
       self.last_epic_push_time = Time.now
       self.last_epic_push_status = 'started'
       save(validate: false)
 
       Rails.logger.info("Sending study message to Epic")
-      epic_interface.send_study(self)
+      withhold_calendar ? epic_interface.send_study_creation(self) : epic_interface.send_study(self)
 
       self.last_epic_push_status = 'complete'
       save(validate: false)

--- a/app/views/dashboard/epic_queues/_auth_user_change_list.html.haml
+++ b/app/views/dashboard/epic_queues/_auth_user_change_list.html.haml
@@ -1,0 +1,37 @@
+-# Copyright © 2011-2017 MUSC Foundation for Research Development~
+-# All rights reserved.~
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+-# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+-# derived from this software without specific prior written permission.~
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+.bootstrap-table-dropdown-overflow
+  #epic-queues-custom-toolbar
+  %table.epic-queue-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: dashboard_epic_queues_path(user_change: true), striped: 'true', toolbar: '#epic-queues-custom-toolbar' } }
+    %thead.primary-header
+      %tr
+        %th{data: { field: "protocol", align: "left", sortable: 'true', class: 'text-primary' } }
+          = t(:epic_queues)[:protocol]
+        %th{data: { field: "pis", align: "left", sortable: 'true' } }
+          = t(:epic_queues)[:PIs]
+        %th{data: { field: 'created_at', align: 'left', sortable: 'true' } }
+          = t(:epic_queues)[:created_at]
+        %th{data: { field: 'name', align: 'left', sortable: 'true' } }
+          = t(:epic_queues)[:by]
+        %th{data: { field: "date", align: "left", sortable: 'true', sorter: "dateSorter" } }
+          = t(:epic_queues)[:date]
+        %th{data: { field: "status", align: "left", sortable: 'true' } }
+          = t(:epic_queues)[:status]

--- a/app/views/dashboard/epic_queues/_epic_queue_list.html.haml
+++ b/app/views/dashboard/epic_queues/_epic_queue_list.html.haml
@@ -25,9 +25,15 @@
           data: { toggle: 'tab' }
       %li
         = link_to t(:dashboard)[:epic_queues][:headers][:past], '#past', data: { toggle: 'tab' }
+      %li
+        = link_to t(:dashboard)[:epic_queues][:headers][:authorized_user_update],
+          '#authorized-user-update',
+          data: { toggle: 'tab' }
   .panel-body
     .tab-content
       .tab-pane.fade.in.active#current
         = render "epic_queues_table"
       .tab-pane.fade#past
         = render "epic_queue_records_table"
+      .tab-pane.fade#authorized-user-update
+        = render "auth_user_change_list"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -59,6 +59,7 @@ en:
       headers:
         current: "Current"
         past: "Past"
+        authorized_user_update: "Authorized User Update"
 
     ##################
     #  FULFILLMENTS  #

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,3 +26,7 @@ end
 every 1.day, :at => '4:30 am' do
   rake "update_protocol_with_validated_rm"
 end
+
+every 1.day, :at => '5:00 pm' do
+  rake 'send_to_epic'
+end

--- a/db/migrate/20171003152920_add_user_change_to_epic_queues.rb
+++ b/db/migrate/20171003152920_add_user_change_to_epic_queues.rb
@@ -1,0 +1,5 @@
+class AddUserChangeToEpicQueues < ActiveRecord::Migration[5.1]
+  def change
+    add_column :epic_queues, :user_change, :boolean, default: false
+  end
+end

--- a/lib/tasks/send_to_epic.rake
+++ b/lib/tasks/send_to_epic.rake
@@ -1,0 +1,10 @@
+task send_to_epic: :environment do
+
+  epic_queues = EpicQueue.where(user_change: true, attempted_push: false)
+
+  epic_queues.each do |eq|
+    p = Protocol.find(eq.protocol_id)
+    p.push_to_epic(EPIC_INTERFACE, nil, nil, true)
+  end
+end
+


### PR DESCRIPTION
Background: After a protocol is pushed to Epic, and new user comes into the study team, currently it is a manual process to update both in SPARC and Epic with the new user.

When a new user who has Epic access (project_roles.epic_access = 1) is being "Added" to a protocol that has been pushed to epic before (protocols.selected_for_epic = 1; and protocols. last_epic_push_time is NOT NULL), a SOAP message will pushed to Epic with only the protocol information and the identity information without the timeline (CYCLE).

1). Please queue the authorized user change (on protocols that have already been pushed to Epic) and send it out daily to Epic.

2). Please display the protocols that have the authorized user change on a tab on the "Epic Queue" page.

[#145759415]

Story - https://www.pivotaltracker.com/story/show/145759415