### PR TITLE
wth - (SPARCDashboard) Epic Queue Past Tab "Type" Bug

### DIFF
--- a/app/views/dashboard/epic_queues/_epic_queue_list.html.haml
+++ b/app/views/dashboard/epic_queues/_epic_queue_list.html.haml
@@ -26,7 +26,7 @@
       %li
         = link_to t(:dashboard)[:epic_queues][:headers][:past], '#past', data: { toggle: 'tab' }
       %li
-        = link_to t(:dashboard)[:epic_queues][:headers][:authorized_user_update],
+        = link_to t(:dashboard)[:epic_queues][:headers][:protocol_update],
           '#authorized-user-update',
           data: { toggle: 'tab' }
   .panel-body

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -59,7 +59,7 @@ en:
       headers:
         current: "Current"
         past: "Past"
-        authorized_user_update: "Authorized User Update"
+        protocol_update: "Protocol Update"
 
     #########
     # FORMS #

--- a/lib/tasks/send_to_epic.rake
+++ b/lib/tasks/send_to_epic.rake
@@ -24,7 +24,7 @@ task send_to_epic: :environment do
 
   epic_queues.each do |eq|
     p = Protocol.find(eq.protocol_id)
-    p.push_to_epic(EPIC_INTERFACE, 'admin_push', eq.identity_id, true)
+    p.push_to_epic(EPIC_INTERFACE, eq.user_change? ? 'protocol_update' : 'admin_push', eq.identity_id, true)
     if p.last_epic_push_status == 'complete'
       eq.update_attribute(:attempted_push, true)
       eq.destroy


### PR DESCRIPTION
The "Past" column on Epic Queue view on SPARCDashboard is showing the wrong "Type" for some of the pushes. For example, the screenshot attached is showing a general user who did the admin push on 4/4/2018. When I invested into the audit trail, it shows that this study team user deleted 3 project roles with epic access on 4/4/2018. So it seems that it should have been an "Protocol Update" as type.

Please look into this bug, and double-check all the types are tagged correctly, and fix the data that has been affected.

[#156541424]

Story - https://www.pivotaltracker.com/story/show/156541424