### PR TITLE
KG - Fix SystemSurvey Display order Sorting

### DIFF
--- a/app/models/system_survey.rb
+++ b/app/models/system_survey.rb
@@ -27,6 +27,10 @@ class SystemSurvey < Survey
   # 2 surveys can't have the same access code and both be active
   validates_uniqueness_of :active, scope: [:type, :access_code], if: -> { self.active }
 
+  default_scope -> {
+    order(:display_order)
+  }
+
   def self.yaml_klass
     Survey.name
   end

--- a/app/views/surveyor/surveys/index.html.haml
+++ b/app/views/surveyor/surveys/index.html.haml
@@ -26,7 +26,7 @@
       .bootstrap-table-dropdown-overflow
         #surveys-custom-toolbar
           = link_to t(:surveyor)[:systemsurveys][:new], surveyor_surveys_path(type: 'SystemSurvey'), method: :post, remote: true, class: "btn btn-success", id: "new-survey-button"
-        %table.survey-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: surveyor_surveys_path(type: 'SystemSurvey'), striped: 'true', toolbar: '#surveys-custom-toolbar', pagination: 'true', page_size: '20' } }
+        %table.survey-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: surveyor_surveys_path(type: 'SystemSurvey'), striped: 'true', toolbar: '#surveys-custom-toolbar', pagination: 'true', page_size: '20', sort_name: 'display_order' } }
           %thead.primary-header
             %tr
               %th.col-sm-3{ data: { field: "title", align: "left", sortable: 'true' } }

--- a/spec/features/surveyor/user_edits_survey_fields_spec.rb
+++ b/spec/features/surveyor/user_edits_survey_fields_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'User edits survey fields', js: true do
     end
 
     scenario 'and sees updated display order' do
-      create(:system_survey, access_code: @survey.access_code, version: @survey.version+1, display_order: 0)
+      @new_survey = create(:system_survey, access_code: @survey.access_code, version: @survey.version+1, display_order: 0)
 
       visit surveyor_surveys_path
       wait_for_javascript_to_finish
@@ -96,7 +96,7 @@ RSpec.describe 'User edits survey fields', js: true do
       first('.edit-survey').click
       wait_for_javascript_to_finish
 
-      bootstrap_select "#survey-#{@survey.id}-display_order", 'Add as last'
+      bootstrap_select "#survey-#{@new_survey.id}-display_order", 'Add as last'
       wait_for_javascript_to_finish
 
       expect(@survey.reload.display_order).to eq(2)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155976063

With the recent changes to the survey/form builder, a default scope was added to survey that caused System Surveys to no longer be sorted by the display order. Adding a default scope to SystemSurvey overrides this and correctly sorts them.