### PR TITLE
wth - (SPARCDashboard) Validate Calendar when Sending Protocol to Epic

### DIFF
--- a/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
+++ b/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
@@ -60,6 +60,8 @@ $(document).ready ->
     $.ajax
       type: 'PUT'
       url: "/dashboard/sub_service_requests/#{sub_service_request_id}/push_to_epic"
+      error: (xhr, ajaxOptions, thrownError) ->
+        swal('Error', 'This protocol has failed to be sent to Epic because of failed validation. Please make sure the service calendar is intact before trying again.', 'error')
 
   $(document).on 'click', '#resend-surveys-button', ->
     $(this).prop('disabled', true)

--- a/app/controllers/dashboard/sub_service_requests_controller.rb
+++ b/app/controllers/dashboard/sub_service_requests_controller.rb
@@ -128,11 +128,17 @@ class Dashboard::SubServiceRequestsController < Dashboard::BaseController
   end
 
   def push_to_epic
-    begin
-      @sub_service_request.protocol.push_to_epic(EPIC_INTERFACE, "admin_push", current_user.id)
-      flash[:success] = 'Request Pushed to Epic!'
-    rescue
-      flash[:alert] = $!.message
+    sr = @sub_service_request.service_request
+    sr.validate_service_calendar
+    unless sr.errors[:base].length > 0
+      begin
+        @sub_service_request.protocol.push_to_epic(EPIC_INTERFACE, "admin_push", current_user.id)
+        flash[:success] = 'Request Pushed to Epic!'
+      rescue
+        flash[:alert] = $!.message
+      end
+    else
+      raise 'error'
     end
   end
 

--- a/app/views/dashboard/sub_service_requests/_request_details.html.haml
+++ b/app/views/dashboard/sub_service_requests/_request_details.html.haml
@@ -26,9 +26,10 @@
     %tbody
       %tr
         - if Setting.find_by_key("use_epic").value
-          %td.text-center
-            %button.btn.btn-sm.btn-primary#send_to_epic_button{ data: { sub_service_request_id: sub_service_request.id, toggle: 'tooltip', placement: 'top', delay: '{"show":"500"}'}, title: t(:dashboard)[:sub_service_requests][:tabs][:request_details][:tooltips][:send_to_epic] }
-              = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:options][:send_to_epic]
+          - if sub_service_request.protocol.selected_for_epic? && sub_service_request.organization.services(&:selected_for_epic).any?
+            %td.text-center
+              %button.btn.btn-sm.btn-primary#send_to_epic_button{ data: { sub_service_request_id: sub_service_request.id, toggle: 'tooltip', placement: 'top', delay: '{"show":"500"}'}, title: t(:dashboard)[:sub_service_requests][:tabs][:request_details][:tooltips][:send_to_epic] }
+                = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:options][:send_to_epic]
         - if sub_service_request.ctrc?
           %td.text-center
             %button.btn.btn-sm.btn-warning#admin_approvals_button{ data: { sub_service_request_id: sub_service_request.id }}

--- a/app/views/dashboard/sub_service_requests/_request_details.html.haml
+++ b/app/views/dashboard/sub_service_requests/_request_details.html.haml
@@ -26,7 +26,7 @@
     %tbody
       %tr
         - if Setting.find_by_key("use_epic").value
-          - if sub_service_request.protocol.selected_for_epic? && sub_service_request.organization.services(&:selected_for_epic).any?
+          - if sub_service_request.protocol.selected_for_epic? && sub_service_request.organization.services(&:send_to_epic).any?
             %td.text-center
               %button.btn.btn-sm.btn-primary#send_to_epic_button{ data: { sub_service_request_id: sub_service_request.id, toggle: 'tooltip', placement: 'top', delay: '{"show":"500"}'}, title: t(:dashboard)[:sub_service_requests][:tabs][:request_details][:tooltips][:send_to_epic] }
                 = t(:dashboard)[:sub_service_requests][:tabs][:request_details][:options][:send_to_epic]

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -31,7 +31,7 @@ FactoryGirl.define do
 
     trait :ctrc do
       after(:create) do |organization, evaluator|
-        organization.tag_list = "ctrc_clinical_services"
+        organization.tag_list = "ctrc"
 
         organization.save
       end

--- a/spec/views/dashboard/sub_service_requests/_request_details_spec.html.haml_spec.rb
+++ b/spec/views/dashboard/sub_service_requests/_request_details_spec.html.haml_spec.rb
@@ -25,9 +25,12 @@ RSpec.describe 'dashboard/sub_service_requests/_request_details', type: :view do
 
   context "Export to excel" do
     it "should display service_request_id and sub_service_request_id in href" do
-      protocol = stub_protocol
-      service_request = stub_service_request(protocol: protocol)
-      sub_service_request = stub_sub_service_request(service_request: service_request)
+      protocol = create(:protocol, :without_validations, selected_for_epic: true)
+      service_request = create(:service_request, :without_validations, protocol: protocol)
+      org = create(:organization)
+      create(:service, organization: org, send_to_epic: true)
+      sub_service_request = create(:sub_service_request, protocol: protocol, service_request: service_request, organization: org)
+
       render_request_details(protocol: protocol, service_request: service_request, sub_service_request: sub_service_request)
       expect(response).to have_tag('a', with: { href: "/service_requests/#{service_request.id}.xlsx?admin_offset=1&sub_service_request_id=#{sub_service_request.id}" }, text: "Export to Excel")
     end
@@ -37,9 +40,11 @@ RSpec.describe 'dashboard/sub_service_requests/_request_details', type: :view do
     stub_config("use_epic", true)
     
     it "should display 'Send to Epic' button" do
-      protocol = stub_protocol
-      service_request = stub_service_request(protocol: protocol)
-      sub_service_request = stub_sub_service_request(service_request: service_request)
+      protocol = create(:protocol, :without_validations, selected_for_epic: true)
+      service_request = create(:service_request, :without_validations, protocol: protocol)
+      org = create(:organization)
+      create(:service, organization: org, send_to_epic: true)
+      sub_service_request = create(:sub_service_request, protocol: protocol, service_request: service_request, organization: org)
 
       render_request_details(protocol: protocol, service_request: service_request, sub_service_request: sub_service_request)
 
@@ -48,10 +53,13 @@ RSpec.describe 'dashboard/sub_service_requests/_request_details', type: :view do
   end
 
   context "use_epic falsey" do
+    stub_config("use_epic", false)
     it "should not display 'Send to Epic' button" do
-      protocol = stub_protocol
-      service_request = stub_service_request(protocol: protocol)
-      sub_service_request = stub_sub_service_request(service_request: service_request)
+      protocol = create(:protocol, :without_validations, selected_for_epic: true)
+      service_request = create(:service_request, :without_validations, protocol: protocol)
+      org = create(:organization)
+      create(:service, organization: org, send_to_epic: true)
+      sub_service_request = create(:sub_service_request, protocol: protocol, service_request: service_request, organization: org)
 
       render_request_details(protocol: protocol, service_request: service_request, sub_service_request: sub_service_request)
 
@@ -61,9 +69,11 @@ RSpec.describe 'dashboard/sub_service_requests/_request_details', type: :view do
 
   context "SubServiceRequest associated with CTRC Organization" do
     it "should display 'Administrative Approvals' button" do
-      protocol = stub_protocol
-      service_request = stub_service_request(protocol: protocol)
-      sub_service_request = stub_sub_service_request(service_request: service_request, ctrc?: true)
+      protocol = create(:protocol, :without_validations, selected_for_epic: true)
+      service_request = create(:service_request, :without_validations, protocol: protocol)
+      org = create(:organization, :ctrc)
+      create(:service, organization: org, send_to_epic: true)
+      sub_service_request = create(:sub_service_request, protocol: protocol, service_request: service_request, organization: org)
 
       render_request_details(protocol: protocol, service_request: service_request, sub_service_request: sub_service_request)
 


### PR DESCRIPTION
Background: On SPARCDashboard Admin Edit "Request Details" tab, the "Send to Epic" button sends a whole protocol to Epic. But it's currently showing on requests for admins who don't have services going to Epic, and doesn't validate the service calendar.

Acceptance criteria:
1). The "Send to Epic" button should only show up when a protocol has been selected to be sent to Epic (protocols.selected_for_epic = 1);
2). The "Send to Epic" button should only show up on if the SSR organization has services that goes to Epic (services.send_to_epic = 1);
3). Validation should be put on the "Send to Epic" button, with a popup error message "This protocol has failed to be sent to Epic because of failed validation. Please make sure the service calendar is intact before trying again." when it has a broken calendar;
4). When the validation fails, no protocol (SOAP) message should be sent to Epic.

[#151880302]

Story - https://www.pivotaltracker.com/story/show/151880302