### PR TITLE
Jl - finished status select refactor

### DIFF
--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -302,11 +302,14 @@ module Dashboard::SubServiceRequestsHelper
     end
 
     new_statuses.each do |status|
-      status
+      status.push(:class=> 'finished-status')
     end
   end
 
   def in_finished_status?(status)
+    finished_statuses = Setting.find_by_key("finished_statuses")
+    puts "<>"*1000
+    puts finished_statuses.inspect
     status.include?('Complete') || status.include?('Withdrawn')
   end
 end

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -307,10 +307,7 @@ module Dashboard::SubServiceRequestsHelper
   end
 
   def in_finished_status?(status)
-    finished_statuses = Setting.find_by_key("finished_statuses")
-    puts "<>"*1000
-    puts finished_statuses.inspect
-    status.include?('Complete') || status.include?('Withdrawn')
+    Setting.find_by_key("finished_statuses").value.include?(status.last)
   end
 end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/154025715

We needed to use the finished statuses that are in the settings table rather than hard coding them into the sub service request's helper. It was also requested that the highlighting of the finished statuses were kept in, even though a request was already in a finished status.