### PR TITLE
wth - (SPARCRequest & SPARCDashboard) Document Types (.PDF)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -26,20 +26,20 @@ class Document < ApplicationRecord
   belongs_to :protocol
   has_attached_file :document #, :preserve_files => true
   validates_attachment_file_name :document, matches: [
-    /\.pdf$/,
-    /\.docx?$/,
-    /\.xlsx?$/,
-    /\.rtf$/,
-    /\.txt$/,
-    /\.csv$/,
-    /\.ppt?$/,
-    /\.msg$/,
-    /\.eml$/,
-    /\.jpg$/,
-    /\.gif$/,
-    /\.png$/,
-    /\.tiff$/,
-    /\.jpeg$/
+    /\.pdf$/i,
+    /\.docx?$/i,
+    /\.xlsx?$/i,
+    /\.rtf$/i,
+    /\.txt$/i,
+    /\.csv$/i,
+    /\.ppt?$/i,
+    /\.msg$/i,
+    /\.eml$/i,
+    /\.jpg$/i,
+    /\.gif$/i,
+    /\.png$/i,
+    /\.tiff$/i,
+    /\.jpeg$/i
   ]
 
   validates :doc_type, :document, presence: true


### PR DESCRIPTION
In expansion of a previous story https://www.pivotaltracker.com/story/show/153447613 - a user was unable to upload a document due to .PDF where .pdf was then allowed when converting. Please include .PDF into the allowable document types

[#156761394]

Story - https://www.pivotaltracker.com/story/show/156761394