### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Better Language for Missing Pri…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,10 @@ en:
           attributes:
             content:
               blank: "has to be answered"
+        project_role:
+          attributes:
+            identity_id:
+              blank: "^Primary PI can't be blank"
       messages:
         spoofed_media_type: "has format errors. Please re-save the file in a different format and try again."
     attributes:


### PR DESCRIPTION
…mary PI

Background: When creating a study or project without choosing a Primary PI, the current error message says "Project roles identity can't be blank". This may be confusing to frontend users.

Please change the error message language to "Primary PI can't be blank". instead.

[#152412509]

Story - https://www.pivotaltracker.com/story/show/152412509