### PR TITLE
Jl - Subject count bug

### DIFF
--- a/app/models/arm.rb
+++ b/app/models/arm.rb
@@ -194,7 +194,7 @@ class Arm < ApplicationRecord
 
   def update_liv_subject_counts
     self.line_items_visits.each do |liv|
-      if liv.subject_count != self.subject_count && liv.line_item.sub_service_request.can_be_edited?
+      if !liv.subject_count? && liv.line_item.sub_service_request.can_be_edited?
         liv.update_attributes(subject_count: self.subject_count)
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/157013080

The current code was blowing away custom subject counts with the arm's subject count in the arm's after_save callback. I've changed to only do this if the line item's visit subject count is nil.