### PR TITLE
wth - (SPARCDashboard) Tool Tip Style Variation

### DIFF
--- a/app/views/dashboard/service_requests/_service_requests.html.haml
+++ b/app/views/dashboard/service_requests/_service_requests.html.haml
@@ -66,3 +66,4 @@
 :javascript
   $('.view-consolidated').tooltip();
   $('.export-consolidated').tooltip();
+  $('.coverage-analysis-report').tooltip();


### PR DESCRIPTION
In Dashboard there is a variation in the style of the tool tips when hovering over buttons.
 "View Consolidated Request" & "Export Consolidated Request"  tool tips pop up above the button and have white wording on a black background.
The tool tip for " Coverage Analysis Report" displays below the button and off-centered--and with black wording on a white background.

[#153825386]

Story - https://www.pivotaltracker.com/story/show/153825386