### PR TITLE
Jl - calendar lock move visit fix

### DIFF
--- a/app/lib/dashboard/service_calendars.rb
+++ b/app/lib/dashboard/service_calendars.rb
@@ -51,7 +51,7 @@ module Dashboard
 
       returning_html += select_tag("jump_to_visit_#{arm.id}", visits_select_options(arm, pages), class: 'jump_to_visit selectpicker', url: path_method.call(service_request, pages: pages, arm_id: arm.id, tab: tab, sub_service_request_id: ssr_id, portal: portal))
 
-      unless portal || @merged || @review
+      unless portal || @merged || @review || service_request.protocol.locked
         returning_html += link_to 'Move Visit', 'javascript:void(0)', class: 'move_visits', data: { 'arm-id' => arm.id, tab: tab, 'sr-id' => service_request.id, portal: portal }
       end
 

--- a/app/views/dashboard/calendar_structure/_table.html.haml
+++ b/app/views/dashboard/calendar_structure/_table.html.haml
@@ -27,10 +27,10 @@
         %div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' }, title: t(:calendar_structure)[:tooltips][:lock_calendar] }
           - if @user.catalog_overlord
             %button.btn.btn-success#calendar-lock-button{ class: "calendar-lock", data: { protocol_id: protocol.id, locked: protocol.locked.to_s } }
-              -if protocol.locked == false
-                = t(:calendar_structure)[:lock_calendar]
-              -else
+              -if protocol.locked
                 = t(:calendar_structure)[:unlock_calendar]
+              -else
+                = t(:calendar_structure)[:lock_calendar]
       %table#calendar-structure-table{ data: { toggle: 'table', 'show-columns' => 'true', 'show-toggle' => 'true', url: dashboard_arms_path(format: :json, protocol_id: protocol.id), striped: 'true', toolbar: '#calendar-structure-custom-toolbar' } }
         %thead.primary-header
           %tr

--- a/app/views/service_calendars/master_calendar/pppv/_pppv_calendar.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_pppv_calendar.html.haml
@@ -31,8 +31,9 @@
         .text-center
           %span{class: 'glyphicon glyphicon-lock locked', style: 'font-size:50px;color:black;', data: { toggle: 'tooltip', placement: 'top', delay: '{"show":"500"}' }, title: t(:calendar_structure)[:tooltips][:arm_info] }
       .pull-right
-        %button.btn.btn-warning.move-visit-button{ data: { arm_id: arm.id, pages: pages.to_s, page: page, review: review.to_s, portal: portal.to_s, admin: admin.to_s, tab: tab, merged: merged.to_s, consolidated: consolidated.to_s, statuses_hidden: statuses_hidden, toggle: 'tooltip', placement: 'bottom', delay: '{"show":"500"}' }, title: t(:calendars)[:tooltips][:move_visit_button]}
-          = t(:proper)[:service_calendar][:move_visit][:header]
+        - unless arm.protocol.locked
+          %button.btn.btn-warning.move-visit-button{ data: { arm_id: arm.id, pages: pages.to_s, page: page, review: review.to_s, portal: portal.to_s, admin: admin.to_s, tab: tab, merged: merged.to_s, consolidated: consolidated.to_s, statuses_hidden: statuses_hidden, toggle: 'tooltip', placement: 'bottom', delay: '{"show":"500"}' }, title: t(:calendars)[:tooltips][:move_visit_button]}
+            = t(:proper)[:service_calendar][:move_visit][:header]
         .divider
     .clearfix
   = hidden_field_tag :service_request_id, service_request.id


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/151621373

A user should not be able to move visits around if the calendar is locked. This is also a small fix for the displaying of 'Lock' vs 'Unlock'