### PR TITLE
Jtm remove archiving from service provider

### DIFF
--- a/app/helpers/dashboard/protocols_helper.rb
+++ b/app/helpers/dashboard/protocols_helper.rb
@@ -50,8 +50,8 @@ module Dashboard::ProtocolsHelper
     end
   end
 
-  def display_archive_button(protocol, permission_to_edit)
-    if permission_to_edit
+  def display_archive_button(protocol, permission_to_edit, current_user)
+    if permission_to_edit || Protocol.for_super_user(current_user.id).include?(protocol)
       content_tag( :button, (protocol.archived ? t(:protocols)[:summary][:unarchive] : t(:protocols)[:summary][:archive])+" #{protocol.type.capitalize}", 
                     type: 'button', 
                     class: 'protocol-archive-button btn btn-default btn-sm',

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -60,7 +60,16 @@ class Organization < ApplicationRecord
   # TODO: In rails 5, the .or operator will be added for ActiveRecord queries. We should try to
   #       condense this to a single query at that point
   scope :authorized_for_identity, -> (identity_id) {
-    orgs = includes(:super_users, :service_providers).where("super_users.identity_id = ? or service_providers.identity_id = ?", identity_id, identity_id).references(:super_users, :service_providers).distinct(:organizations)
+    authorized_for_super_user(identity_id).or( authorized_for_service_provider(identity_id) )
+  }
+
+  scope :authorized_for_super_user, -> (identity_id) {
+    orgs = joins(:super_users).where(super_users: { identity_id: identity_id } ).references(:super_users).distinct(:organizations)
+    where(id: orgs + Organization.authorized_child_organizations(orgs.map(&:id))).distinct
+  }
+
+  scope :authorized_for_service_provider, -> (identity_id) {
+    orgs = joins(:service_providers).where(service_providers: { identity_id: identity_id } ).references(:service_providers).distinct(:organizations)
     where(id: orgs + Organization.authorized_child_organizations(orgs.map(&:id))).distinct
   }
 

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -236,17 +236,23 @@ class Protocol < ApplicationRecord
     # returns protocols with ssrs in orgs authorized for identity
     return nil if identity_id == '0'
 
-    ssrs = SubServiceRequest.where.not(status: 'first_draft').where(organization_id: Organization.authorized_for_identity(identity_id))
-
     if SuperUser.where(identity_id: identity_id).any?
-      empty_protocol_ids  = includes(:sub_service_requests).where(sub_service_requests: { id: nil }).ids
-      protocol_ids        = ssrs.distinct.pluck(:protocol_id)
-      all_protocol_ids    = (protocol_ids + empty_protocol_ids).uniq
-
-      where(id: all_protocol_ids)
+      self.for_super_user(identity_id)
     else
+      ssrs = SubServiceRequest.where.not(status: 'first_draft').where(organization_id: Organization.authorized_for_service_provider(identity_id))
       joins(:sub_service_requests).merge(ssrs).distinct
     end
+  }
+
+  scope :for_super_user, -> (identity_id) {
+    # returns protocols with ssrs in orgs authorized for identity
+    ssrs = SubServiceRequest.where.not(status: 'first_draft').where(organization_id: Organization.authorized_for_super_user(identity_id))
+
+    empty_protocol_ids  = includes(:sub_service_requests).where(sub_service_requests: { id: nil }).ids
+    protocol_ids        = ssrs.distinct.pluck(:protocol_id)
+    all_protocol_ids    = (protocol_ids + empty_protocol_ids).uniq
+
+    where(id: all_protocol_ids)
   }
 
   scope :show_archived, -> (boolean) {

--- a/app/views/dashboard/associated_users/update.js.coffee
+++ b/app/views/dashboard/associated_users/update.js.coffee
@@ -27,7 +27,7 @@ $("#modal_place").modal('hide')
 window.location = "/dashboard"
 # Update the entire view to account for the current users rights change
 <% elsif @current_user_updated %>
-$("#summary-panel").html("<%= escape_javascript(render('dashboard/protocols/summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit || @admin, user: @user)) %>")
+$("#summary-panel").html("<%= escape_javascript(render('dashboard/protocols/summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit, admin: @admin, user: @user)) %>")
 $("#authorized-users-panel").html("<%= escape_javascript(render('dashboard/associated_users/table', protocol: @protocol, permission_to_edit: @permission_to_edit || @admin)) %>")
 $("#documents-panel").html("<%= escape_javascript(render( 'dashboard/documents/documents_table', protocol: @protocol, permission_to_edit: @permission_to_edit || @admin )) %>")
 $("#service-requests-panel").html("<%= escape_javascript(render('dashboard/service_requests/service_requests', protocol: @protocol, permission_to_edit: @permission_to_edit, user: @user, view_only: false, show_view_ssr_back: false)) %>")

--- a/app/views/dashboard/protocols/_summary.html.haml
+++ b/app/views/dashboard/protocols/_summary.html.haml
@@ -28,8 +28,8 @@
           = protocol.notes.count
       %button.btn.btn-sm.btn-info.view-protocol-details-button{ data: { protocol_id: protocol.id, toggle: 'tooltip', placement: 'bottom', delay: '{"show":"500"}' }, title: t(:protocols)[:summary][:tooltips][:details] }
         = I18n.t('protocols.view_details.button', protocol_type: protocol_type)
-      = edit_protocol_button_display(protocol, permission_to_edit)
-      = display_archive_button(protocol, permission_to_edit)
+      = edit_protocol_button_display(protocol, (permission_to_edit || admin))
+      = display_archive_button(protocol, permission_to_edit, user)
     .clearfix
   .panel-body#protocol-summary.text-left
     - if Setting.find_by_key("research_master_enabled").value && protocol.is_study?

--- a/app/views/dashboard/protocols/archive.js.coffee
+++ b/app/views/dashboard/protocols/archive.js.coffee
@@ -17,4 +17,4 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$('#summary-panel').replaceWith("<%= j render 'summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit || @admin %>")
+$('#summary-panel').replaceWith("<%= j render 'summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit, admin: @admin, user: @user %>")

--- a/app/views/dashboard/protocols/show.html.haml
+++ b/app/views/dashboard/protocols/show.html.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 = stylesheet_link_tag 'associated_users_table'
 .panel-group#protocol_show_information_panel
-  = render 'dashboard/protocols/summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit || @admin
+  = render 'dashboard/protocols/summary', protocol: @protocol, protocol_type: @protocol_type, permission_to_edit: @permission_to_edit, admin: @admin, user: @user
   = render 'dashboard/associated_users/table', protocol: @protocol, permission_to_edit: @permission_to_edit || @admin
   = render 'dashboard/calendar_structure/table', protocol: @protocol
   = render 'dashboard/service_requests/service_requests', protocol: @protocol, super_user_orgs: @super_user_orgs, permission_to_edit: @permission_to_edit, user: @user, view_only: false, show_view_ssr_back: @show_view_ssr_back, statuses_hidden: %(first_draft)

--- a/spec/views/dashboard/protocols/_summary.html.haml_spec.rb
+++ b/spec/views/dashboard/protocols/_summary.html.haml_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'dashboard/protocols/summary', type: :view do
       protocol: protocol,
       protocol_type: protocol.type,
       permission_to_edit: true,
+      admin: true,
       user: jug2
   end
 


### PR DESCRIPTION
In a project's protocol summary section, anyone with access to the project can archive the project (service provider, PI, Super Users, etc...). Should we minimize the ability for service providers to archive projects?
Update Note on 11/15/2017:
Please remove service provider's access to the "Archive Project/Study" button on SPARCDashboard Project/Study Summary form, so that the function is only available to authorized study team users (with Authorize/Change Study Charges right), super users and overlords who have access to that Project/Study.

#154766583

https://www.pivotaltracker.com/story/show/154766583