### PR TITLE
wth - (SPARC/RMID API) Handling Deleted RMID Record

### DIFF
--- a/app/controllers/research_masters_controller.rb
+++ b/app/controllers/research_masters_controller.rb
@@ -1,0 +1,22 @@
+class ResearchMastersController < ApplicationController
+  #RMID will send a token to this controller action, preventing any other
+  #accessibility to this route
+  before_action :restrict_access
+
+
+  def update
+    @protocol = Protocol.find(params[:protocol_id])
+    #currently, this route is only used when an RMID is deleted, thus we set it
+    #to nil
+    @protocol.update_attribute(:research_master_id, nil)
+    head :ok
+  end
+
+  private
+
+  def restrict_access
+    api_key = Setting.find_by(key: 'research_master_api_token').value == params[:access_token]
+    head :unauthorized unless api_key
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ SparcRails::Application.routes.draw do
   end
 
   resources :protocols, except: [:index, :destroy] do
+    resource :research_master, only: [:update]
     member do
       put :update_protocol_type
       get :approve_epic_rights


### PR DESCRIPTION
Background: When a RMID is used by a SPARC protocol, that SPARC protocol is associated with the RMID, with short title and long title pulled from RMID record, and pro# pulled from the associated eIRB record (if it exists). However, when the RMID record is deleted, currently it's failing the API, because the long title, short title, pro# on the SPARC protocol will be updated to blank. Ideally, the user should update the RMID in SPARC, but this scenario should be taken into consideration.

Please change the API rules, so that when the RMID a SPARC protocol uses doesn't exist any more, remove the RMID in SPARC database when API refreshes, but keep the long title, short title, and pro#.

Acceptance criteria:
1). When a user deletes a RMID that already has associated SPARC record, no fatal error happens;
2). The current long title, short title, and pro# should be kept;
3). This method should be tied with RMID configuration for turning on/off.

[#151617565]

Story - https://www.pivotaltracker.com/story/show/151617565