### PR TITLE
wth - (SPARCRequest & SPARCDashboard)Special Character Silent Failure

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -36,6 +36,15 @@ higher_level_of_privacy_no_epic = '#study_type_answer_higher_level_of_privacy_no
 
 $(document).ready ->
 
+  $(document).on 'blur', '#protocol_short_title, #protocol_title', ->
+    regex = /^[a-zA-Z0-9!@#\$%\^\&*\)\(+=._-]+$/
+    unless regex.test($(this).val())
+      $(this).parent('div').find('span').removeClass('hide')
+      $(this).parents('div.form-group').addClass('has-error')
+    else
+      $(this).parent('div').find('span').addClass('hide')
+      $(this).parents('div.form-group').removeClass('has-error')
+
   if $('.human-subjects:checkbox:checked').length > 0
     $('.rm-id').addClass('required')
 

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -64,6 +64,14 @@ class Protocol < ApplicationRecord
 
   validates :indirect_cost_rate, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 1000 }, allow_blank: true
 
+  validates :short_title,
+    format: { with: /^[a-zA-Z0-9!@#\$%\^\&*\)\(+=._-]+$/,
+              message: '- No special characters allowed', multiline: true }
+
+  validates :title,
+    format: { with: /^[a-zA-Z0-9!@#\$%\^\&*\)\(+=._-]+$/,
+              message: '- No special characters allowed', multiline: true }
+
   attr_accessor :requester_id
   attr_accessor :validate_nct
   attr_accessor :study_type_questions

--- a/app/views/dashboard/protocols/form/_project_fields.html.haml
+++ b/app/views/dashboard/protocols/form/_project_fields.html.haml
@@ -30,6 +30,8 @@
         title: t(:protocols)[:tooltips][:short_title]
       .col-lg-10
         = form.text_field :short_title, class: 'form-control'
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Short Title")
 
     .form-group.row
       = form.label :title,
@@ -39,6 +41,8 @@
         title: t(:protocols)[:tooltips][:title]
       .col-lg-10
         = form.text_field :title, class: 'form-control'
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Project Title")
 
     .form-group.row#funding-status
       = form.label :funding_status,

--- a/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_study_information.html.haml
@@ -47,6 +47,8 @@
         = form.text_field :short_title,
           class: [('form-control'), (Setting.find_by_key("research_master_enabled").value ? 'rm-id-dependent rm-locked-fields' : '')],
           disabled: Setting.find_by_key("research_master_enabled").value && protocol.research_master_id.present?
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Short Title")
 
     .form-group.row
       = form.label :title,
@@ -58,6 +60,8 @@
         = form.text_field :title,
           class: [('form-control'), (Setting.find_by_key("research_master_enabled").value ? 'rm-id-dependent rm-locked-fields' : '')],
           disabled: Setting.find_by_key("research_master_enabled").value && protocol.research_master_id.present?
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Study Title")
 
     .form-group.row#funding-status
       = form.label :funding_status,

--- a/app/views/protocols/form/_project_fields.html.haml
+++ b/app/views/protocols/form/_project_fields.html.haml
@@ -30,6 +30,8 @@
         title: t(:protocols)[:tooltips][:short_title]
       .col-lg-10
         = form.text_field :short_title, class: 'form-control'
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Short Title")
 
     .form-group.row
       = form.label :title,
@@ -39,6 +41,8 @@
         title: t(:protocols)[:tooltips][:title]
       .col-lg-10
         = form.text_field :title, class: 'form-control'
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Project Title")
 
     .form-group.row#funding-status
       = form.label :funding_status,

--- a/app/views/protocols/form/study_form_sections/_study_information.html.haml
+++ b/app/views/protocols/form/study_form_sections/_study_information.html.haml
@@ -43,6 +43,8 @@
         = form.text_field :short_title,
           class: [('form-control'), (Setting.find_by_key("research_master_enabled").value ? 'rm-id-dependent rm-locked-fields' : '')],
           disabled: Setting.find_by_key("research_master_enabled").value && protocol.research_master_id.present?
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Short Title")
 
     .form-group.row
       = form.label :title,
@@ -54,6 +56,8 @@
         = form.text_field :title,
           class: [('form-control'), (Setting.find_by_key("research_master_enabled").value ? 'rm-id-dependent rm-locked-fields' : '')],
           disabled: Setting.find_by_key("research_master_enabled").value && protocol.research_master_id.present?
+        %span.help-block.hide
+          = t('protocols.help_text', title: "Study Title")
 
     .form-group.row#funding-status
       = form.label :funding_status,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,6 +390,7 @@ en:
     edit: "Edit %{protocol_type} Information"
     created: "%{protocol_type} Created!"
     updated: "%{protocol_type} Updated!"
+    help_text: "Please remove the special character in the %{title} field and try again"
     summary:
       header: "%{protocol_type} Summary"
       archive: "Archive"

--- a/lib/tasks/remove_special_characters.rake
+++ b/lib/tasks/remove_special_characters.rake
@@ -1,0 +1,31 @@
+namespace :data do
+  task remove_special_characters: :environment do
+
+    puts "Removing special characters from Protocol titles..."
+
+    updated_protocols = []
+
+    regex = /^[a-zA-Z0-9!@#\$%\^\&*\)\(+=._-]+$/
+
+    progress_bar = ProgressBar.new(Protocol.all.count)
+
+    Protocol.all.each do |protocol|
+      if regex.match?(protocol.short_title)
+        protocol.short_title.gsub(/^[a-zA-Z0-9!@#\$%\^\&*\)\(+=._-]+$/, '')
+        protocol.save
+        updated_protocols << protocol.id
+      end
+
+      if regex.match?(protocol.title)
+        protocol.title.gsub(/^[a-zA-Z0-9!@#\$%\^\&*\)\(+=._-]+$/, '')
+        protocol.save
+        updated_protocols << protocol.id
+      end
+      progress_bar.increment!
+    end
+
+    puts "#{updated_protocols.uniq.count} Protocols updated"
+    puts "Done"
+  end
+end
+


### PR DESCRIPTION
When testing different special characters, I found that some special characters ( ±, ≥ ) were failing to be saved silently with long title and short title (and probably other text fields, too), with 500 error.

[#152339799]

Story - https://www.pivotaltracker.com/story/show/152339799