### PR TITLE
KG - Milestone Budget Amounts Conversion

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -303,6 +303,38 @@ class Protocol < ApplicationRecord
     end
   }
 
+  def initial_amount=(amount)
+    write_attribute(:initial_amount, amount.to_f * 100)
+  end
+
+  def initial_amount
+    read_attribute(:initial_amount) / 100.0
+  end
+
+  def initial_amount_clinical_services=(amount)
+    write_attribute(:initial_amount_clinical_services, amount.to_f * 100)
+  end
+
+  def initial_amount_clinical_services
+    read_attribute(:initial_amount_clinical_services) / 100.0
+  end
+
+  def negotiated_amount=(amount)
+    write_attribute(:negotiated_amount, amount.to_f * 100)
+  end
+
+  def negotiated_amount
+    read_attribute(:negotiated_amount) / 100.0
+  end
+
+  def negotiated_amount_clinical_services=(amount)
+    write_attribute(:negotiated_amount_clinical_services, amount.to_f * 100)
+  end
+
+  def negotiated_amount_clinical_services
+    read_attribute(:negotiated_amount_clinical_services) / 100.0
+  end
+
   def is_study?
     self.type == 'Study'
   end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/157211048

It turns out that my local machine had been using the old `decimal 8,2` data types versus the new integer types, which is what caused the numbers to save correctly for me but not on -d. To save/retrieve the values, simply divide / multiply them by 100.