### PR TITLE
JM - (SPARCForms) View Response Likert Bug

### DIFF
--- a/app/assets/javascripts/likert.js.coffee
+++ b/app/assets/javascripts/likert.js.coffee
@@ -21,3 +21,5 @@
 $(document).ready ->
   $(document). on 'click', '.likert-option', ->
     $(this).find('input').prop('checked', true)
+
+  $("#disable-likert *").prop('disabled',true)

--- a/app/assets/javascripts/likert.js.coffee
+++ b/app/assets/javascripts/likert.js.coffee
@@ -22,4 +22,4 @@ $(document).ready ->
   $(document). on 'click', '.likert-option', ->
     $(this).find('input').prop('checked', true)
 
-  $("#disable-likert *").prop('disabled',true)
+  $(".disable-likert *").prop('disabled',true)

--- a/app/views/surveyor/responses/form/_response_question.html.haml
+++ b/app/views/surveyor/responses/form/_response_question.html.haml
@@ -36,7 +36,7 @@
     .form-group
       %p.question-description
         = raw(question.description)
-  .question-options{ id: ['new', 'edit', 'preview'].include?(action_name) ? '' : 'disable-likert' }
+  .question-options{ class: ['new', 'edit', 'preview'].include?(action_name) ? '' : 'disable-likert' }
     = render "surveyor/responses/form/form_partials/#{question.question_type}_form_partial", qr: qr, question: question, question_response: question_response
   - if question.errors.any?
     .alert.alert-danger

--- a/app/views/surveyor/responses/form/_response_question.html.haml
+++ b/app/views/surveyor/responses/form/_response_question.html.haml
@@ -36,7 +36,7 @@
     .form-group
       %p.question-description
         = raw(question.description)
-  .question-options
+  .question-options{ id: ['new', 'edit', 'preview'].include?(action_name) ? '' : 'disable-likert' }
     = render "surveyor/responses/form/form_partials/#{question.question_type}_form_partial", qr: qr, question: question, question_response: question_response
   - if question.errors.any?
     .alert.alert-danger

--- a/app/views/surveyor/responses/form/form_partials/_likert_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_likert_form_partial.html.haml
@@ -31,5 +31,5 @@
         - if ['new', 'edit', 'preview'].include?(action_name)
           = qr.label :content, option.content, class: "radio-inline option no-padding", data: { question_id: question.id, option_id: option.id }
         - else
-          %label.radio-inline.option.no-padding
+          %label.radio-inline.option.no-padding.disabled
             = option.content

--- a/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
+++ b/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'User views a System Satisfaction Survey response', js: true do
 
     expect(page).to have_content('System Satisfaction Survey')
     expect(page).to have_selector('.question', count: 1)
-    expect(page).to have_selector('#disable-likert', count: 1)
+    expect(page).to have_selector('.disable-likert', count: 1)
     expect(page).to have_selector('.likert input[checked="checked"]', count: 1)
   end
 end

--- a/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
+++ b/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'User views a System Satisfaction Survey response', js: true do
 
     expect(page).to have_content('System Satisfaction Survey')
     expect(page).to have_selector('.question', count: 1)
-    expect(page).to have_selector('.likert input[disabled="disabled"]', count: 2)
+    expect(page).to have_selector('#disable-likert', count: 1)
     expect(page).to have_selector('.likert input[checked="checked"]', count: 1)
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156545721

When viewing a user's Survey or Form response with a Likert scale, the user is able to click other Likert options' labels and change the selected radio button. This will not change the data but the radio buttons should not be selectable.