### PR TITLE
KG - Fix Pending Responses and Survey Report

### DIFF
--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -53,6 +53,10 @@ class Surveyor::ResponsesController < Surveyor::BaseController
 
     respond_to do |format|
       format.js
+      format.html { # Only used to take System Surveys via Service Survey emails
+        redirect_to surveyor_response_complete_path(@response) if @response.completed?
+        @response.question_responses.build
+      }
     end
   end
 

--- a/app/reports/survey_responses.rb
+++ b/app/reports/survey_responses.rb
@@ -31,7 +31,7 @@ class SurveyResponseReport < ReportingModule
   def default_options
     {
       "Date Range" => {:field_type => :date_range, :for => "created_at", :from => "2012-03-01".to_date, :to => Date.today},
-      Survey => {:field_type => :select_tag, :custom_name_method => :report_title, :required => true},
+      SystemSurvey => {:field_type => :select_tag, :custom_name_method => :report_title, :required => true},
       "Include Pending Responses" => { field_type: :check_box_tag, for: "show_pending" }
     }
   end
@@ -40,13 +40,13 @@ class SurveyResponseReport < ReportingModule
   def column_attrs
     attrs = {}
 
-    attrs["SRID"] = "sub_service_request.try(:display_id)"
+    attrs["SRID"] = "respondable.is_a?(ServiceRequest) ? respondable.id : respondable.try(:display_id)"
     attrs["User ID"] = :identity_id
     attrs["User Name"] = "identity.try(:full_name)"
     attrs["Submitted Date"] = "created_at.try(:strftime, \"%D\")"
 
-    if params[:survey_id]
-      survey = Survey.find(params[:survey_id])
+    if params[:system_survey_id]
+      survey = Survey.find(params[:system_survey_id])
       survey.sections.each do |section|
         section.questions.each do |question|
           question.question_responses.each do |qr|
@@ -89,7 +89,7 @@ class SurveyResponseReport < ReportingModule
   def where args={}
     created_at = (args[:created_at_from] ? args[:created_at_from] : self.default_options["Date Range"][:from]).to_time.strftime("%Y-%m-%d 00:00:00")..(args[:created_at_to] ? args[:created_at_to] : self.default_options["Date Range"][:to]).to_time.strftime("%Y-%m-%d 23:59:59")
 
-    return :responses => {:created_at => created_at, :survey_id => args[:survey_id]}
+    return :responses => {:created_at => created_at, :survey_id => args[:system_survey_id]}
   end
 
   # Return only uniq records for
@@ -111,12 +111,12 @@ class SurveyResponseReport < ReportingModule
   def create_report(worksheet)
     super
 
-    start_date = (params[:created_at_from] ? params[:created_at_from] : "2012-03-01".to_date).to_time.strftime("%Y-%m-%d 00:00:00")
-    end_date = (params[:created_at_to] ? params[:created_at_to] : Date.today).to_time.strftime("%Y-%m-%d 23:59:59")
+    start_date                = (params[:created_at_from] ? params[:created_at_from] : "2012-03-01".to_date).to_time.strftime("%Y-%m-%d 00:00:00")
+    end_date                  = (params[:created_at_to] ? params[:created_at_to] : Date.today).to_time.strftime("%Y-%m-%d 23:59:59")
     # assumes the first question where only one option can be picked is the satisfaction question
-    survey                    = Survey.find(params[:survey_id])
+    survey                    = Survey.find(params[:system_survey_id])
     questions                 = Question.where(question_type: ['yes_no', 'likert', 'radio_button'], section: Section.where(survey: survey))
-    responses                 = QuestionResponse.where(question: questions, created_at: start_date..end_date).where.not(content: [nil, ""])
+    responses                 = QuestionResponse.includes(:response).where(question: questions, responses: { created_at: start_date..end_date }).where.not(content: [nil, ""])
     total_percent_satisfied   = responses.map{ |qr| percent_satisfied(qr.content.downcase) }.sum
     average_percent_satisifed = responses.count == 0 ? 0 : (total_percent_satisfied.to_f / responses.count.to_f).round(2)
 

--- a/app/views/surveyor/responses/edit.html.haml
+++ b/app/views/surveyor/responses/edit.html.haml
@@ -17,31 +17,14 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-= stylesheet_link_tag "system_satisfaction"
-
-= t('surveyor.responses.emails.service_survey.greeting', name: @identity.full_name)
-%br
-%br
-
-= t(:surveyor)[:responses][:emails][:service_survey][:text1]
-= "#{ssr_institution(@ssr.organization)} - #{ssr_provider(@ssr.organization)} - #{ssr_program_core(@ssr.organization)}."
-= t(:surveyor)[:responses][:emails][:service_survey][:text2]
-%br
-= t(:surveyor)[:responses][:emails][:service_survey][:text3]
-
-%br
-
-%ul
-- @surveys.each do |survey|
-  - unless response = survey.responses.where(identity: @identity, respondable: @ssr).first
-    - response = survey.responses.create(identity: @identity, respondable: @ssr)
-  %li
-    = link_to survey.title, url_for(controller: '/surveyor/responses', action: :edit, only_path: false, id: response.id, format: :html), target: '_blank'
-
-- if @surveys.pluck(:access_code).include?("sctr-customer-satisfaction-survey")
-  #sctr-grant-citation
-    %br
-    = t(:surveyor)[:responses][:emails][:sctr_customer_satisfaction][:grant_reminder]
-    %br
-    %em.gray-text
-      = raw(t(:surveyor)[:responses][:emails][:sctr_customer_satisfaction][:grant_info])
+.col-sm-8.col-sm-offset-2
+  .panel.panel-default#survey-panel
+    .panel-heading.text-center
+      %h4.panel-title
+        = @survey.title
+    = form_for @response, url: surveyor_response_path(@response), method: :put, remote: true do |f|
+      .panel-body
+        = render 'surveyor/responses/form/edit_form', f: f, survey: @survey, response: @response
+      .panel-footer
+        .clearfix
+          = f.submit t(:actions)[:submit], class: 'btn btn-primary pull-right'

--- a/app/views/surveyor/responses/form/_edit_form.html.haml
+++ b/app/views/surveyor/responses/form/_edit_form.html.haml
@@ -17,31 +17,24 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-= stylesheet_link_tag "system_satisfaction"
-
-= t('surveyor.responses.emails.service_survey.greeting', name: @identity.full_name)
-%br
-%br
-
-= t(:surveyor)[:responses][:emails][:service_survey][:text1]
-= "#{ssr_institution(@ssr.organization)} - #{ssr_provider(@ssr.organization)} - #{ssr_program_core(@ssr.organization)}."
-= t(:surveyor)[:responses][:emails][:service_survey][:text2]
-%br
-= t(:surveyor)[:responses][:emails][:service_survey][:text3]
-
-%br
-
-%ul
-- @surveys.each do |survey|
-  - unless response = survey.responses.where(identity: @identity, respondable: @ssr).first
-    - response = survey.responses.create(identity: @identity, respondable: @ssr)
-  %li
-    = link_to survey.title, url_for(controller: '/surveyor/responses', action: :edit, only_path: false, id: response.id, format: :html), target: '_blank'
-
-- if @surveys.pluck(:access_code).include?("sctr-customer-satisfaction-survey")
-  #sctr-grant-citation
-    %br
-    = t(:surveyor)[:responses][:emails][:sctr_customer_satisfaction][:grant_reminder]
-    %br
-    %em.gray-text
-      = raw(t(:surveyor)[:responses][:emails][:sctr_customer_satisfaction][:grant_info])
+#survey-response
+  - unless survey.description.blank?
+    .form-group
+      %p.survey-description.no-margin
+        = raw(survey.description)
+  .form-group.alert.alert-warning
+    = t(:errors)[:user_note]
+  .survey-sections
+    - survey.sections.eager_load(questions: :options).each do |section|
+      .panel.panel-default.section
+        .panel-heading
+          %h4.panel-title
+            = section.title
+        .panel-body
+          - unless section.description.blank?
+            .form-group
+              %p.section-description.no-margin
+                = raw(section.description)
+          - section.questions.each_with_index do |question, index|
+            = f.fields_for :question_responses do |qr|
+              = render 'surveyor/responses/form/response_question', qr: qr, section: section, question: question, index: index

--- a/app/views/surveyor/responses/update.js.coffee
+++ b/app/views/surveyor/responses/update.js.coffee
@@ -20,6 +20,8 @@
 <% if @response.valid? %>
 if $('#modal_place:visible').length > 0
   $('#modal_place').modal('hide')
+else
+  window.location = "<%= surveyor_response_complete_path(@response) %>"
 <% else %>
 <% @response.question_responses.each do |qr| %>
 <% if qr.valid? %>

--- a/spec/mailers/survey_notification_spec.rb
+++ b/spec/mailers/survey_notification_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe SurveyNotification do
 
     #ensure that the e-mail contains a link to the survey
     it 'should contain the survey link' do
-      expect(["/surveyor/responses/", "/new.html"].all? { |s| mail.body.include?(s) }).to eq(true)
+      expect(["/surveyor/responses/", "/edit.html"].all? { |s| mail.body.include?(s) }).to eq(true)
     end
 
     it 'should not contain the SCTR grant citation paragraph' do
@@ -107,7 +107,7 @@ RSpec.describe SurveyNotification do
 
     #ensure that the e-mail contains a link to the survey
     it 'should contain the survey link' do
-      expect(["/surveyor/responses/", "/new.html"].all? { |s| mail.body.include?(s) }).to eq(true)
+      expect(["/surveyor/responses/", "/edit.html"].all? { |s| mail.body.include?(s) }).to eq(true)
     end
 
     it 'should contain the SCTR grant citation paragraph' do


### PR DESCRIPTION
#1254 removed the functionality for pending responses but they need to be brought back. Use the `ResponsesController#edit.html` action when taking surveys via the Service Survey emails so that we can have blank responses for the Survey Responses Report.