### PR TITLE
SJ - Fix for duplicate ids/names on page html [#156510801]

### DIFF
--- a/app/views/surveyor/responses/form/form_partials/_radio_button_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_radio_button_form_partial.html.haml
@@ -25,5 +25,5 @@
       = option.content
     - else
       .col-lg-1.text-center
-        = radio_button_tag :content_radio, '', question_response.content.downcase == option.content.downcase, disabled: true
+        = radio_button_tag "question_response_#{question_response.id}", '', question_response.content.downcase == option.content.downcase, disabled: true, id: "question_response_#{question_response.id}"
       = option.content

--- a/app/views/surveyor/responses/form/form_partials/_yes_no_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_yes_no_form_partial.html.haml
@@ -26,5 +26,5 @@
         = option.content
       - else
         .col-lg-6.no-padding.text-center.option{ data: { question_id: question.id, option_id: option.id } }
-          = radio_button_tag :content_yes_no, option.content.downcase, question_response.content.downcase == option.content.downcase, disabled: true
+          = radio_button_tag "question_response_#{question_response.id}", option.content.downcase, question_response.content.downcase == option.content.downcase, disabled: true, id: "question_response_#{question_response.id}"
         = option.content


### PR DESCRIPTION
The way the form was constructed, we were generating the exact same ID and Name for all radio buttons on the form, this is both incorrect html, and causes display bugs, as the browser only expect one with the same name.

[#156510801]

https://www.pivotaltracker.com/story/show/156510801