### PR TITLE
ml_consolidated_request_cost_display

### DIFF
--- a/app/views/dashboard/protocols/show.xlsx.axlsx
+++ b/app/views/dashboard/protocols/show.xlsx.axlsx
@@ -28,8 +28,8 @@ default = wb.styles.add_style alignment: { horizontal: :left }
 # centered = wb.styles.add_style alignment: { horizontal: :center }
 # bordered = wb.styles.add_style :border=> {:style => :thin, :color => "00000000"}
 # centered_bordered = wb.styles.add_style :border => {:style => :thin, :color => "00000000"}, :alignment => {:horizontal => :center}
-money = wb.styles.add_style :format_code => '$#,##0.00_;[Red]-$#,##0.00'
-bold_money = wb.styles.add_style :format_code => '$#,##0.00_;[Red]-$#,##0.00', b: true
+money = wb.styles.add_style :format_code => '$#,##0.00_);[Red]-$#,###.00'
+bold_money = wb.styles.add_style :format_code => '$#,##0.00_);[Red]-$#,###.00', b: true
 percent = wb.styles.add_style :format_code => '0.00\%', b: true
 row_header_style = wb.styles.add_style b: true
 header_style = wb.styles.add_style sz: 12, b: true, bg_color: '0099FF', fg_color: 'FFFFFF', alignment: { horizontal: :left }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/153946927

The cost columns of the Consolidated Cooperate Study Budget Report, generated by clicking the "Export Consolidated Request", are not displaying correctly, with the red $numbers and duplicative $ amount.