### PR TITLE
wth - (SPARCRequest) Epic Push Origin Bug

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -182,6 +182,7 @@ class ProtocolsController < ApplicationController
     # Do the final push to epic in a separate thread.  The page which is
     # rendered will
     push_protocol_to_epic(@protocol)
+    epic_queue.destroy
 
     respond_to do |format|
       format.html
@@ -291,7 +292,7 @@ class ProtocolsController < ApplicationController
     # Thread.new do
     begin
       # Do the actual push.  This might take a while...
-      protocol.push_to_epic(EPIC_INTERFACE, "submission_push", current_user.id)
+      protocol.push_to_epic(EPIC_INTERFACE, "overlord_push", current_user.id)
       errors = EPIC_INTERFACE.errors
       session[:errors] = errors unless errors.empty?
       @epic_errors = true unless errors.empty?

--- a/lib/tasks/fix_historical_epic_queues.rake
+++ b/lib/tasks/fix_historical_epic_queues.rake
@@ -1,0 +1,38 @@
+namespace :data do
+  task fix_historical_epic_queues: :environment do
+
+    puts "Fetching Epic Queue Records with an origin of pi_email_approval since May 2017"
+
+    epic_queue_records = EpicQueueRecord.where(
+      origin: 'pi_email_approval',
+      created_at: Date.parse('01-05-2017')..Date.today
+    )
+
+    puts "#{epic_queue_records.count} Epic Queue Records with an origin of pi_email_approval since May 2017"
+
+    eqr_updated = []
+
+    epic_queue_records.each do |eqr|
+      updated_record = eqr.update_attribute(:origin, 'overlord_push')
+      eqr_updated << updated_record
+    end
+
+    puts "#{eqr_updated.count} Epic Queue Records updated"
+
+    puts "Finding duplicated Epic Queues for deletion..."
+
+    duplicated_eqs = []
+
+    EpicQueueRecord.all.each do |eqr|
+      eq = EpicQueue.find_by(protocol_id: eqr.protocol_id, identity_id: eqr.identity_id)
+      if !eq.nil?
+        deleted_eq = eq.destroy
+        duplicated_eqs << deleted_eq
+      end
+    end
+
+    puts "#{duplicated_eqs.count} duplicated Epic Queues deleted"
+
+    puts "Done"
+  end
+end

--- a/lib/tasks/send_to_epic.rake
+++ b/lib/tasks/send_to_epic.rake
@@ -7,6 +7,7 @@ task send_to_epic: :environment do
     p.push_to_epic(EPIC_INTERFACE, 'admin_push', eq.identity_id, true)
     if p.last_epic_push_status == 'complete'
       eq.update_attribute(:attempted_push, true)
+      eq.destroy
     end
   end
 end


### PR DESCRIPTION
1). Look into the duplicated entries between epic_queues table and epic_queue_records table. Once a protocol has been pushed to Epic from the queue, it should only show up in the epic_queue_records table, instead of both.
2). Fix historical data, the "pi_email_approval" entries since May 2017 should be "submission_push" or "admin_push" instead; And duplicated entries should be removed from the epic_queues table.

[#151955764]

Story - https://www.pivotaltracker.com/story/show/151955764