### PR TITLE
wth - (SPARCRequest) Epic Push Origin Bug

### DIFF
--- a/app/controllers/dashboard/epic_queues_controller.rb
+++ b/app/controllers/dashboard/epic_queues_controller.rb
@@ -28,6 +28,7 @@ class Dashboard::EpicQueuesController < Dashboard::BaseController
       format.json do
         if params[:user_change]
           @epic_queues = EpicQueue.where(
+            attempted_push: false,
             user_change: true
           )
         else

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -294,7 +294,7 @@ class ProtocolsController < ApplicationController
     # Thread.new do
     begin
       # Do the actual push.  This might take a while...
-      protocol.push_to_epic(EPIC_INTERFACE, "pi_email_approval", current_user.id)
+      protocol.push_to_epic(EPIC_INTERFACE, "submission_push", current_user.id)
       errors = EPIC_INTERFACE.errors
       session[:errors] = errors unless errors.empty?
       @epic_errors = true unless errors.empty?

--- a/lib/tasks/send_to_epic.rake
+++ b/lib/tasks/send_to_epic.rake
@@ -4,7 +4,10 @@ task send_to_epic: :environment do
 
   epic_queues.each do |eq|
     p = Protocol.find(eq.protocol_id)
-    p.push_to_epic(EPIC_INTERFACE, nil, nil, true)
+    p.push_to_epic(EPIC_INTERFACE, 'admin_push', eq.identity_id, true)
+    if p.last_epic_push_status == 'complete'
+      eq.update_attribute(:attempted_push, true)
+    end
   end
 end
 


### PR DESCRIPTION
1). There are only 2 types/origins of Epic push: Submission Push and Admin Push. However, there is a 3rd origin "pi_email_approval" showing up in the epic_queue_records table (see screenshot #1). If those are actually overlord pushes, please use "overlord_push" for data records instead. Please look into what's causing that, make historical data consistent, and fix the bug.

2). In the epic_queues table, it appears to be showing protocols that has already been pushed to Epic too, when it should only show the ones that still awaiting to be pushed. See screenshot #2.

[#151955764]

Story - https://www.pivotaltracker.com/story/show/151955764