### PR TITLE
Removed inactive services from related services search [#152038451]

### DIFF
--- a/app/controllers/catalog_manager/services_controller.rb
+++ b/app/controllers/catalog_manager/services_controller.rb
@@ -198,8 +198,7 @@ class CatalogManager::ServicesController < CatalogManager::AppController
 
   def search
     term = params[:term].strip
-    services = Service.where("name LIKE '%#{term}%' OR abbreviation LIKE '%#{term}%' OR cpt_code LIKE '%#{term}%'")
-
+    services = Service.where("is_available=1 AND (name LIKE '%#{term}%' OR abbreviation LIKE '%#{term}%' OR cpt_code LIKE '%#{term}%')")
     reformatted_services = []
     services.each do |service|
       reformatted_services << {"label" => service.display_service_name, "value" => service.name, "id" => service.id}


### PR DESCRIPTION
#152038451

Background: When linking services in SPARCCatalog, currently the search result is showing both active and inactive services, which is confusing if the user has multiple hospital services that under the same code/name but are not provided any more.

In the bootstrappified SPARCCatalog, please only return the active services for "Related Services" search box.

https://www.pivotaltracker.com/story/show/152038451