### PR TITLE
JM - (SPARCReport) Protocols Report: Include Epic Option and Report Columns

### DIFF
--- a/app/reports/protocols.rb
+++ b/app/reports/protocols.rb
@@ -34,7 +34,8 @@ class ProtocolsReport < ReportingModule
       Institution => {:field_type => :select_tag, :has_dependencies => "true"},
       Provider => {:field_type => :select_tag, :dependency => '#institution_id', :dependency_id => 'parent_id'},
       Program => {:field_type => :select_tag, :dependency => '#provider_id', :dependency_id => 'parent_id'},
-      Core => {:field_type => :select_tag, :dependency => '#program_id', :dependency_id => 'parent_id'}
+      Core => {:field_type => :select_tag, :dependency => '#program_id', :dependency_id => 'parent_id'},
+      "Include Epic Interface Columns" => {:field_type => :check_box_tag, :for => 'show_epic_cols', :field_label => 'Include Epic Interface Columns'}
     }
   end
 
@@ -73,6 +74,11 @@ class ProtocolsReport < ReportingModule
     attrs["Business Manager(s)"] = "service_request.try(:protocol).try(:billing_managers).try(:map){|x| x.full_name}.try(:join, ', ')"
     attrs["Business Manager Email(s)"] = "service_request.try(:protocol).try(:billing_business_manager_email)"
 
+    if params[:show_epic_cols]
+      attrs["Selected For Epic"] = "service_request.try(:protocol).try(:selected_for_epic) ? 'Yes' : service_request.try(:protocol).try(:selected_for_epic).nil? ? '' : 'No'"
+      attrs["Last Epic Push Date"] = "service_request.try(:protocol).try(:last_epic_push_time)"
+      attrs["Last Epic Push Status"] = "service_request.try(:protocol).try(:last_epic_push_status)"
+    end
 
     attrs
   end

--- a/app/views/reports/_setup.html.haml
+++ b/app/views/reports/_setup.html.haml
@@ -24,9 +24,9 @@
   #report-fields
     - report.options.each do |field, options|
       .form-group
+        - next if (field == "Include Epic Interface Columns" && !Setting.find_by_key("use_epic").value) # Only show Epic field if use_epic is set to true
         - field_type  = options[:field_type] || 'text_field_tag'
         - field_label = "#{options[:field_label] || field.to_s.titleize}:"
-
         = render "reports/form_partials/#{options[:field_type]}_form_partial", options: options, field_label: field_label, field: field
   .report-actions.text-center
     = submit_tag t(:reporting)[:actions][:create], class: "btn btn-success", data: { disable_with: false }

--- a/app/views/reports/form_partials/_check_box_tag_form_partial.html.haml
+++ b/app/views/reports/form_partials/_check_box_tag_form_partial.html.haml
@@ -23,6 +23,7 @@
 - default_classes = options[:required] ? "required" : ""
 - name            = options[:for] ? "report[#{options[:for]}]" : "report[#{field.name.underscore}_id]"
 - name           += "[]" if multiple
+- show_epic       = options[:field_label] == "Include Epic Interface Columns"
 
 = label_tag nil, field_label, class: ['col-sm-3 control-label', default_classes]
 - if grouping && multiple # we have a defined grouping
@@ -44,9 +45,8 @@
         = label_tag k, '', class: ['checkbox-inline', default_classes] do
           = check_box_tag name, k, selected.include?(v), class: default_classes, type: "checkbox"
           = v
-
 - else # for individual checkboxes that have true/false
   .col-sm-9
-    = check_box_tag name, true, selected.any?, class: default_classes, type: "checkbox"
+    = check_box_tag name, true, selected.any?, class: default_classes, type: "checkbox" unless (show_epic && !(Setting.find_by_key("use_epic").value)) # Only show Epic checkbox if use_epic is set to true
 
 -# TODO define behavior if multiple is a method or string representation of method chain


### PR DESCRIPTION
Story:  https://www.pivotaltracker.com/story/show/154604748

Background: The Protocols report in SPARCReport module gives users all the protocol-related informations. However, currently the Epic-related information is not shown in any report (except for customized Tableau report), and can only be access on the Epic Queue view from SPARCDashboard.

Please:
1). Add a new filter/checkbox on Protocols report for "Include Epic Interface Columns";
2). Add 3 new columns to the protocols report when the checkbox is chosen: "Selected For Epic" (protocols.selected_for_epic), "Last Epic Push Date" (protocols.last_epic_push_time; only keep date), and "Last Epic Push Status" (protocols.last_epic_push_status);
3). Please tie this new filter with the Epic configuration: when not using Epic, it shouldn't show up.