### PR TITLE
JM - (SPARCDashboard) Coverage Analysis Only Show Hospital Services

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -39,6 +39,8 @@ class ServiceRequestsController < ApplicationController
     @service_list_false = @service_request.service_list(false)
     @line_items = @service_request.line_items
     @display_all_services = params[:display_all_services] == 'true' ? true : false
+    @use_epic = Setting.find_by_key("use_epic").value
+
     @report_type = params[:report_type]
     respond_to do |format|
       format.xlsx do

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -42,6 +42,24 @@ module Dashboard::SubServiceRequestsHelper
     end
   end
 
+  def display_line_items_otf(sub_service_request, use_epic, lis)
+    if sub_service_request.nil?
+      # only show the services that are set to be pushed to Epic when use_epic = true
+      if use_epic
+        lis.select{ |li| Service.find(li.service_id).send_to_epic }
+      else
+        lis
+      end
+    else
+      # only show the services that are set to be pushed to Epic when use_epic = true
+      if use_epic
+        sub_service_request.one_time_fee_line_items.select{ |li| Service.find(li.service_id).send_to_epic }
+      else
+        sub_service_request.one_time_fee_line_items
+      end
+    end
+  end
+
   def service_request_owner_display sub_service_request
     if sub_service_request.status == "draft"
       content_tag(:span, 'Not available in draft status.')

--- a/app/models/arm.rb
+++ b/app/models/arm.rb
@@ -46,6 +46,15 @@ class Arm < ApplicationRecord
     write_attribute(:name, name.squish)
   end
 
+  def display_line_items_visits(use_epic, display_all_services)
+    if use_epic
+      # only show the services that are set to be pushed to Epic
+      display_all_services ? line_items_visits.joins(:service).where(services: {send_to_epic: true}) : line_items_visits.joins(:service).where(services: {send_to_epic: true}).joins(:visits).where.not( "research_billing_qty = 0 and insurance_billing_qty = 0 and effort_billing_qty = 0" ).uniq
+    else
+      display_all_services ? line_items_visits : line_items_visits.joins(:visits).where.not( "research_billing_qty = 0 and insurance_billing_qty = 0 and effort_billing_qty = 0" ).uniq
+    end
+  end
+
   def name_formatted_properly
     if !name.blank? && name.match(/\A([ ]*[A-Za-z0-9``~!@#$%^&()\-_+={}|<>.,;'"][ ]*)+\z/).nil?
       errors.add(:name, I18n.t(:errors)[:arms][:bad_characters])

--- a/app/views/service_requests/coverage_analysis.xlsx.axlsx
+++ b/app/views/service_requests/coverage_analysis.xlsx.axlsx
@@ -87,7 +87,7 @@ wb.add_worksheet(name: "Review") do |sheet|
 
   ##### beginning of arms
   if has_per_patient_per_visit_services
-
+    
     arms_to_be_displayed = @display_all_services ? @service_request.arms : Arm.where(protocol: @service_request.protocol).joins(:line_items_visits).joins(:visits).where.not( "research_billing_qty = 0 and insurance_billing_qty = 0 and effort_billing_qty = 0" ).uniq
 
     arms_to_be_displayed.each do |arm|
@@ -152,7 +152,7 @@ wb.add_worksheet(name: "Review") do |sheet|
       @service_list_false.each do |key, value|
         next if @sub_service_request.present? && @sub_service_request.organization.name != value[:process_ssr_organization_name]
 
-        line_items_visits = @display_all_services ? arm.line_items_visits : arm.line_items_visits.joins(:visits).where.not( "research_billing_qty = 0 and insurance_billing_qty = 0 and effort_billing_qty = 0" ).uniq
+        line_items_visits = arm.display_line_items_visits(@use_epic, @display_all_services)
 
         #Only show value[:name] when it hasn't been filtered out by the above line
         if (value[:line_items].map(&:id) & line_items_visits.map(&:line_item_id) ).present?
@@ -219,10 +219,14 @@ wb.add_worksheet(name: "Review") do |sheet|
   service_rows = []
   services_sub_header_rows = []
   services_sub_header_rows << sheet.add_row(['Other Services'], :style => name_header_style)
+
   @service_list_true.each do |key, value|
     next unless @sub_service_request.nil? or @sub_service_request.organization.name == value[:process_ssr_organization_name]
+
+    line_items = display_line_items_otf(@sub_service_request, @use_epic, value[:line_items])
+
+    next if line_items.empty?
     services_sub_header_rows << sheet.add_row([value[:name]], :style => sub_header_style)
-    line_items = @sub_service_request.nil? ? value[:line_items] : @sub_service_request.one_time_fee_line_items
 
     line_items.each do |line_item|
       service_row = [line_item.service.name, "", "", ""]


### PR DESCRIPTION
I've tested protocol 7344 (non one time fee services) and protocol 11935 (one time fee services) to see that both are displaying services appropriately based on use_epic being turned on/off.  See description below:

Background: Currently, the "Coverage Analysis Report" generated from SPARCDashboard is showing every service that exists on the protocol (with the option of display Chosen Services or All Services), as shown in the screenshot below.

To help further with the Coverage Analysis process which is only pertinent to hospital services, please:
1). If the application has Epic configuration turned on (use_epic = true), on the generated CA report, please only show the services that are set to be pushed to Epic (services.send_to_epic = 1)

2). If the application has Epic configuration turned off (i.e. for institutions not using the SPARC/Epic interface), keep the current CA report logic and list all services (no matter sending to Epic or not). So that institutions who are not using Epic interface can still review protocols using this report, and base on their workflow to review CPT-coded service or all.

https://www.pivotaltracker.com/story/show/154613430
