### PR TITLE
Step 5 Organization Forms Not Showing Bug

### DIFF
--- a/app/views/service_requests/document_management/_document_management_left.html.haml
+++ b/app/views/service_requests/document_management/_document_management_left.html.haml
@@ -20,6 +20,6 @@
 .col-md-9.document-management-left
   = render 'service_requests/document_management/documents', service_request: service_request
   = render 'service_requests/document_management/notes', service_request: service_request, notable_type: notable_type, notable_id: notable_id
-  - if service_request.additional_detail_services.present?
+  - if service_request.additional_detail_services.present? || service_request.additional_detail_organizations.present?
     .document-management-submissions
       = render "additional_details/document_management_submissions", service_request: service_request


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/153816095

In step 5, when viewing a Service Request that has associated forms only for organizations but not services, the additional details forms section is not displayed.