### PR TITLE
KG - Questionnaire Migration Bug

### DIFF
--- a/db/migrate/20171023191651_migrate_questionnaire_data_to_surveys.rb
+++ b/db/migrate/20171023191651_migrate_questionnaire_data_to_surveys.rb
@@ -122,6 +122,7 @@ class MigrateQuestionnaireDataToSurveys < ActiveRecord::Migration[5.1]
             created_at: questionnaire_response.created_at,
             updated_at: questionnaire_response.updated_at
           })
+          QuestionResponse.create(question_response_params)
         end
       end
     end


### PR DESCRIPTION
The migration was not creating QuestionResponses from the Submissions' QuestionnaireResponses. This caused all QuestionnaireResponse data to be lost in the migration.