### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Permissible Values should Follo…

### DIFF
--- a/app/views/dashboard/documents/_document_form.html.haml
+++ b/app/views/dashboard/documents/_document_form.html.haml
@@ -34,7 +34,7 @@
             .form-group
               = form.label :doc_type, t(:documents)[:form_fields][:document_type], class: 'col-sm-4 control-label required'
               .col-sm-7
-                = form.select :doc_type, options_for_select(PermissibleValue.get_inverted_hash('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
+                = form.select :doc_type, options_for_select(PermissibleValue.order(:sort_order).get_inverted_hash('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
             .form-group#doc-type-other-field{ display_if(document.doc_type == 'other') }
               = form.label :doc_type_other, t(:documents)[:form_fields][:specify_doc_type], class: 'col-sm-4 control-label required'
               .col-sm-7

--- a/app/views/documents/_document_form.html.haml
+++ b/app/views/documents/_document_form.html.haml
@@ -35,7 +35,7 @@
             .form-group
               = form.label :doc_type, t(:documents)[:form_fields][:document_type], class: 'col-sm-4 control-label required'
               .col-sm-7
-                = form.select :doc_type, options_for_select(PermissibleValue.get_inverted_hash('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
+                = form.select :doc_type, options_for_select(PermissibleValue.order(:sort_order).get_inverted_hash('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'form-control selectpicker'
             .form-group#doc-type-other-field{ display_if(document.doc_type == 'other') }
               = form.label :doc_type_other, t(:documents)[:form_fields][:specify_doc_type], class: 'col-sm-4 control-label required'
               .col-sm-7


### PR DESCRIPTION
…w the Sort_Order Defined

Background: When adding a new document type into the permissible_values table, although the option is showing up on the frontend, the sequence of the list is not following the order defined in sort_oder column (because this attribute is new).

Please update the methods to display the defined permissible values (document type, grant code, impact area, etc) by the defined order in permissible_values.sort_order.

[#152658805]

Story - https://www.pivotaltracker.com/story/show/152658805