### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Epic User Update/Deletion Feature

### DIFF
--- a/app/controllers/associated_users_controller.rb
+++ b/app/controllers/associated_users_controller.rb
@@ -99,6 +99,10 @@ class AssociatedUsersController < ApplicationController
   def destroy
     epic_access         = @protocol_role.epic_access
     protocol_role_clone = @protocol_role.clone
+    epic_queue_manager = EpicQueueManager.new(
+      @protocol_role.protocol, current_user, @protocol_role
+    )
+    epic_queue_manager.create_epic_queue
 
     @protocol_role.destroy
 

--- a/app/controllers/dashboard/associated_users_controller.rb
+++ b/app/controllers/dashboard/associated_users_controller.rb
@@ -119,6 +119,10 @@ class Dashboard::AssociatedUsersController < Dashboard::BaseController
     @protocol           = @protocol_role.protocol
     epic_access         = @protocol_role.epic_access
     protocol_role_clone = @protocol_role.clone
+    epic_queue_manager = EpicQueueManager.new(
+      @protocol, @user, @protocol_role
+    )
+    epic_queue_manager.create_epic_queue
 
     @protocol_role.destroy
 

--- a/app/lib/epic_queue_manager.rb
+++ b/app/lib/epic_queue_manager.rb
@@ -7,7 +7,7 @@ class EpicQueueManager
   end
 
   def create_epic_queue
-    if Setting.find_by_key("use_epic").value && withheld_from_epic?(@protocol) && @protocol_role.epic_access
+    if Setting.find_by_key("use_epic").value && withheld_from_epic?(@protocol)
       unless withheld_epic_queue?(@protocol)
         EpicQueue.create(
           protocol_id: @protocol.id,


### PR DESCRIPTION
With a previous story (https://www.pivotaltracker.com/story/show/145759415), when there is a user added with epic rights on an existing protocol (that has been pushed to Epic), or epic rights have been added to an existing user, SPARC is now automatically queuing the protocol and sending only protocol information over to Epic daily.

However, 1). when a user with Epic rights is removed from existing Epic protocols, or 2). when a user with Epic rights is changed to no Epic rights, it is not triggering the protocol info to update.

Please add the 2 criteria into the method, so that we are covered with any user changes related to Epic rights being updated.

[#152091104]

Story - https://www.pivotaltracker.com/story/show/152091104