### PR TITLE
JM- (SPARCRequest) Step 2: Add Styling to Finished SSRs

### DIFF
--- a/app/helpers/service_requests_helper.rb
+++ b/app/helpers/service_requests_helper.rb
@@ -62,6 +62,14 @@ module ServiceRequestsHelper
     header
   end
 
+  def service_name_display(service, sub_service_request_id)
+    if SubServiceRequest.find(sub_service_request_id).can_be_edited?
+      link_to(service.display_service_name, "javascript:void(0)", class: "service service-#{service.id} btn btn-default", data: { id: service.id })
+    else
+      link_to "<i class='glyphicon glyphicon-lock text-danger'></i> #{service.display_service_name}".html_safe, "javascript:void(0)", class: "text-danger list-group-item-danger service service-#{service.id} btn btn-default list-group-item", data: { id: service.id }
+    end
+  end
+
   # RIGHT NAVIGATION BUTTONS
   def faq_helper
     if Setting.find_by_key("use_faq_link").value

--- a/app/helpers/service_requests_helper.rb
+++ b/app/helpers/service_requests_helper.rb
@@ -62,11 +62,15 @@ module ServiceRequestsHelper
     header
   end
 
-  def service_name_display(service, sub_service_request_id)
-    if SubServiceRequest.find(sub_service_request_id).can_be_edited?
-      link_to(service.display_service_name, "javascript:void(0)", class: "service service-#{service.id} btn btn-default", data: { id: service.id })
+  def service_name_display(line_item)
+    ssr = line_item.sub_service_request
+    service = line_item.service
+    display_name = service.display_service_name + (ssr.ssr_id ? " (#{ssr.ssr_id})" : "")
+
+    if ssr.can_be_edited?
+      link_to(display_name, "javascript:void(0)", class: "service service-#{service.id} btn btn-default", data: { id: service.id })
     else
-      link_to "<i class='glyphicon glyphicon-lock text-danger'></i> #{service.display_service_name}".html_safe, "javascript:void(0)", class: "text-danger list-group-item-danger service service-#{service.id} btn btn-default list-group-item", data: { id: service.id }
+      link_to "<i class='glyphicon glyphicon-lock text-danger'></i> #{display_name}".html_safe, "javascript:void(0)", class: "text-danger list-group-item-danger service service-#{service.id} btn btn-default list-group-item", data: { id: service.id }
     end
   end
 

--- a/app/views/service_requests/protocol/_service.html.haml
+++ b/app/views/service_requests/protocol/_service.html.haml
@@ -19,6 +19,6 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .service-view
   .name
-    = link_to service.display_service_name, 'javascript:void(0)', class: "service service-#{service.id} btn btn-default", data: { id: service.id }
+    = service_name_display(service, sub_service_request_id)
   .col-sm-12.service-description.hidden{ class: "service-description-#{service.id}" }
     = organization_description_display(service)

--- a/app/views/service_requests/protocol/_service.html.haml
+++ b/app/views/service_requests/protocol/_service.html.haml
@@ -19,6 +19,6 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .service-view
   .name
-    = service_name_display(service, sub_service_request_id)
-  .col-sm-12.service-description.hidden{ class: "service-description-#{service.id}" }
-    = organization_description_display(service)
+    = service_name_display(line_item)
+  .col-sm-12.service-description.hidden{ class: "service-description-#{line_item.service.id}" }
+    = organization_description_display(line_item.service)

--- a/app/views/service_requests/protocol/_service_list.html.haml
+++ b/app/views/service_requests/protocol/_service_list.html.haml
@@ -31,4 +31,4 @@
           = value[:name]
       .panel-body
         - value[:services].each do |service|
-          = render 'service_requests/protocol/service', service: service
+          = render 'service_requests/protocol/service', service: service, sub_service_request_id: value[:line_items].first.sub_service_request_id

--- a/app/views/service_requests/protocol/_service_list.html.haml
+++ b/app/views/service_requests/protocol/_service_list.html.haml
@@ -30,5 +30,5 @@
         %h1.panel-title
           = value[:name]
       .panel-body
-        - value[:services].each do |service|
-          = render 'service_requests/protocol/service', service: service, sub_service_request_id: value[:line_items].first.sub_service_request_id
+        - value[:line_items].each do |li|
+          = render 'service_requests/protocol/service', line_item: li


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/154745469
Background: On the SPARCRequest Step 2 (Services and Protocol Information) page, the services contained in an already completed (or other finished_statuses) are shown on the list in the center of the page without differentiation from the new/active ones.

Please apply the same styling (pink background highlight, and little lock) that is used for requests in finished statuses (as shown in the shopping cart "Completed" tab) to the services listed in the center of this page for consistency.

UPDATE (4/11) per Wenjun:
Add SSR id