### PR TITLE
wth - (SPARCRequest Step 3 & SPARCDashboard) Adding 2 new Timeline Fi…

### DIFF
--- a/app/assets/javascripts/dashboard/milestone.js.coffee
+++ b/app/assets/javascripts/dashboard/milestone.js.coffee
@@ -20,6 +20,12 @@
 
 $ ->
 
+  if $('.initial-budget-sponsor-received-date-picker').val() != ''
+    $('.initial-amount').removeClass('hide')
+
+  if $('.budget-agreed-upon-date-picker').val() != ''
+    $('.negotiated-amount').removeClass('hide')
+
   $(document).on 'dp.change', '.start-date-picker', (e) ->
     $('.start-date-setter').val(e.date)
 
@@ -32,6 +38,15 @@ $ ->
   $(document).on 'dp.change', '.recruitment-end-date-picker', (e) ->
     $('.recruitment-end-date-setter').val(e.date)
 
-  $(document).on 'dp.hide', '.start-date-picker, .end-date-picker, .recruitment-start-date-picker, .recruitment-end-date-picker', ->
+  $(document).on 'dp.change', '.initial-budget-sponsor-received-date-picker', (e) ->
+    $('.initial-budget-sponsor-received-date-setter').val(e.date)
+
+  $(document).on 'dp.change', '.budget-agreed-upon-date-picker', (e) ->
+    $('.budget-agreed-upon-setter').val(e.date)
+
+  $(document).on 'dp.hide', '.start-date-picker, .end-date-picker, .recruitment-start-date-picker, .recruitment-end-date-picker, .initial-budget-sponsor-received-date-picker, .budget-agreed-upon-date-picker', ->
+    $('.milestone-form').submit()
+
+  $(document).on 'blur', '.initial-amount, .negotiated-amount', ->
     $('.milestone-form').submit()
 

--- a/app/assets/javascripts/service_details.js.coffee
+++ b/app/assets/javascripts/service_details.js.coffee
@@ -57,3 +57,16 @@ $(document).ready ->
     $('.name-validation').tooltip()
     $('.subject-count').tooltip()
     $('.visit-count').tooltip()
+
+
+  $(document).on 'dp.change', '.initial-budget-sponsor-received-date-picker', ->
+    $('.initial-amount').removeClass('hide')
+
+  $(document).on 'dp.change', '.budget-agreed-upon-date-picker', ->
+    $('.negotiated-amount').removeClass('hide')
+
+  if $('.initial-budget-sponsor-received-date-picker').val() != ''
+    $('.initial-amount').removeClass('hide')
+
+  if $('.budget-agreed-upon-date-picker').val() != ''
+    $('.negotiated-amount').removeClass('hide')

--- a/app/controllers/dashboard/milestones_controller.rb
+++ b/app/controllers/dashboard/milestones_controller.rb
@@ -35,7 +35,11 @@ class Dashboard::MilestonesController < Dashboard::BaseController
       :start_date,
       :end_date,
       :recruitment_start_date,
-      :recruitment_end_date
+      :recruitment_end_date,
+      :initial_budget_sponsor_received_date,
+      :budget_agreed_upon_date,
+      :initial_amount,
+      :negotiated_amount
     )
   end
 end

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -262,10 +262,10 @@ class ServiceRequestsController < ApplicationController
       required_keys = params[:study] ? :study : params[:project] ? :project : nil
       if required_keys.present?
         temp = params.require(required_keys).permit(:start_date, :end_date,
-          :recruitment_start_date, :recruitment_end_date).to_h
+          :recruitment_start_date, :recruitment_end_date, :initial_budget_sponsor_received_date, :budget_agreed_upon_date, :initial_amount, :negotiated_amount).to_h
 
         # Finally, transform date attributes.
-        date_attrs = %w(start_date end_date recruitment_start_date recruitment_end_date)
+        date_attrs = %w(start_date end_date recruitment_start_date recruitment_end_date initial_budget_sponsor_received_date budget_agreed_upon_date)
         temp.inject({}) do |h, (k, v)|
           if date_attrs.include?(k) && v.present?
             h.merge(k => Time.strptime(v, "%m/%d/%Y"))

--- a/app/views/dashboard/milestones/update.js.coffee
+++ b/app/views/dashboard/milestones/update.js.coffee
@@ -23,3 +23,9 @@ $(".datetimepicker:not(.time)").datetimepicker(format: 'MM/DD/YYYY', allowInputT
 $('.datetimepicker.time').datetimepicker(format: 'hh:mm A', allowInputToggle: true)
 $(".selectpicker").selectpicker()
 $('[data-toggle="tooltip"]').tooltip()
+if $('.initial-budget-sponsor-received-date-picker').val() != ''
+  $('.initial-amount').removeClass('hide')
+
+if $('.budget-agreed-upon-date-picker').val() != ''
+  $('.negotiated-amount').removeClass('hide')
+

--- a/app/views/dashboard/protocols/_milestone.html.haml
+++ b/app/views/dashboard/protocols/_milestone.html.haml
@@ -72,3 +72,64 @@
                 value: (protocol.recruitment_end_date.strftime('%_m/%d/%Y') rescue nil)
               = f.hidden_field :recruitment_end_date, value: nil,
                 class: 'recruitment-end-date-setter'
+        - if protocol.funding_source == 'industry'
+          .form-group.col-lg-12#initial-budget-sponsor-received-date
+            = f.label :initial_budget_sponsor_received_date,
+              t(:proper)[:service_details][:initial_budget_sponsor_received_date],
+              class: 'col-lg-2 control-label'
+            .col-lg-4
+              = text_field_tag 'initial_budget_sponsor_received_date', nil,
+                class: 'datetimepicker form-control initial-budget-sponsor-received-date-picker',
+                value: (protocol.initial_budget_sponsor_received_date.strftime('%_m/%d/%Y') rescue nil)
+              = f.hidden_field :initial_budget_sponsor_received_date, value: nil,
+                class: 'initial-budget-sponsor-received-date-setter'
+            - if protocol.has_clinical_services?
+              .initial-amount.hide
+                = f.label :initial_amount,
+                  t(:proper)[:service_details][:initial_amount_clinical_services],
+                  class: 'col-lg-2 control-label'
+                .col-lg-4
+                  .input-group
+                    .input-group-addon $
+                    = f.number_field :initial_amount,
+                      class: 'form-control'
+            - else
+              .initial-amount.hide
+                = f.label :initial_amount,
+                  t(:proper)[:service_details][:initial_amount_non_clinical_services],
+                  class: 'col-lg-2 control-label'
+                .col-lg-4
+                  .input-group
+                    .input-group-addon $
+                    = f.number_field :initial_amount,
+                      class: 'form-control'
+          .form-group.col-lg-12#budget-agreed-upon-date
+            = f.label :budget_agreed_upon_date,
+              t(:proper)[:service_details][:budget_agreed_upon_date],
+              class: 'col-lg-2 control-label'
+            .col-lg-4
+              = text_field_tag 'budget_agreed_upon_date', nil,
+                class: 'datetimepicker form-control budget-agreed-upon-date-picker',
+                value: (protocol.budget_agreed_upon_date.strftime('%_m/%d/%Y') rescue nil)
+              = f.hidden_field :budget_agreed_upon_date, value: nil,
+                class: 'budget-agreed-upon-setter'
+            - if protocol.has_clinical_services?
+              .negotiated-amount.hide
+                = f.label :negotiated_amount,
+                  t(:proper)[:service_details][:negotiated_amount_clinical_services],
+                  class: 'col-lg-2 control-label'
+                .col-lg-4
+                  .input-group
+                    .input-group-addon $
+                    = f.number_field :negotiated_amount,
+                      class: 'form-control'
+            - else
+              .negotiated-amount.hide
+                = f.label :negotiated_amount,
+                  t(:proper)[:service_details][:negotiated_amount_non_clinical_services],
+                  class: 'col-lg-2 control-label'
+                .col-lg-4
+                  .input-group
+                    .input-group-addon $
+                    = f.number_field :negotiated_amount,
+                      class: 'form-control'

--- a/app/views/service_requests/service_details/_details_dates.html.haml
+++ b/app/views/service_requests/service_details/_details_dates.html.haml
@@ -65,3 +65,60 @@
           = f.text_field :recruitment_end_date,
             class: 'datetimepicker form-control',
             value: (service_request.protocol.recruitment_end_date.strftime('%_m/%d/%Y') rescue nil)
+    - if service_request.protocol.funding_source == 'industry'
+      .form-group.col-lg-12#initial-budget-sponsor-received-date
+        = f.label :initial_budget_sponsor_received_date,
+          t(:proper)[:service_details][:initial_budget_sponsor_received_date],
+          class: 'col-lg-2 control-label'
+        .col-lg-4
+          = f.text_field :initial_budget_sponsor_received_date,
+            class: 'datetimepicker form-control initial-budget-sponsor-received-date-picker',
+            value: (service_request.protocol.initial_budget_sponsor_received_date.strftime('%_m/%d/%Y') rescue nil)
+        - if service_request.has_ctrc_clinical_services?
+          .initial-amount.hide
+            = f.label :initial_amount,
+              t(:proper)[:service_details][:initial_amount_clinical_services],
+              class: 'col-lg-2 control-label'
+            .col-lg-4
+              .input-group
+                .input-group-addon $
+                = f.number_field :initial_amount,
+                  class: 'form-control'
+        - else
+          .initial-amount.hide
+            = f.label :initial_amount,
+              t(:proper)[:service_details][:initial_amount_non_clinical_services],
+              class: 'col-lg-2 control-label'
+            .col-lg-4
+              .input-group
+                .input-group-addon $
+                = f.number_field :initial_amount,
+                  class: 'form-control'
+      .form-group.col-lg-12#budget-agreed-upon-date
+        = f.label :budget_agreed_upon_date,
+          t(:proper)[:service_details][:budget_agreed_upon_date],
+          class: 'col-lg-2 control-label'
+        .col-lg-4
+          = f.text_field :budget_agreed_upon_date,
+            class: 'datetimepicker form-control budget-agreed-upon-date-picker',
+            value: (service_request.protocol.budget_agreed_upon_date.strftime('%_m/%d/%Y') rescue nil)
+        - if service_request.has_ctrc_clinical_services?
+          .negotiated-amount.hide
+            = f.label :negotiated_amount,
+              t(:proper)[:service_details][:negotiated_amount_clinical_services],
+              class: 'col-lg-2 control-label'
+            .col-lg-4
+              .input-group
+                .input-group-addon $
+                = f.number_field :negotiated_amount,
+                  class: 'form-control'
+        - else
+          .negotiated-amount.hide
+            = f.label :negotiated_amount,
+              t(:proper)[:service_details][:negotiated_amount_non_clinical_services],
+              class: 'col-lg-2 control-label'
+            .col-lg-4
+              .input-group
+                .input-group-addon $
+                = f.number_field :negotiated_amount,
+                  class: 'form-control'

--- a/app/views/service_requests/service_details/_service_details_left.html.haml
+++ b/app/views/service_requests/service_details/_service_details_left.html.haml
@@ -17,7 +17,7 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.col-md-9.service-details-left  
+.col-md-9.service-details-left
   = render 'service_requests/service_details/details_dates', service_request: service_request, protocol: protocol
   - if (sub_service_request.nil? ? service_request.has_per_patient_per_visit_services? : sub_service_request.has_per_patient_per_visit_services?)
     = render 'service_requests/service_details/details_arms', service_request: service_request

--- a/config/locales/proper.en.yml
+++ b/config/locales/proper.en.yml
@@ -106,6 +106,12 @@ en:
       end_date: "End Date"
       recruitment_start: "Estimated Recruitment Start Date"
       recruitment_end: "Estimated Recruitment End Date"
+      initial_budget_sponsor_received_date: "Initial Budget Sponsor Received Date"
+      budget_agreed_upon_date: 'Budget Agreed Upon Date'
+      initial_amount_clinical_services: 'Initial Amount Per Patient'
+      initial_amount_non_clinical_services: 'Initial Site Level Account Offered'
+      negotiated_amount_clinical_services: 'Negotiated Amount Per Patient'
+      negotiated_amount_non_clinical_services: 'Negotiated Site Level Amount'
       tooltips:
         start_date: 'Study/Project estimated start date (used by service providers to prioritize)'
         end_date: 'Study/Project estimated end date (used by service providers to prioritize)'

--- a/db/migrate/20180125155307_add_new_timeline_fields_to_protocols.rb
+++ b/db/migrate/20180125155307_add_new_timeline_fields_to_protocols.rb
@@ -1,0 +1,6 @@
+class AddNewTimelineFieldsToProtocols < ActiveRecord::Migration[5.1]
+  def change
+    add_column :protocols, :initial_budget_sponsor_received_date, :datetime, after: :end_date
+    add_column :protocols, :budget_agreed_upon_date, :datetime, after: :initial_budget_sponsor_received_date
+  end
+end

--- a/db/migrate/20180126140905_add_initial_amount_and_negotiated_amount_to_protocols.rb
+++ b/db/migrate/20180126140905_add_initial_amount_and_negotiated_amount_to_protocols.rb
@@ -1,0 +1,6 @@
+class AddInitialAmountAndNegotiatedAmountToProtocols < ActiveRecord::Migration[5.1]
+  def change
+    add_column :protocols, :initial_amount, :decimal, precision: 8, scale: 2, after: :budget_agreed_upon_date
+    add_column :protocols, :negotiated_amount, :decimal, precision: 8, scale: 2, after: :initial_amount
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171206151250) do
+ActiveRecord::Schema.define(version: 20180126140905) do
 
   create_table "admin_rates", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer "line_item_id"
@@ -610,6 +610,10 @@ ActiveRecord::Schema.define(version: 20171206151250) do
     t.string "last_epic_push_status"
     t.datetime "start_date"
     t.datetime "end_date"
+    t.datetime "initial_budget_sponsor_received_date"
+    t.datetime "budget_agreed_upon_date"
+    t.decimal "initial_amount", precision: 8, scale: 2
+    t.decimal "negotiated_amount", precision: 8, scale: 2
     t.string "billing_business_manager_static_email"
     t.datetime "recruitment_start_date"
     t.datetime "recruitment_end_date"

--- a/spec/api/v1/protocols/get_protocol_spec.rb
+++ b/spec/api/v1/protocols/get_protocol_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:protocol).attributes.
                                 keys.
-                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked'].include?(key) }.
+                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked', 'budget_agreed_upon_date', 'initial_budget_sponsor_received_date', 'initial_amount', 'negotiated_amount'].include?(key) }.
                                 push('callback_url', 'sparc_id').
                                 sort
         expect(parsed_body['protocol'].keys.sort).to eq(expected_attributes)
@@ -81,7 +81,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:protocol).attributes.
                                 keys.
-                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked'].include?(key) }.
+                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked', 'budget_agreed_upon_date', 'initial_budget_sponsor_received_date', 'initial_amount', 'negotiated_amount'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'arms', 'service_requests', 'project_roles', 'human_subjects_info').
                                 sort
 

--- a/spec/api/v1/protocols/get_protocols_spec.rb
+++ b/spec/api/v1/protocols/get_protocols_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:protocol).attributes.
                                 keys.
-                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked'].include?(key) }.
+                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked', 'budget_agreed_upon_date', 'initial_budget_sponsor_received_date', 'initial_amount', 'negotiated_amount'].include?(key) }.
                                 push('callback_url', 'sparc_id').
                                 sort
 
@@ -93,7 +93,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:protocol).attributes.
                                 keys.
-                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked'].include?(key) }.
+                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked', 'budget_agreed_upon_date', 'initial_budget_sponsor_received_date', 'initial_amount', 'negotiated_amount'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'arms', 'service_requests', 'project_roles', 'human_subjects_info').
                                 sort
 

--- a/spec/api/v1/protocols/get_protocols_with_ids_spec.rb
+++ b/spec/api/v1/protocols/get_protocols_with_ids_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:protocol).attributes.
                                 keys.
-                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked'].include?(key) }.
+                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked', 'budget_agreed_upon_date', 'initial_budget_sponsor_received_date', 'initial_amount', 'negotiated_amount'].include?(key) }.
                                 push('callback_url', 'sparc_id').
                                 sort
         expect(parsed_body['protocols'].map(&:keys).flatten.uniq.sort).to eq(expected_attributes)
@@ -93,7 +93,7 @@ RSpec.describe 'SPARCCWF::APIv1', type: :request do
         parsed_body         = JSON.parse(response.body)
         expected_attributes = build(:protocol).attributes.
                                 keys.
-                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked'].include?(key) }.
+                                reject { |key| ['study_phase', 'id', 'created_at', 'updated_at', 'deleted_at', 'research_master_id', 'sub_service_requests_count', 'rmid_validated', 'locked', 'budget_agreed_upon_date', 'initial_budget_sponsor_received_date', 'initial_amount', 'negotiated_amount'].include?(key) }.
                                 push('callback_url', 'sparc_id', 'arms', 'service_requests', 'project_roles', 'human_subjects_info').
                                 sort
 


### PR DESCRIPTION
…elds to Collect Budget Negotiation Metrics

Background: The initial and final awards dates and dollar amounts have been collected manually in another system.

As an effort to centralize the timeline information, please
1). Add 2 more date fields into the SPARCRequest Step 3 page and SPARCDashboard "Milestones" section to collect the "Initial Sponsor Budget Received Date" and "Budget Agreed Upon Date" dates for protocols with industry funding source (display should be logic driven by funding source). Both fields are non-required.
2). When either of these new dates are filled out, please then display the corresponding 2 amount $ fields for users to fill in the corresponding initial and negotiated budget dollar amount. The $ fields should be hidden when no dates are filled out, for better usability.

[#153600730]

Story - https://www.pivotaltracker.com/story/show/153600730