### PR TITLE
wth - (SPARCRequest) Step 6: Adjust Table Display for Consistency

### DIFF
--- a/app/views/service_requests/review.html.haml
+++ b/app/views/service_requests/review.html.haml
@@ -28,9 +28,14 @@
     = render 'service_requests/review/instructions'
     = render 'service_requests/review/protocol_information', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/authorized_users', service_request: @service_request, protocol: @service_request.protocol
+    = render 'service_requests/review/calendars', service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, tab: @tab, arm: @arm, portal: @portal, admin: @admin, review: @review, merged: @merged, consolidated: @consolidated, display_all_services: @display_all_services
     = render 'service_requests/review/documents', service_request: @service_request, protocol: @service_request.protocol
     = render 'service_requests/review/notes', service_request: @service_request, notable_id: @notable_id, notable_type: @notable_type
-    = render 'service_requests/review/calendars', service_request: @service_request, sub_service_request: @sub_service_request, pages: @pages, tab: @tab, arm: @arm, portal: @portal, admin: @admin, review: @review, merged: @merged, consolidated: @consolidated, display_all_services: @display_all_services
+    - if @service_request.additional_detail_services.present?
+      = render "additional_details/document_management_submissions_table", service_request: @service_request, objects_with_questionnaires: @service_request.line_items, questionable_type: 'Service'
+
+    - if @service_request.additional_detail_organizations.present?
+      = render "additional_details/document_management_submissions_table", service_request: @service_request, objects_with_questionnaires: @service_request.sub_service_requests, questionable_type: 'Organization'
 = render 'service_requests/navigation/footer', service_request: @service_request, sub_service_request_id: @sub_service_request.try(:id), css_class: @css_class, back: @back, forward: @forward
 
 - if Setting.find_by_key("system_satisfaction_survey").value


### PR DESCRIPTION
Background: Currently, on SPARCRequest Step 6 (Review Your Request), the sequence of the tables displayed doesn't follow the steps, and the Forms table (when form functionality is activated) is not present for users to review the form-related info.

Please:
1). Adjust the sequence of the displayed tables on SPARCRequest Step 6, so that the "Clinical Services", "Non-clinical Services", and "Total Costs" table shows up before the "Documents" table.

2). Add the "Forms" table (with viewing function) to below the "Notes" table, for user to get a whole view of the protocol/request.

[#153994564]

Story - https://www.pivotaltracker.com/story/show/153994564