### PR TITLE
JM - (SPARC Script) Update All Protocol Info That Have Been Pushed to Epic

### DIFF
--- a/lib/epic_interface.rb
+++ b/lib/epic_interface.rb
@@ -190,7 +190,7 @@ class EpicInterface
 
   # Build a study creation message to send to epic and return it as a
   # string.
-  def study_creation_message(study)
+  def study_creation_message(study, include_cofc=true)
     xml = Builder::XmlMarkup.new(indent: 2)
 
     xml.query(root: @study_root, extension: "STUDY#{study.id}")
@@ -207,7 +207,9 @@ class EpicInterface
         emit_category_grouper(xml, study)
         emit_study_type(xml, study)
         emit_ide_number(xml, study)
-        emit_cofc(xml, study)
+        if include_cofc
+          emit_cofc(xml, study)
+        end
         emit_rmid(xml, study)
 
       }

--- a/lib/tasks/update_protocol_info_pushed_to_epic.rake
+++ b/lib/tasks/update_protocol_info_pushed_to_epic.rake
@@ -1,0 +1,28 @@
+# Copyright © 2011-2018 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+namespace :data do 
+  task :update_protocol_info_pushed_to_epic => :environment do
+    epic_interface = EPIC_INTERFACE
+    Protocol.where(last_epic_push_status: 'complete').each do |protocol|
+      epic_interface.study_creation_message(protocol)
+    end
+  end
+end

--- a/lib/tasks/update_protocol_info_pushed_to_epic.rake
+++ b/lib/tasks/update_protocol_info_pushed_to_epic.rake
@@ -20,9 +20,23 @@
 
 namespace :data do 
   task :update_protocol_info_pushed_to_epic => :environment do
-    epic_interface = EPIC_INTERFACE
-    Protocol.where(last_epic_push_status: 'complete').each do |protocol|
-      epic_interface.study_creation_message(protocol)
+    CSV.open("tmp/protocols_emit_cofc_skipped.csv", "wb") do |csv|
+      csv << ["Protocol ID", "Last Epic Push Time", "Last Epic Push Status", "Updated_at", "Created_at", "Selected For Epic", "Study Type Question Group ID"]
+
+      epic_interface = EPIC_INTERFACE
+
+      Protocol.where(last_epic_push_status: 'complete').each do |protocol|
+        if protocol.study_type_answers.empty?
+          csv << [protocol.id, protocol.last_epic_push_time, protocol.last_epic_push_status, protocol.updated_at, protocol.created_at, protocol.selected_for_epic, protocol.study_type_question_group_id]
+          # Per Wenjun:  skip only the emit_cofc method call, run everything else in the study_creation_message method for protocols that do not have any study_type_answers
+          epic_interface.study_creation_message(protocol, false)
+          puts "Skipped emit_cofc for #{protocol.id}"
+        else
+          epic_interface.study_creation_message(protocol)
+          puts "Updated protocol #{protocol.id}"
+        end
+      end
     end
+    puts "This script created temp/protocols_emit_cofc_skipped.csv"
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/154602635

Background: Although we have the auto-update user information to Epic now for protocols that have been previously sent to Epic, there are some protocols that have user updated before that feature existed. (Also, the RMID project has caused some title updates as well.)

Please create a script to update all the protocol-level information (use study_creation_message method?) for studies that have been pushed to Epic successfully before.

***Update:
For studies that do not have study_type_answers, skip the emit_cofc method call in the study_creation_message method.
