### PR TITLE
wth - (SPARCDashboard) Epic Queue Past Tab "Type" Historical Data Fix

### DIFF
--- a/lib/tasks/fix_historical_epic_queue_data.rake
+++ b/lib/tasks/fix_historical_epic_queue_data.rake
@@ -1,0 +1,14 @@
+namespace :data do
+  task fix_historical_epic_queue_data: :environment do
+    eqrs = EpicQueueRecord.where(created_at: '2017-10-26'.to_date..'2018-04-10'.to_date)
+
+    eqrs.each do |eqr|
+      identity = eqr.identity
+
+      unless identity.is_super_user? || identity.is_service_provider? || identity.is_overlord?
+        eqr.update_attribute(:origin, 'Protocol Update')
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
As a task for cleaning up historical records following a previous story: https://www.pivotaltracker.com/story/show/156541424,
please create a script to update the "Type" on historical records in the Epic Queue records, so that if the data entry was between the date range of "10/26/2017" and "4/11/2018", and the identity_id on that queue record is neither a service provider, super user, or overlord, please change the type to "Protocol Update"

[#156665003]

Story - https://www.pivotaltracker.com/story/show/156665003