### PR TITLE
KG - Display Order Not Updating Bug

### DIFF
--- a/app/assets/javascripts/surveyor/surveys.js.coffee
+++ b/app/assets/javascripts/surveyor/surveys.js.coffee
@@ -91,7 +91,7 @@ $(document).ready ->
       success: ->
         build_dependents_selectpicker($('.survey').data('survey-id'))
 
-  $(document).on 'change', '.select-depender, .select-question-type', ->
+  $(document).on 'change', '.select-display-order, .select-depender, .select-question-type', ->
     send_update_request($(this), $(this).val())
 
   $(document).on 'focusout', '#survey-modal input[type="text"], #form-modal input[type="text"]:not([id$="-surveyable"]), #survey-modal textarea, #form-modal textarea', ->

--- a/app/controllers/surveyor/survey_updater_controller.rb
+++ b/app/controllers/surveyor/survey_updater_controller.rb
@@ -49,6 +49,7 @@ class Surveyor::SurveyUpdaterController < Surveyor::BaseController
         :description,
         :access_code,
         :version,
+        :display_order,
         :active,
         :surveyable_id,
         :surveyable_type

--- a/app/views/surveyor/surveys/form/_survey_fields.html.haml
+++ b/app/views/surveyor/surveys/form/_survey_fields.html.haml
@@ -46,7 +46,7 @@
       - else
         = label_tag "survey-#{survey.id}-display_order", t(:surveyor)[:surveys][:form][:survey_information][:display_order], class: 'col-lg-2 control-label required'
         .col-lg-10
-          = select_tag "survey-#{survey.id}-display_order", display_order_options(survey), class: 'form-control selectpicker', include_blank: t(:constants)[:prompts][:none]
+          = select_tag "survey-#{survey.id}-display_order", display_order_options(survey), class: 'form-control selectpicker select-display-order', include_blank: t(:constants)[:prompts][:none]
     .form-group
       = label_tag "survey-#{survey.id}-active", t(:surveyor)[:surveys][:form][:survey_information][:active], class: 'col-lg-2 control-label'
       .col-lg-10


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155976063

This is covering Kyle Hutson's last comment about the Display Order not updating.

There were 2 issues present:
1. The JavaScript that is supposed to trigger when changing the select was not doing so. Something in the v3.2.0 update caused this to no longer trigger. I added the selector to the JavaScript and it now sends requests as it should.
2. The SurveyUpdaterController's params were not allowing `display_order` to be passed. I had to add this as well.