### PR TITLE
Ability to specify multiple ldap_base for searching [#152927779]

### DIFF
--- a/config/ldap.yml.example
+++ b/config/ldap.yml.example
@@ -21,7 +21,7 @@
 development:
   ldap_host: authldap.musc.edu
   ldap_port: 636
-  ldap_base: 'ou=people,dc=musc,dc=edu'
+  ldap_base: ['ou=people,dc=musc,dc=edu']
   ldap_encryption: simple_tls
   ldap_domain: musc.edu
   ldap_uid: uid
@@ -30,12 +30,12 @@ development:
   ldap_email: mail
   ldap_auth_username: 'username'
   ldap_auth_password: 'password'
-  ldap_filter: "(&(|(|(|(cn=#{term}*)(sn=#{term}*))(givenName=#{term}*))(mail=#{term}*))(msRTCSIP-UserEnabled=TRUE))"  
+  ldap_filter: "(&(|(|(|(cn=#{term}*)(sn=#{term}*))(givenName=#{term}*))(mail=#{term}*))(msRTCSIP-UserEnabled=TRUE))"
 
 test:
   ldap_host: authldap.musc.edu
   ldap_port: 636
-  ldap_base: 'ou=people,dc=musc,dc=edu'
+  ldap_base: ['ou=people,dc=musc,dc=edu']
   ldap_encryption: simple_tls
   ldap_domain: musc.edu
   ldap_uid: uid

--- a/db/migrate/20180417172116_change_ldap_base_setting_to_json.rb
+++ b/db/migrate/20180417172116_change_ldap_base_setting_to_json.rb
@@ -1,0 +1,13 @@
+class ChangeLdapBaseSettingToJson < ActiveRecord::Migration[5.1]
+  def up
+    Setting.where(key: 'ldap_base').each do |setting|
+      setting.update_attributes(data_type: 'json', value: "[\"#{setting.read_attribute(:value)}\"]")
+    end
+  end
+
+  def down
+    Setting.where(key: 'ldap_base').each do |setting|
+      setting.update_attributes(data_type: 'string', value: setting.value.first)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180416170741) do
+ActiveRecord::Schema.define(version: 20180417172116) do
 
   create_table "admin_rates", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin" do |t|
     t.integer "line_item_id"


### PR DESCRIPTION
This converts the ldap_base setting to a json array and uses that array to search multiple base DN.   This will still work with single base DN instances.