### PR TITLE
KG - Survey/Form Migration Section Naming Issue

### DIFF
--- a/db/migrate/20171023191651_migrate_questionnaire_data_to_surveys.rb
+++ b/db/migrate/20171023191651_migrate_questionnaire_data_to_surveys.rb
@@ -50,7 +50,7 @@ class MigrateQuestionnaireDataToSurveys < ActiveRecord::Migration[5.1]
     # Store new questions by their old item_id
     items_and_questions = {}
 
-    questionnaires.each_with_index do |questionnaire, index|
+    questionnaires.each_with_index do |questionnaire|
       survey_params = ActionController::Parameters.new({
         title: questionnaire.name,
         description: nil,
@@ -65,7 +65,7 @@ class MigrateQuestionnaireDataToSurveys < ActiveRecord::Migration[5.1]
       })
       
       new_survey = Form.create(survey_params.permit!)
-      new_section = Section.create(survey: new_survey, title: "Section #{index+1}")
+      new_section = Section.create(survey: new_survey, title: "Section 1")
 
       items.select{ |i| i.questionnaire_id == questionnaire.id }.each do |item|
         question_params = ActionController::Parameters.new({


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156522192

Originally this was using an index to name the sections. Only 1 section is made for each Form but this index was from looping over the Questionnaires. This would cause the single section to be named something like "Section 4". Really, they should all just be called "Section 1" since there is only 1 section being made.