### PR TITLE
wth - (SPARCDashboard) Add Push Type Column to Epic Queue Page Past Tab

### DIFF
--- a/app/views/dashboard/epic_queue_records/index.json.jbuilder
+++ b/app/views/dashboard/epic_queue_records/index.json.jbuilder
@@ -4,5 +4,6 @@ json.(@epic_queue_records) do |eqr|
   json.pis format_pis(eqr.protocol)
   json.date format_epic_queue_created_at(eqr)
   json.status eqr.status.capitalize
+  json.type eqr.origin.try(:titleize)
   json.by eqr.try(:identity).try(:full_name)
 end

--- a/app/views/dashboard/epic_queues/_epic_queue_records_table.html.haml
+++ b/app/views/dashboard/epic_queues/_epic_queue_records_table.html.haml
@@ -31,5 +31,7 @@
           = t(:epic_queues)[:date]
         %th{data: { field: "status", align: "left", sortable: 'true' } }
           = t(:epic_queues)[:status]
+        %th{data: { field: 'type', align: 'left', sortable: 'true' } }
+          = t(:epic_queues)[:type]
         %th{data: { field: 'by', align: 'left', sortable: 'true' } }
           = t(:epic_queues)[:by]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1194,6 +1194,7 @@ en:
     send: 'Send'
     by: 'By'
     sent_protocols: 'Sent Protocols'
+    type: 'Type'
   footer:
     mail_to: "hundc@musc.edu"
     mail_link: "Sign Up For the SPARC Request Listserv"


### PR DESCRIPTION
Background: Now there are multiple types of Epic pushed in the system ("Submission Push", "Overlord Push", "Authorized User Update"), it would be beneficial to add a column on the "Past" tab of Epic Queue page to display the different types.

[#153575741]

Story - https://www.pivotaltracker.com/story/show/153575741