### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Validate File Types

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -25,7 +25,26 @@ class Document < ApplicationRecord
   has_and_belongs_to_many :sub_service_requests
   belongs_to :protocol
   has_attached_file :document #, :preserve_files => true
-  do_not_validate_attachment_file_type :document
+  validates_attachment :document, content_type: { content_type: [
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-office",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.ms-powerpoint",
+    "application/octet-stream",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/msword",
+    "application/vnd.ms-excel",
+    "image/jpeg",
+    "text/csv",
+    "text/rtf",
+    "text/plain",
+    "text/msg",
+    "message/rfc822",
+    "image/gif",
+    "image/png",
+    "image/tiff"
+  ] }
 
   validates :doc_type, :document, presence: true
   validates :doc_type_other, presence: true, if: Proc.new { |doc| doc.doc_type == 'other' }

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -22,3 +22,14 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "application/pdf", :pdf
+Mime::Type.register "application/xls", :xls
+Rack::Mime::MIME_TYPES.merge!({
+    ".xls"     => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".xlsx"     => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".ppt"     => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".pptx"     => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".doc"     => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".docx"     => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+})


### PR DESCRIPTION
When testing, we realized that you have the ability to upload any type of document. This includes .exe files, which we view as a potential security concern.

Validating rtf, txt, xls, xlsx, csv, ppt, pptx, msg, eml (for emails),
jpeg, gif, png, tiff (and other graph formats), pdf, doc, docx

[#153447613]

Story - https://www.pivotaltracker.com/story/show/153447613