### PR TITLE
JM - (SPARCDashboard) Go to Fulfillment Link should Directly Link to the Corresponding Request Page

### DIFF
--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -74,10 +74,10 @@ module Dashboard::SubServiceRequestsHelper
       if sub_service_request.in_work_fulfillment?
         if user.clinical_provider_rights?
           # In fulfillment and user has rights
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], Setting.find_by_key("clinical_work_fulfillment_url").value, target: "_blank", class: "btn btn-primary btn-md"
+          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], fulfillment_sub_service_request_path(sub_service_request), target: "_blank", class: "btn btn-primary btn-md"
         else
           # In fulfillment, user does not have rights, disable button
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], Setting.find_by_key("clinical_work_fulfillment_url").value, target: "_blank", class: "btn btn-primary btn-md", disabled: true
+          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], fulfillment_sub_service_request_path(sub_service_request), target: "_blank", class: "btn btn-primary btn-md", disabled: true
         end
       else
         # Not in Fulfillment

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -74,10 +74,10 @@ module Dashboard::SubServiceRequestsHelper
       if sub_service_request.in_work_fulfillment?
         if user.clinical_provider_rights?
           # In fulfillment and user has rights
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], fulfillment_sub_service_request_path(sub_service_request), target: "_blank", class: "btn btn-primary btn-md"
+          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md"
         else
           # In fulfillment, user does not have rights, disable button
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], fulfillment_sub_service_request_path(sub_service_request), target: "_blank", class: "btn btn-primary btn-md", disabled: true
+          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md", disabled: true
         end
       else
         # Not in Fulfillment

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -74,10 +74,10 @@ module Dashboard::SubServiceRequestsHelper
       if sub_service_request.in_work_fulfillment?
         if user.clinical_provider_rights?
           # In fulfillment and user has rights
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md"
+          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request/#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md"
         else
           # In fulfillment, user does not have rights, disable button
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md", disabled: true
+          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request/#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md", disabled: true
         end
       else
         # Not in Fulfillment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,11 +226,6 @@ SparcRails::Application.routes.draw do
     root to: 'catalog#index'
   end
 
-  ### redirect in sparc-fulfillment routes.rb ###
-  namespace :fulfillment do
-    resources :sub_service_request, only: [:show]
-  end
-
   namespace :dashboard do
 
     resources :approvals, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,11 @@ SparcRails::Application.routes.draw do
     root to: 'catalog#index'
   end
 
+  ### redirect in sparc-fulfillment routes.rb ###
+  namespace :fulfillment do
+    resources :sub_service_request, only: [:show]
+  end
+
   namespace :dashboard do
 
     resources :approvals, only: [:new, :create]

--- a/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
+++ b/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
             render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
             expect(response).to have_tag("a", text: "Go to Fulfillment",
-              with: { href: "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}" })
+              with: { href: "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request/#{sub_service_request.id}" })
           end
         end
 
@@ -142,7 +142,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
 
             render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
-            expect(response).to have_tag("a", text: "In Fulfillment", with: { href: "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}" })
+            expect(response).to have_tag("a", text: "In Fulfillment", with: { href: "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request/#{sub_service_request.id}" })
           end
         end
       end

--- a/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
+++ b/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
             render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
             expect(response).to have_tag("a", text: "Go to Fulfillment",
-              with: { href: Setting.find_by_key("clinical_work_fulfillment_url").value })
+              with: { href: fulfillment_sub_service_request_path(sub_service_request) })
           end
         end
 
@@ -142,7 +142,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
 
             render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
-            expect(response).to have_tag("a", text: "In Fulfillment", with: { href: Setting.find_by_key("clinical_work_fulfillment_url").value })
+            expect(response).to have_tag("a", text: "In Fulfillment", with: { href: fulfillment_sub_service_request_path(sub_service_request) })
           end
         end
       end

--- a/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
+++ b/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
             render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
             expect(response).to have_tag("a", text: "Go to Fulfillment",
-              with: { href: fulfillment_sub_service_request_path(sub_service_request) })
+              with: { href: "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}" })
           end
         end
 
@@ -142,7 +142,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
 
             render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
-            expect(response).to have_tag("a", text: "In Fulfillment", with: { href: fulfillment_sub_service_request_path(sub_service_request) })
+            expect(response).to have_tag("a", text: "In Fulfillment", with: { href: "#{Setting.find_by_key("clinical_work_fulfillment_url").value}/sub_service_request#{sub_service_request.id}" })
           end
         end
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155629819
Background: Currently, after a request has been pushed to SPARCFulfillment, and the user clicks "Go to Fulfillment" button, it opens a new tab showing the SPARCFulfillment homepage (i.e. https://cwf-d.obis.musc.edu/).

For better efficiency, please change this link to be directly pointing to the corresponding request/protocol in SPARCFulfillment (for example: https://cwf-d.obis.musc.edu/protocols/3747).

RELATED FULFILLMENT PR:  https://github.com/sparc-request/sparc-fulfillment/pull/285/files