### PR TITLE
wth - (SPARCDashboard) Push to Fulfillment Error Message Wrong Language

### DIFF
--- a/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
+++ b/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
@@ -54,7 +54,7 @@ $(document).ready ->
       url: "/dashboard/sub_service_requests/#{sub_service_request_id}?check_sr_calendar=true"
       data: data
       error: (xhr, ajaxOptions, thrownError) ->
-        swal('Error', 'This protocol has failed to be sent to Epic because of failed validation. Please make sure the service calendar is intact before trying again.', 'error')
+        swal('Error', 'This protocol has failed to be sent to SPARCFulfillment because of failed validation. Please make sure the service calendar is intact before trying again.', 'error')
 
   $(document).on 'click', '#send_to_epic_button', ->
     $(this).prop( "disabled", true )


### PR DESCRIPTION
On SPARCDashboard inside Admin Edit of an SSR, when a user tries to send an SSR to SPARCFulfillment with a broken calendar, please fix the language in the error message, so that it says "SPARCFulfillment" instead of "Epic";
The "Epic" language should apply when "Send to Epic" is clicked and the calendar is broken.

[#154292119]

Story - https://www.pivotaltracker.com/story/show/154292119