### PR TITLE
wth - (SPARCDashboard) Validate Calendar when Sending Request to SPAR…

### DIFF
--- a/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
+++ b/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
@@ -51,8 +51,10 @@ $(document).ready ->
     data = 'sub_service_request' : 'in_work_fulfillment' : 1
     $.ajax
       type: 'PATCH'
-      url: "/dashboard/sub_service_requests/#{sub_service_request_id}"
+      url: "/dashboard/sub_service_requests/#{sub_service_request_id}?check_sr_calendar=true"
       data: data
+      error: (xhr, ajaxOptions, thrownError) ->
+        swal('Error', 'This protocol has failed to be sent to Epic because of failed validation. Please make sure the service calendar is intact before trying again.', 'error')
 
   $(document).on 'click', '#send_to_epic_button', ->
     $(this).prop( "disabled", true )

--- a/app/controllers/dashboard/sub_service_requests_controller.rb
+++ b/app/controllers/dashboard/sub_service_requests_controller.rb
@@ -84,6 +84,13 @@ class Dashboard::SubServiceRequestsController < Dashboard::BaseController
   end
 
   def update
+    if params[:check_sr_calendar] == 'true'
+      sr = @sub_service_request.service_request
+      sr.validate_service_calendar
+      if sr.errors[:base].length > 0
+        raise 'error'
+      end
+    end
     if @sub_service_request.update_attributes(sub_service_request_params)
       @sub_service_request.distribute_surveys if (@sub_service_request.status == 'complete' && sub_service_request_params[:status].present?)
       flash[:success] = 'Request Updated!'


### PR DESCRIPTION
…CFulfillment

Background: For service providers who are using SPARCFulfillment module, currently when the user clicks the "Send to Fulfillment" button on SPARCDashboard to push the request to SPARCFulfillment, it is not taking into consideration whether the calendar is intact. If the protocol has a broken calendar (i.e. missing visit days, out of sequence visits, etc), it is currently causing the SSR to not show in SPARCFulfillment without any explanation or error message.

Acceptance criteria:
1). Add validation on the "Send to Fulfillment" button to check on the calendar integrity.
2). If the protocol has a broken calendar, a modal with error message "This request has failed to be sent to SPARCFulfillment because of failed validation. Please make sure the service calendar is intact before trying again."
3). The button should stay "Send to Fulfillment" if the send has failed, so that the user could try again.

[#151879348]

Story - https://www.pivotaltracker.com/story/show/151879348