### PR TITLE
KG - Fix Dropdown Dependency Bug

### DIFF
--- a/app/assets/javascripts/surveyor/responses.js.coffee
+++ b/app/assets/javascripts/surveyor/responses.js.coffee
@@ -43,7 +43,6 @@ $(document).ready ->
     option_ids = $(this).find('.option:checked').map( -> 
       $(this).data('option-id')).get()
 
-    console.log question_id
     $(".dependent-for-question-#{question_id}").addClass('hidden')
 
     for option_id in option_ids

--- a/app/assets/javascripts/surveyor/responses.js.coffee
+++ b/app/assets/javascripts/surveyor/responses.js.coffee
@@ -30,3 +30,21 @@ $(document).ready ->
       $(".dependent-for-option-#{option_id}").removeClass('hidden')
     else
       $(".dependent-for-option-#{option_id}").addClass('hidden')
+
+  $(document).on 'change', '.question .selectpicker:not([multiple=multiple])', ->
+    question_id = $(this).data('question-id')
+    option_id = $(this).find('.option:checked').data('option-id')
+
+    $(".dependent-for-question-#{question_id}").addClass('hidden')
+    $(".dependent-for-option-#{option_id}").removeClass('hidden')
+
+  $(document).on 'change', '.question .selectpicker[multiple=multiple]', ->
+    question_id = $(this).data('question-id')
+    option_ids = $(this).find('.option:checked').map( -> 
+      $(this).data('option-id')).get()
+
+    console.log question_id
+    $(".dependent-for-question-#{question_id}").addClass('hidden')
+
+    for option_id in option_ids
+      $(".dependent-for-option-#{option_id}").removeClass('hidden')

--- a/app/views/surveyor/responses/form/form_partials/_dropdown_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_dropdown_form_partial.html.haml
@@ -17,8 +17,9 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-# options_from_collection_for_select(question.options, 'content', 'content')
 .form-group
   - if ['new', 'edit', 'preview'].include?(action_name)
-    = qr.select :content, options_from_collection_for_select(question.options, 'content', 'content'), { include_blank: true }, { class: 'form-control selectpicker option' }
+    = qr.select :content, options_for_select(question.options.map{ |o| [o.content, o.content, { class: 'option', data: { option_id: o.id } }] }), { include_blank: true }, { class: 'form-control selectpicker', data: { question_id: question.id } }
   - else
-    = select_tag :content, options_from_collection_for_select(question.options, 'content', 'content', question_response.content), include_blank: true, class: 'form-control selectpicker option', disabled: true
+    = select_tag :content, options_for_select(question.options.map{ |o| [o.content, o.content, { class: 'option', data: { option_id: o.id } }] }, question_response.content), class: 'form-control selectpicker', include_blank: true, disabled: true, data: { question_id: question.id }

--- a/app/views/surveyor/responses/form/form_partials/_multiple_dropdown_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_multiple_dropdown_form_partial.html.haml
@@ -19,6 +19,6 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .form-group
   - if ['new', 'edit', 'preview'].include?(action_name)
-    = qr.select :content, options_from_collection_for_select(question.options, 'content', 'content'), {}, { class: 'form-control selectpicker option', multiple: true }
+    = qr.select :content, options_for_select(question.options.map{ |o| [o.content, o.content, { class: 'option', data: { option_id: o.id } }] }), {}, { class: 'form-control selectpicker', multiple: true, data: { question_id: question.id } }
   - else
-    = select_tag :content, options_from_collection_for_select(question.options, 'content', 'content', multiple_select_formatter(question_response.content)), class: 'form-control selectpicker option', disabled: true, multiple: true
+    = select_tag :content, options_for_select(question.options.map{ |o| [o.content, o.content, { class: 'option', data: { option_id: o.id } }] }, multiple_select_formatter(question_response.content)), class: 'form-control selectpicker', disabled: true, multiple: true, data: { question_id: question.id }

--- a/spec/features/surveyor/user_previews_survey_spec.rb
+++ b/spec/features/surveyor/user_previews_survey_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'User previews a survey', js: true do
     scenario 'and sees all proper content' do
       expect(all('.section').count).to eq(@survey.sections.count)
       expect(all('.question').count).to eq(@survey.questions.count)
-      expect(all('.option').count).to eq(@survey.questions.map(&:options).count)
+      expect(all('.option').count).to eq(@survey.questions.map(&:options).flatten.count)
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe 'User previews a survey', js: true do
     scenario 'and sees all proper content' do
       expect(all('.section').count).to eq(@form.sections.count)
       expect(all('.question').count).to eq(@form.questions.count)
-      expect(all('.option').count).to eq(@form.questions.map(&:options).count)
+      expect(all('.option').count).to eq(@form.questions.map(&:options).flatten.count)
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155636943

Dropdown and Multiple Dropdown type questions did not work with dependent questions. To solve this, I mapped out the options to include a data attribute `data-option-id` so that javascript could determine the option's dependent questions. I also added `data-question-id` to the selectpickers so that options can be hidden.