### PR TITLE
KG - Customize Time Zone With Dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ SPARC_VERSION=v3.0.0
 institution=University
 institution_logo=/assets/institution_logo2017.png
 org_logo=/assets/org_logo2017.png
+time_zone=Eastern Time (US & Canada)

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,9 @@ Bundler.require(*Rails.groups)
 
 module SparcRails
   class Application < Rails::Application
+
+    Dotenv::Railtie.load
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
@@ -47,7 +50,7 @@ module SparcRails
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    config.time_zone = 'Eastern Time (US & Canada)'
+    config.time_zone = ENV['time_zone'] || 'Eastern Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
**Pivotal: https://www.pivotaltracker.com/story/show/157564966**

**Original PR: https://github.com/sparc-request/sparc-request/pull/1177**

Allows institutions to customize the application's time zone to fit their needs. Default to Eastern time if no value is set in `env`.