### PR TITLE
Pr mailer issue contact

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,10 +68,9 @@ class ApplicationController < ActionController::Base
   end
 
   def rmid_server_status(protocol)
-    if Setting.find_by_key("research_master_enabled").value
-      @rmid_server_down = protocol.rmid_server_status
-      @rmid_server_down ? flash[:alert] = t(:protocols)[:summary][:tooltips][:rmid_server_down] : nil
-    end
+    return unless Setting.safe_value('research_master_enabled')
+    @rmid_server_down = protocol.rmid_server_status
+    @rmid_server_down ? flash[:alert] = t(:protocols)[:summary][:tooltips][:rmid_server_down] : nil
   end
 
   def authorization_error msg, ref

--- a/app/controllers/dashboard/base_controller.rb
+++ b/app/controllers/dashboard/base_controller.rb
@@ -48,10 +48,9 @@ class Dashboard::BaseController < ActionController::Base
   private
 
   def rmid_server_status(protocol)
-    if Setting.find_by_key("research_master_enabled").value
-      @rmid_server_down = protocol.rmid_server_status
-      @rmid_server_down ? flash[:alert] = t(:protocols)[:summary][:tooltips][:rmid_server_down] : nil
-    end
+    return unless Setting.safe_value('research_master_enabled')
+    @rmid_server_down = protocol.rmid_server_status
+    @rmid_server_down ? flash[:alert] = t(:protocols)[:summary][:tooltips][:rmid_server_down] : nil
   end
 
   def protocol_authorizer_view

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -32,8 +32,14 @@ class Setting < ApplicationRecord
 
   validate :value_matches_type, if: Proc.new{ !self.read_attribute(:value).nil? }
   validate :parent_value_matches_parent_type, if: Proc.new{ self.parent_key.present? }
-  
-  # Needed to correctly write boolean true and false as value in specs  
+
+  def self.safe_value(key)
+    s = Setting.find_by_key(key)
+    return nil if s.nil?
+    s.value
+  end
+
+  # Needed to correctly write boolean true and false as value in specs
   def value=(value)
     if [TrueClass, FalseClass].include?(value.class)
       value_will_change!
@@ -45,7 +51,7 @@ class Setting < ApplicationRecord
 
   def value
     case data_type
-    when 'boolean'  
+    when 'boolean'
       read_attribute(:value) == 'true'
     when 'json'
       begin

--- a/app/views/notifier/_notification_email.html.haml
+++ b/app/views/notifier/_notification_email.html.haml
@@ -47,12 +47,12 @@
     /***** OTHER EMAIL TIDBITS *****
     - if display_notes?(@status, @role, @notes)
       %p= t(:notifier)[:notes_present]
-    
+
     - if @status != 'ssr_destroyed'
       %p= t(:notifier)[:body6]
-    
-    %p= t(:mailer)[:issue_contact]
-    
+
+    %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))
+
     - if @role != 'none'
       = render "acknowledgments"
     /***** END OTHER EMAIL TIDBITS *****

--- a/app/views/notifier/_notification_email.html.haml
+++ b/app/views/notifier/_notification_email.html.haml
@@ -51,7 +51,7 @@
     - if @status != 'ssr_destroyed'
       %p= t(:notifier)[:body6]
 
-    %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))
+    %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_center_email_to: Setting.get_setting_by_key('success_center_email_to'))
 
     - if @role != 'none'
       = render "acknowledgments"

--- a/app/views/notifier/_notification_email.html.haml
+++ b/app/views/notifier/_notification_email.html.haml
@@ -51,7 +51,7 @@
     - if @status != 'ssr_destroyed'
       %p= t(:notifier)[:body6]
 
-    %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_center_email_to: Setting.get_setting_by_key('success_center_email_to'))
+    %p= t('mailer.issue_contact', success_center_phone: Setting.safe_value('success_center_phone'), success_center_email_to: Setting.safe_value('success_center_email_to'))
 
     - if @role != 'none'
       = render "acknowledgments"

--- a/app/views/notifier/account_status_change.html.haml
+++ b/app/views/notifier/account_status_change.html.haml
@@ -23,7 +23,7 @@
 
   %head
     %meta{ :"http-equiv" => "content-type", :content => "text/html;charset=UTF-8" }
-    %title= t(:notifier)[:status_change][:body1] 
+    %title= t(:notifier)[:status_change][:body1]
 
   %body
     - if @approved
@@ -31,7 +31,7 @@
       = t(:notifier)[:status_change][:body3]
       = t(:notifier)[:status_change][:body4]
     - else
-      = t(:notifier)[:status_change][:body5]  
+      = t(:notifier)[:status_change][:body5]
     %br
     %br
-    = t(:mailer)[:issue_contact]
+    = t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))

--- a/app/views/notifier/account_status_change.html.haml
+++ b/app/views/notifier/account_status_change.html.haml
@@ -34,4 +34,4 @@
       = t(:notifier)[:status_change][:body5]
     %br
     %br
-    = t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_center_email_to: Setting.get_setting_by_key('success_center_email_to'))
+    = t('mailer.issue_contact', success_center_phone: Setting.safe_value('success_center_phone'), success_center_email_to: Setting.safe_value('success_center_email_to'))

--- a/app/views/notifier/account_status_change.html.haml
+++ b/app/views/notifier/account_status_change.html.haml
@@ -34,4 +34,4 @@
       = t(:notifier)[:status_change][:body5]
     %br
     %br
-    = t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))
+    = t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_center_email_to: Setting.get_setting_by_key('success_center_email_to'))

--- a/app/views/user_mailer/authorized_user_changed.html.haml
+++ b/app/views/user_mailer/authorized_user_changed.html.haml
@@ -27,6 +27,6 @@
   = render "user_info_table"
   %br
   %br
-  %p= t(:mailer)[:issue_contact]
+  %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))
   %br
   = render "acknowledgments"

--- a/app/views/user_mailer/authorized_user_changed.html.haml
+++ b/app/views/user_mailer/authorized_user_changed.html.haml
@@ -27,6 +27,6 @@
   = render "user_info_table"
   %br
   %br
-  %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_center_email_to: Setting.get_setting_by_key('success_center_email_to'))
+  %p= t('mailer.issue_contact', success_center_phone: Setting.safe_value('success_center_phone'), success_center_email_to: Setting.safe_value('success_center_email_to'))
   %br
   = render "acknowledgments"

--- a/app/views/user_mailer/authorized_user_changed.html.haml
+++ b/app/views/user_mailer/authorized_user_changed.html.haml
@@ -27,6 +27,6 @@
   = render "user_info_table"
   %br
   %br
-  %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))
+  %p= t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_center_email_to: Setting.get_setting_by_key('success_center_email_to'))
   %br
   = render "acknowledgments"

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -618,5 +618,25 @@
     "version":        "",
     "parent_key":     "",
     "parent_value":   ""
+  },
+  {
+    "key": "success_center_phone",
+    "value": "(843) 792-8300",
+    "friendly_name": "Success center phone number",
+    "description": "phone number to call when serice request is made successfully",
+    "group": "",
+    "version": "",
+    "parent_key": "",
+    "parent_value": ""
+  }, 
+  {
+    "key": "success_email_to",
+    "value": "success@musc.edu",
+    "friendly_name": "Success email-to",
+    "description": "email to send to when service request is made successfully",
+    "group": "",
+    "version": "",
+    "parent_key": "",
+    "parent_value": ""
   }
 ]

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -440,6 +440,26 @@
     "parent_value":   ""
   },
   {
+    "key": "success_center_phone",
+    "value": "(843) 792-8300",
+    "friendly_name": "Success center phone number",
+    "description": "phone number to call when serice request is made successfully",
+    "group": "",
+    "version": "",
+    "parent_key": "",
+    "parent_value": ""
+  }, 
+  {
+    "key": "success_center_email_to",
+    "value": "success@musc.edu",
+    "friendly_name": "Success email-to",
+    "description": "email to send to when service request is made successfully",
+    "group": "",
+    "version": "",
+    "parent_key": "",
+    "parent_value": ""
+  },
+  {
     "key":            "suppress_ldap_for_user_search",
     "value":          "false",
     "friendly_name":  "Suppress LDAP for User Search",
@@ -618,25 +638,5 @@
     "version":        "",
     "parent_key":     "",
     "parent_value":   ""
-  },
-  {
-    "key": "success_center_phone",
-    "value": "(843) 792-8300",
-    "friendly_name": "Success center phone number",
-    "description": "phone number to call when serice request is made successfully",
-    "group": "",
-    "version": "",
-    "parent_key": "",
-    "parent_value": ""
-  }, 
-  {
-    "key": "success_email_to",
-    "value": "success@musc.edu",
-    "friendly_name": "Success email-to",
-    "description": "email to send to when service request is made successfully",
-    "group": "",
-    "version": "",
-    "parent_key": "",
-    "parent_value": ""
   }
 ]

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -452,7 +452,7 @@
   {
     "key": "success_center_email_to",
     "value": "success@musc.edu",
-    "friendly_name": "Success email-to",
+    "friendly_name": "Success center email",
     "description": "email to send to when service request is made successfully",
     "group": "",
     "version": "",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1425,7 +1425,7 @@ en:
     contact_information: "Contact Information"
     delete_intro: "An Authorized User has been deleted in"
     epic_access: "Epic Access"
-    issue_contact: "Please contact the SUCCESS Center at (843) 792-8300 or success@musc.edu for assistance with this process or with any questions you may have."
+    issue_contact: "Please contact the SUCCESS Center at %{success_center_phone} or %{success_email_to} for assistance with this process or with any questions you may have."
     name: "Name:"
     p_id: "Protocol ID:"
     p_info: "Protocol Information"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1425,7 +1425,7 @@ en:
     contact_information: "Contact Information"
     delete_intro: "An Authorized User has been deleted in"
     epic_access: "Epic Access"
-    issue_contact: "Please contact the SUCCESS Center at %{success_center_phone} or %{success_email_to} for assistance with this process or with any questions you may have."
+    issue_contact: "Please contact the SUCCESS Center at %{success_center_phone} or %{success_center_email_to} for assistance with this process or with any questions you may have."
     name: "Name:"
     p_id: "Protocol ID:"
     p_info: "Protocol Information"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe UserMailer do
       it 'should display correct subject' do
         expect(@mail).to have_subject("SPARCRequest Authorized Users Update (Protocol #{@protocol.id})")
       end
-    
+
       it "should display the 'added' message" do
         # An Authorized User has been added in SparcDashboard ***(link to protocol)***
         expect(@mail).to have_xpath("//p[normalize-space(text()) = 'An Authorized User has been added in']")
@@ -55,7 +55,7 @@ RSpec.describe UserMailer do
       end
 
       it "should display message conclusion" do
-        expect(@mail).to have_xpath("//p[normalize-space(text()) = 'Please contact the SUCCESS Center at (843) 792-8300 or success@musc.edu for assistance with this process or with any questions you may have.']")
+        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_email_to')} for assistance with this process or with any questions you may have.']")
       end
 
       it "should display acknowledgments" do
@@ -118,7 +118,7 @@ RSpec.describe UserMailer do
       end
 
       it "should display message conclusion" do
-        expect(@mail).to have_xpath("//p[normalize-space(text()) = 'Please contact the SUCCESS Center at (843) 792-8300 or success@musc.edu for assistance with this process or with any questions you may have.']")
+        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_email_to')} for assistance with this process or with any questions you may have.']")
       end
 
       it "should display acknowledgments" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe UserMailer do
       end
 
       it "should display message conclusion" do
-        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_email_to')} for assistance with this process or with any questions you may have.']")
+        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_center_email_to')} for assistance with this process or with any questions you may have.']")
       end
 
       it "should display acknowledgments" do
@@ -118,7 +118,7 @@ RSpec.describe UserMailer do
       end
 
       it "should display message conclusion" do
-        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_email_to')} for assistance with this process or with any questions you may have.']")
+        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_center_email_to')} for assistance with this process or with any questions you may have.']")
       end
 
       it "should display acknowledgments" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe UserMailer do
       end
 
       it "should display message conclusion" do
-        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_center_email_to')} for assistance with this process or with any questions you may have.']")
+        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.safe_value('success_center_phone')} or #{Setting.safe_value('success_center_email_to')} for assistance with this process or with any questions you may have.']")
       end
 
       it "should display acknowledgments" do
@@ -118,7 +118,7 @@ RSpec.describe UserMailer do
       end
 
       it "should display message conclusion" do
-        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_center_email_to')} for assistance with this process or with any questions you may have.']")
+        expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.safe_value('success_center_phone')} or #{Setting.safe_value('success_center_email_to')} for assistance with this process or with any questions you may have.']")
       end
 
       it "should display acknowledgments" do


### PR DESCRIPTION
add two settings key:

1. success_center_phone

2. success_email_to

usage:

```
t('mailer.issue_contact', success_center_phone: Setting.get_setting_by_key('success_center_phone'), success_email_to: Setting.get_setting_by_key('success_email_to'))
```

test:
```
expect(@mail).to have_xpath("//p[text() = 'Please contact the SUCCESS Center at #{Setting.get_setting_by_key('success_center_phone')} or #{Setting.get_setting_by_key('success_email_to')} for assistance with this process or with any questions you may have.']")
```