### PR TITLE
wth - db/schema.rb Table Collation

### DIFF
--- a/db/migrate/20171206153259_convert_database_to_utf8mb4.rb
+++ b/db/migrate/20171206153259_convert_database_to_utf8mb4.rb
@@ -1,0 +1,30 @@
+class ConvertDatabaseToUtf8mb4 < ActiveRecord::Migration[5.1]
+  def change
+    def db
+      ActiveRecord::Base.connection
+    end
+
+    def up
+      return if Rails.env.staging? or Rails.env.production?
+
+      execute "ALTER DATABASE `#{db.current_database}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+      db.tables.each do |table|
+        execute "ALTER TABLE `#{table}` ROW_FORMAT=DYNAMIC CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+        db.columns(table).each do |column|
+          case column.sql_type
+            when /([a-z]*)text/i
+              default = (column.default.blank?) ? '' : "DEFAULT '#{column.default}'"
+              null = (column.null) ? '' : 'NOT NULL'
+              execute "ALTER TABLE `#{table}` MODIFY `#{column.name}` #{column.sql_type.upcase} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci #{default} #{null};"
+            when /varchar\(([0-9]+)\)/i
+              sql_type = column.sql_type.upcase
+              default = (column.default.blank?) ? '' : "DEFAULT '#{column.default}'"
+              null = (column.null) ? '' : 'NOT NULL'
+              execute "ALTER TABLE `#{table}` MODIFY `#{column.name}` #{sql_type} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci #{default} #{null};"
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171025145319) do
+ActiveRecord::Schema.define(version: 20171206153259) do
 
   create_table "admin_rates", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer "line_item_id"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20171025145319) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "selected", default: false
     t.index ["organization_id"], name: "index_available_statuses_on_organization_id"
   end
 
@@ -180,6 +181,7 @@ ActiveRecord::Schema.define(version: 20171025145319) do
     t.string "status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "selected", default: false
     t.index ["organization_id"], name: "index_editable_statuses_on_organization_id"
   end
 


### PR DESCRIPTION
We noticed recently that `db/schema.rb` is changing the `COLLATE=....` attribute on various tables that are being altered by migrations. We came to the conclusion that several of our tables which have not been altered in a long time by migrations may need to be updated. It would appear that these should be the options for our `create_table`s:

`options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"`

Please update the schema table statements to use the updated engine, charset, and collation
update collation

[#152679915]

Story - https://www.pivotaltracker.com/story/show/152679915

**NOTE - This only changes development databases (development and test), production will have to follow steps listed in this blog (https://railsmachine.com/articles/2017/05/19/converting-a-rails-database-to-utf8mb4.html)**