### PR TITLE
Status changed bug fix

### DIFF
--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -344,7 +344,7 @@ class SubServiceRequest < ApplicationRecord
   end
 
   def update_past_status
-    if self.status_changed? && !@prev_status.blank?
+    if self.saved_change_to_status? && !@prev_status.blank?
       past_status = self.past_statuses.create(status: @prev_status, date: Time.now)
       user_id = AuditRecovery.where(auditable_id: past_status.id, auditable_type: 'PastStatus').first.user_id
       past_status.update_attribute(:changed_by_id, user_id)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/157920468

Deprecation warning in rails 5.1.6:
DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. 
The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now).
 To maintain the current behavior, use `saved_change_to_attribute?` instead. 