### PR TITLE
Jtm add quantity validation non clinical services

### DIFF
--- a/app/controllers/dashboard/line_items_controller.rb
+++ b/app/controllers/dashboard/line_items_controller.rb
@@ -53,6 +53,9 @@ class Dashboard::LineItemsController < Dashboard::BaseController
     if line_item_params[:service_id].blank?
       @sub_service_request.errors.add(:service, 'must be selected')
       @errors = @sub_service_request.errors
+    elsif line_item_params[:quantity].blank? && Service.find(line_item_params[:service_id]).one_time_fee
+      @sub_service_request.errors.add(:base, 'Must input a quantity')
+      @errors = @sub_service_request.errors
     elsif !@sub_service_request.create_line_item(line_item_params)
       @errors = @sub_service_request.errors
     else

--- a/app/views/dashboard/study_level_activities/_study_level_activity_form.html.haml
+++ b/app/views/dashboard/study_level_activities/_study_level_activity_form.html.haml
@@ -34,11 +34,11 @@
             = form.hidden_field :sub_service_request_id
             = form.hidden_field :service_request_id
             .form-group
-              = form.label "service", t(:dashboard)[:study_level_activities][:form][:service], class: "col-sm-4 control-label"
+              = form.label "service", t(:dashboard)[:study_level_activities][:form][:service], class: "col-sm-4 control-label required"
               .col-sm-7
                 = sla_form_services_select(form, line_item)
             .form-group
-              = form.label "quantity", t(:dashboard)[:study_level_activities][:form][:quantity_requested], class: "col-sm-4 control-label"
+              = form.label "quantity", t(:dashboard)[:study_level_activities][:form][:quantity_requested], class: "col-sm-4 control-label required"
               .col-sm-7
                 = form.text_field "quantity", {class: 'form-control'}
             .form-group

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -322,8 +322,8 @@ en:
         complete: "Complete"
         actions: "Actions"
       form:
-        service: "Service:"
-        quantity_requested: "Quantity Requested:"
+        service: "Service:*"
+        quantity_requested: "Quantity Requested:*"
         in_process: "In Process Date:"
         complete: "Complete Date:"
       actions:

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -322,8 +322,8 @@ en:
         complete: "Complete"
         actions: "Actions"
       form:
-        service: "Service:*"
-        quantity_requested: "Quantity Requested:*"
+        service: "Service:"
+        quantity_requested: "Quantity Requested:"
         in_process: "In Process Date:"
         complete: "Complete Date:"
       actions:

--- a/spec/controllers/dashboard/line_items/post_create_spec.rb
+++ b/spec/controllers/dashboard/line_items/post_create_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Dashboard::LineItemsController do
     context "params[:line_item][:service_id] blank" do
       before(:each) do
         @service_request = build_stubbed(:service_request)
-
         @sub_service_request = findable_stub(SubServiceRequest) do
           build_stubbed(:sub_service_request, service_request: @service_request)
         end
@@ -56,6 +55,12 @@ RSpec.describe Dashboard::LineItemsController do
       before(:each) do
         @service_request = build_stubbed(:service_request)
 
+        @service = findable_stub(Service) do
+          build_stubbed(:service)
+        end
+        allow(@service).to receive(:one_time_fee).
+          and_return(true)
+
         @sub_service_request = findable_stub(SubServiceRequest) do
           build_stubbed(:sub_service_request, service_request: @service_request)
         end
@@ -63,7 +68,7 @@ RSpec.describe Dashboard::LineItemsController do
           and_return("candidate pppv services")
 
         log_in_dashboard_identity(obj: build_stubbed(:identity))
-        post :create, params: { line_item: { service_id: 'not blank', sub_service_request_id: @sub_service_request.id } }, xhr: true
+        post :create, params: { line_item: { service_id: @service.id, sub_service_request_id: @sub_service_request.id } }, xhr: true
       end
 
       it "should set @sub_service_request from params[:line_item][:sub_service_request_id]" do
@@ -86,6 +91,10 @@ RSpec.describe Dashboard::LineItemsController do
       before(:each) do
         @service_request = build_stubbed(:service_request)
 
+        @service = findable_stub(Service) do
+          build_stubbed(:service)
+        end
+
         @sub_service_request = findable_stub(SubServiceRequest) do
           build_stubbed(:sub_service_request, service_request: @service_request)
         end
@@ -96,7 +105,7 @@ RSpec.describe Dashboard::LineItemsController do
 
         log_in_dashboard_identity(obj: build_stubbed(:identity))
         post :create, params: {
-            line_item: { service_id: "not blank",
+            line_item: { service_id: @service.id,
             quantity: 1,
             sub_service_request_id: @sub_service_request.id 
             } }, xhr: true
@@ -122,6 +131,10 @@ RSpec.describe Dashboard::LineItemsController do
       before(:each) do
         @service_request = build_stubbed(:service_request)
 
+        @service = findable_stub(Service) do
+          build_stubbed(:service)
+        end
+
         @sub_service_request = findable_stub(SubServiceRequest) do
           build_stubbed(:sub_service_request, service_request: @service_request)
         end
@@ -132,7 +145,7 @@ RSpec.describe Dashboard::LineItemsController do
         logged_in_user = build_stubbed(:identity)
         log_in_dashboard_identity(obj: logged_in_user)
         post :create, params: {
-            line_item: { service_id: "not blank",
+            line_item: { service_id: @service.id,
             sub_service_request_id: @sub_service_request.id,
             quantity: 1
             } }, xhr: true

--- a/spec/controllers/dashboard/line_items/post_create_spec.rb
+++ b/spec/controllers/dashboard/line_items/post_create_spec.rb
@@ -52,7 +52,37 @@ RSpec.describe Dashboard::LineItemsController do
       it { is_expected.to respond_with :ok }
     end
 
-    context "params[:line_item][:service_id] present but params[:line_item] still describes an invalid LineItem" do
+    context "params[:line_item][:quantity] blank" do
+      before(:each) do
+        @service_request = build_stubbed(:service_request)
+
+        @sub_service_request = findable_stub(SubServiceRequest) do
+          build_stubbed(:sub_service_request, service_request: @service_request)
+        end
+        allow(@sub_service_request).to receive(:candidate_pppv_services).
+          and_return("candidate pppv services")
+
+        log_in_dashboard_identity(obj: build_stubbed(:identity))
+        post :create, params: { line_item: { service_id: 'not blank', sub_service_request_id: @sub_service_request.id } }, xhr: true
+      end
+
+      it "should set @sub_service_request from params[:line_item][:sub_service_request_id]" do
+        expect(assigns(:sub_service_request)).to eq(@sub_service_request)
+      end
+
+      it "should set @service_request to ServiceRequest of @sub_service_request" do
+        expect(assigns(:service_request)).to eq(@service_request)
+      end
+
+      it "should add an error message to SubServiceRequest for Service" do
+        expect(assigns(:errors).full_messages).to eq(["Must input a quantity"])
+      end
+
+      it { is_expected.to render_template "dashboard/line_items/create" }
+      it { is_expected.to respond_with :ok }
+    end
+
+    context "params[:line_item][:service_id] and params[:line_item][:quantity] present but params[:line_item] still describes an invalid LineItem" do
       before(:each) do
         @service_request = build_stubbed(:service_request)
 
@@ -67,6 +97,7 @@ RSpec.describe Dashboard::LineItemsController do
         log_in_dashboard_identity(obj: build_stubbed(:identity))
         post :create, params: {
             line_item: { service_id: "not blank",
+            quantity: 1,
             sub_service_request_id: @sub_service_request.id 
             } }, xhr: true
       end
@@ -102,7 +133,8 @@ RSpec.describe Dashboard::LineItemsController do
         log_in_dashboard_identity(obj: logged_in_user)
         post :create, params: {
             line_item: { service_id: "not blank",
-            sub_service_request_id: @sub_service_request.id 
+            sub_service_request_id: @sub_service_request.id,
+            quantity: 1
             } }, xhr: true
       end
 


### PR DESCRIPTION
Current, SPARCDashboard Admin Edit section is allowing admin users to add/edit Non-clinical services with blank "Quantity Requested" field, which is creating bad data and could cause silent failure when pushing the request to SPARCFulfillment.
Please:
1). Add validation to the "Quantity Requested" field for Adding/Editing Non-clinical services;
2). Please indicate the required fields with "*" in the popup modal.