### PR TITLE
customize time zone with dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ SPARC_VERSION=v3.0.0
 institution=University
 institution_logo=/assets/institution_logo2017.png
 org_logo=/assets/org_logo2017.png
+time_zone=Eastern Time (US & Canada)

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,9 @@ Bundler.require(*Rails.groups)
 
 module SparcRails
   class Application < Rails::Application
+
+    Dotenv::Railtie.load
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
@@ -47,7 +50,7 @@ module SparcRails
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    config.time_zone = 'Eastern Time (US & Canada)'
+    config.time_zone = ENV['time_zone']
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
@@ -87,7 +90,7 @@ module SparcRails
       margin_top: '2in',
       margin_bottom: '1in',
       print_media_type: true
-      
+
     ##  Error pages
     config.exceptions_app = self.routes
   end


### PR DESCRIPTION
# Note on dotenv load order
dotenv is initialized in your Rails app during the `before_configuration` callback, which is fired when the Application constant is defined in config/application.rb with `class Application < Rails::Application`. If you need it to be initialized sooner, you can manually call `Dotenv::Railtie.load`.

# use dotenv to load time_zone
```
config.time_zone = ENV['time_zone']
```