### PR TITLE
KG - Survey/Form Migration Bug

### DIFF
--- a/db/migrate/20171023191651_migrate_questionnaire_data_to_surveys.rb
+++ b/db/migrate/20171023191651_migrate_questionnaire_data_to_surveys.rb
@@ -93,7 +93,7 @@ class MigrateQuestionnaireDataToSurveys < ActiveRecord::Migration[5.1]
             content: 'No'
           )
         else
-          item_options.select{ |io| io.item_id = item.id }.each do |item_option|
+          item_options.select{ |io| io.item_id == item.id }.each do |item_option|
             option_params = ActionController::Parameters.new({
               question: new_question,
               content: item_option.content,


### PR DESCRIPTION
The migration was accidentally assignment, rather than comparing `item_id`s. This caused options to associate to the wrong question.