### PR TITLE
wth - Use Yarn to manage our front-end assets

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -21,6 +21,7 @@
 SparcRails::Application.config.assets.paths.unshift "#{Rails.root}/themes/assets/stylesheets"
 SparcRails::Application.config.assets.paths.unshift "#{Rails.root}/themes/assets/images"
 SparcRails::Application.config.assets.paths.unshift "#{Rails.root}/themes/assets/javascripts"
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
 Rails.application.config.assets.precompile += %w( additional_details/application.css )
 Rails.application.config.assets.precompile += %w( additional_details/application.js )
 Rails.application.config.assets.precompile += %w( admin/application.css )

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sparc-request",
+  "version": "1.0.0",
+  "main": "index.js",
+  "repository": "https://github.com/sparc-request/sparc-request.git",
+  "author": "SPARCRequest <sparcrequest@gmail.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
Yarn is now a part of the Rails default stack. We should use this package manager for our front-end assets like Bootstrap, jQuery, etc.

This is a first step, all new js/css libraries should be added via Yarn.

https://yarnpkg.com/en/
https://github.com/rails/rails/pull/27300
http://weblog.rubyonrails.org/2016/12/10/this-week-in-rails-yarn-webpack-bigint-pks-and-more/
http://nithinbekal.com/posts/yarn-rails/

[#147836807]

Story - https://www.pivotaltracker.com/story/show/147836807