### PR TITLE
KG - Response Table Header Styling

### DIFF
--- a/app/assets/stylesheets/surveyor/responses.sass
+++ b/app/assets/stylesheets/surveyor/responses.sass
@@ -72,26 +72,24 @@
 
 #responses-panel
   .fixed-table-toolbar
-    display: inline-table
-    width: 100%
+    display: flex
+    flex-direction: row
+    align-items: center
     padding: 10px 15px
     background: $sparc-blue
     
-    .bars.pull-left
-      width: 73%
+    .columns
+      order: 3
 
+    .bars
+      flex-grow: 1
+      
       #responses-custom-toolbar
-        width: 100%
-        
         .panel-title
           color: white
-          margin: 2% 0
 
   .fixed-table-container
     border-radius: 0
 
   .fixed-table-pagination
     padding: 0 20px  
-
-  td.short-title, td.primary-pi, td.title
-    word-break: break-word


### PR DESCRIPTION
Following up on https://www.pivotaltracker.com/story/show/156401749

The search in the responses table header was breaking line in Kyle Hutson's browser (see image). I could not replicate this on my machine in Firefox 59.02, Chrome 66.03 or Safari 11.1. This leads me to believe that the issue is due to incompatible styling with older browser versions.

I changed the styles to use Flexbox CSS which is a more reliable solution. Hopefully this will resolve the issue.

![image](https://user-images.githubusercontent.com/12898988/40003389-31cf6c5e-5761-11e8-9003-cc666849fcbd.png)
