### PR TITLE
KG - Bug When Viewing System Satisfaction Response

### DIFF
--- a/app/views/surveyor/responses/form/_show_form.html.haml
+++ b/app/views/surveyor/responses/form/_show_form.html.haml
@@ -17,11 +17,22 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.col-sm-8.col-sm-offset-2
-  .panel.panel-default#survey-panel
-    .panel-heading.text-center
-      %h4.panel-title
-        = @survey.title
-    .form
-      .panel-body
-        = render 'surveyor/responses/form/show_form', survey: @survey, response: @response
+#survey-response
+  - unless survey.description.blank?
+    .form-group
+      %p.survey-description.no-margin
+        = raw(survey.description)
+  .survey-sections
+    - survey.sections.each do |section|
+      .panel.panel-default.section
+        .panel-heading
+          %h4.panel-title
+            = section.title
+        .panel-body
+          - unless section.description.blank?
+            .form-group
+              .col-lg-12.no-padding
+                %p.section-description
+                  = raw(section.description)
+          - response.question_responses.eager_load(question: :options).where(questions: { section: section }).each_with_index do |question_response, index|
+            = render 'surveyor/responses/form/response_question', section: section, question: question_response.question, question_response: question_response, index: index

--- a/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
+++ b/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
@@ -1,0 +1,47 @@
+# Copyright © 2011-2018 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+require 'rails_helper'
+
+RSpec.describe 'User views a System Satisfaction Survey response', js: true do
+  let_there_be_lane
+  fake_login_for_each_test
+
+  before :each do
+    @survey   = create(:system_survey, title: 'System Satisfaction Survey', access_code: 'system-satisfaction-survey')
+    @section  = create(:section, survey: @survey, title: 'System Satisfaction')
+    @question = create(:question, section: @section, content: '1) How satisfied are you with using SPARCRequest today?', question_type: 'likert')
+    @opt_bad  = create(:option, question: @question, content: 'It was awful')
+    @opt_good = create(:option, question: @question, content: 'It was great')
+
+    @response = create(:response, survey: @survey, identity: jug2, respondable: create(:service_request_without_validations))
+                create(:question_response, question: @question, response: @response, content: 'It was great')
+  end
+
+  scenario 'and sees the response' do
+    visit surveyor_response_path(@response)
+    wait_for_javascript_to_finish
+
+    expect(page).to have_content('System Satisfaction Survey')
+    expect(page).to have_selector('.question', count: 1)
+    expect(page).to have_selector('.likert input[disabled="disabled"]', count: 2)
+    expect(page).to have_selector('.likert input[checked="checked"]', count: 1)
+  end
+end


### PR DESCRIPTION
**No story** (shhhhhh)

When you fill out the System Satisfaction Survey via the Review step, an email is sent out with a link to view the response. The page this links to was missing a partial and would not render. I added the correct partial with content and a quick feature spec covering this scenario.

<img width="963" alt="image" src="https://user-images.githubusercontent.com/12898988/36813045-273e9292-1ca1-11e8-9703-bde7af833c95.png">
