### PR TITLE
KG - Response Filter Updates

### DIFF
--- a/app/assets/javascripts/surveyor/responses.js.coffee
+++ b/app/assets/javascripts/surveyor/responses.js.coffee
@@ -76,3 +76,15 @@ $(document).ready ->
       $("#for-Form").addClass('hidden')
       $("#for-Form .selectpicker").selectpicker('deselectAll')
       $("#for-SystemSurvey").removeClass('hidden')
+
+  $(document).on 'change', '#filterrific_with_state', ->
+    selected = $(this).find('option:selected')
+
+    if selected.length == 1
+      selected_value = selected.val()
+
+      $(".survey-select option:not([data-active='#{selected_value}'])").prop('disabled', true)
+      $('.survey-select').selectpicker('refresh')
+    else
+      $('.survey-select option').prop('disabled', false)
+      $('.survey-select').selectpicker('refresh')

--- a/app/helpers/surveyor/responses_helper.rb
+++ b/app/helpers/surveyor/responses_helper.rb
@@ -36,7 +36,7 @@ module Surveyor::ResponsesHelper
   def view_response_button(response)
     link_to(
       content_tag(:span, '', class: 'glyphicon glyphicon-search', aria: { hidden: 'true' }),
-      surveyor_response_path(response),
+      response.new_record? ? '' : surveyor_response_path(response),
       remote: true,
       class: ['btn btn-info view-response', response.completed? ? '' : 'disabled']
     )
@@ -45,7 +45,7 @@ module Surveyor::ResponsesHelper
   def edit_response_button(response)
     link_to(
       content_tag(:span, '', class: 'glyphicon glyphicon-edit', aria: { hidden: 'true' }),
-      edit_surveyor_response_path(response),
+      response.new_record? ? '' : edit_surveyor_response_path(response),
       remote: true,
       class: ['btn btn-warning edit-response', response.completed? ? '' : 'disabled']
     )

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -46,7 +46,6 @@ class SubServiceRequest < ApplicationRecord
   has_many :notifications, :dependent => :destroy
   has_many :subsidies
   has_many :responses, as: :respondable, dependent: :destroy
-  has_many :forms, -> (ssr) { where(surveyable: ssr.services).or(where(surveyable: ssr.organization)).active }, through: :services
   has_many :service_forms, -> { active }, through: :services, source: :forms
   has_many :organization_forms, -> { active }, through: :organization, source: :forms
   has_one :approved_subsidy, :dependent => :destroy
@@ -422,11 +421,11 @@ class SubServiceRequest < ApplicationRecord
   end
 
   def has_completed_forms?
-    self.responses.where(survey: self.forms).any?
+    self.responses.where(survey: self.service_forms + self.organization_forms).any?
   end
 
   def all_forms_completed?
-    self.forms.count == self.responses.count
+    (self.service_forms + self.organization_forms).count == self.responses.count
   end
 
   ##########################

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -65,9 +65,21 @@ class Survey < ApplicationRecord
     'Multiple Dropdown': 'multiple_dropdown'
   }
   
-  def self.for_dropdown_select
+  def self.for_dropdown_select(filtered_states=nil)
     self.all.order(:title).group_by(&:title).map{ |title, surveys|
-      [title, surveys.map{ |survey| ["Version #{survey.version} (#{survey.active ? I18n.t(:surveyor)[:response_filters][:fields][:state_filters][:active] : I18n.t(:surveyor)[:response_filters][:fields][:state_filters][:inactive]})", survey.id] }]
+      [
+        title,
+        surveys.map{ |survey|
+          [
+            "Version #{survey.version} (#{survey.active ? I18n.t(:surveyor)[:response_filters][:fields][:state_filters][:active] : I18n.t(:surveyor)[:response_filters][:fields][:state_filters][:inactive]})",
+            survey.id,
+            {
+              disabled: filtered_states && !filtered_states.include?(survey.active ? 1 : 0),
+              data: { active: survey.active ? '1' : '0' }
+            }
+          ]
+        }
+      ]
     }
   end
 

--- a/app/views/surveyor/responses/_filter_responses_form.html.haml
+++ b/app/views/surveyor/responses/_filter_responses_form.html.haml
@@ -40,11 +40,11 @@
       .form-group.row{ id: "for-#{Form.name}", class: filterrific.of_type == Form.name ? "" : "hidden" }
         = form.label :with_survey, Form.name, class: 'col-lg-3 control-label text-left'
         .col-lg-9
-          = form.select :with_survey, grouped_options_for_select(Form.for(current_user).for_dropdown_select, filterrific.with_survey), {}, class: 'form-control selectpicker', multiple: true
+          = form.select :with_survey, grouped_options_for_select(Form.for(current_user).for_dropdown_select(filterrific.with_state), filterrific.with_survey), {}, class: 'form-control selectpicker survey-select', multiple: true, data: { hide_disabled: 'true' }
       .form-group.row{ id: "for-#{SystemSurvey.name}", class: filterrific.of_type == SystemSurvey.name ? "" : "hidden" }
         = form.label :with_survey, Survey.name, class: 'col-lg-3 control-label text-left'
         .col-lg-9
-          = form.select :with_survey, grouped_options_for_select(SystemSurvey.unscoped.for_dropdown_select, filterrific.with_survey), {}, class: 'form-control selectpicker', multiple: true
+          = form.select :with_survey, grouped_options_for_select(SystemSurvey.unscoped.for_dropdown_select(filterrific.with_state), filterrific.with_survey), {}, class: 'form-control selectpicker survey-select', multiple: true, data: { hide_disabled: 'true' }
       .form-group.row
         .col-sm-12
           %label

--- a/app/views/surveyor/responses/index.html.haml
+++ b/app/views/surveyor/responses/index.html.haml
@@ -21,4 +21,4 @@
   #filter-responses
     = render 'surveyor/responses/filter_responses_form', filterrific: @filterrific, type: @type
 .col-lg-9
-  = render 'surveyor/responses/table', responses: @responses, type: @type
+  = render 'surveyor/responses/table', type: @type

--- a/app/views/surveyor/responses/index.js.coffee
+++ b/app/views/surveyor/responses/index.js.coffee
@@ -18,7 +18,7 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 $('#filter-responses').html("<%= j render 'surveyor/responses/filter_responses_form', filterrific: @filterrific, type: @type %>")
-$('#responses-panel').replaceWith("<%= j render 'surveyor/responses/table', responses: @responses, type: @type %>")
+$('#responses-panel').replaceWith("<%= j render 'surveyor/responses/table', type: @type %>")
 $('#responses-table').bootstrapTable()
 $('.selectpicker').selectpicker()
 $(".datetimepicker:not(.time)").datetimepicker(format: 'MM/DD/YYYY', allowInputToggle: true)

--- a/app/views/surveyor/responses/index.json.jbuilder
+++ b/app/views/surveyor/responses/index.json.jbuilder
@@ -4,7 +4,7 @@ json.(@responses) do |response|
   json.srid             srid == 'N/A' ? 'N/A' : link_to(srid, dashboard_protocol_path(srid.to_s.split('-').first), target: :blank)
   json.short_title      response.try(:respondable).try(:protocol).try(:short_title) || 'N/A'
   json.primary_pi       response.try(:respondable).try(:protocol).try(:primary_principal_investigator).try(:full_name) || 'N/A'
-  json.title            response.survey.title
+  json.title            response.survey.full_title
   json.by               response.identity.try(:full_name) || 'N/A'
   json.complete         complete_display(response)
   json.completion_date  format_date(response.created_at)

--- a/spec/controllers/surveyor/responses/get_index_spec.rb
+++ b/spec/controllers/surveyor/responses/get_index_spec.rb
@@ -54,16 +54,6 @@ RSpec.describe Surveyor::ResponsesController, type: :controller do
         expect(assigns(:type)).to eq('Survey')
       end
 
-      it 'should assign @responses' do
-        @resp = create(:response, survey: create(:system_survey))
-                create(:question_response, response: @resp)
-
-        get :index, params: {}, format: :html
-
-        expect(assigns(:responses)).to be_a(ActiveRecord::Relation)
-        expect(assigns(:responses).first).to eq(@resp)
-      end
-
       it 'should respond ok' do
         get :index, params: {}, format: :html
 
@@ -95,16 +85,6 @@ RSpec.describe Surveyor::ResponsesController, type: :controller do
         }, format: :js, xhr: true
 
         expect(assigns(:type)).to eq('Survey')
-      end
-
-      it 'should assign @responses' do
-        @resp = create(:response, survey: create(:system_survey))
-                create(:question_response, response: @resp)
-
-        get :index, params: {}, format: :js, xhr: true
-
-        expect(assigns(:responses)).to be_a(ActiveRecord::Relation)
-        expect(assigns(:responses).first).to eq(@resp)
       end
 
       it 'should respond ok' do
@@ -176,7 +156,7 @@ RSpec.describe Surveyor::ResponsesController, type: :controller do
               create(:question_response, response: resp2)
               create(:super_user, identity: logged_in_user, organization: org1)
 
-      get :index, params: { type: 'Form' }
+      get :index, params: { type: 'Form' }, format: :json
 
       expect(assigns(:responses).count).to eq(1)
       expect(assigns(:responses).first).to eq(resp1)

--- a/spec/features/surveyor/responses/user_filters_responses_spec.rb
+++ b/spec/features/surveyor/responses/user_filters_responses_spec.rb
@@ -196,8 +196,8 @@ RSpec.describe 'User filters responses', js: true do
   describe 'incomplete filter' do
     before :each do
       @other_survey   = create(:system_survey, title: 'Hollywoo Stars and Celebrities. Do they know things? What do they know? Let\'s find out', active: true)
-      survey_response = create(:response, survey: @survey, updated_at: Time.now - 5.days)
-      other_response  = create(:response, survey: @other_survey, updated_at: Time.now + 5.days)
+      survey_response = create(:response, survey: @survey)
+      other_response  = create(:response, survey: @other_survey)
                         create(:question_response, response: survey_response)
                         # other_response is incomplete
     end
@@ -213,13 +213,31 @@ RSpec.describe 'User filters responses', js: true do
     end
 
     context 'user filters including incomplete responses' do
-      scenario 'and sees both complete and incomplete responses' do
-        find('#filterrific_include_incomplete').click
-        click_button I18n.t(:actions)[:filter]
-        wait_for_javascript_to_finish
+      context 'for surveys' do
+        scenario 'and sees both complete and incomplete responses' do
+          find('#filterrific_include_incomplete').click
+          click_button I18n.t(:actions)[:filter]
+          wait_for_javascript_to_finish
 
-        expect(page).to have_selector('td', text: @survey.title)
-        expect(page).to have_selector('td', text: @other_survey.title)
+          expect(page).to have_selector('td', text: @survey.title)
+          expect(page).to have_selector('td', text: @other_survey.title)
+        end
+      end
+
+      context 'for forms' do
+        scenario 'and sees both complete and incomplete responses' do
+          @other_form     = create(:form, surveyable: @organization, title: 'Formula One', active: true)
+          other_response  = create(:response, survey: @other_form)
+          ssr             = create(:sub_service_request, organization: @organization)
+
+          bootstrap_select '#filterrific_of_type', Form.name
+          find('#filterrific_include_incomplete').click
+          click_button I18n.t(:actions)[:filter]
+          wait_for_javascript_to_finish
+
+          expect(page).to have_selector('td', text: @form.title)
+          expect(page).to have_selector('td', text: @other_form.title)
+        end
       end
     end
   end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/156401749

This does two things:
1. Adds conditional logic to the `state` filter. When you select active or inactive, the survey/form filters change to show only active and/or inactive surveys/forms corresponding to what the user selects.

![image](https://user-images.githubusercontent.com/12898988/42050127-1a05382c-7ad6-11e8-99b9-7d1ae09b81cf.png)

2. Implements the `allow incomplete` filter for Forms. Because forms and surveys function somewhat differently, we don't create blank responses for forms. This meant we have to check all sub service requests for incomplete forms, then initialize new responses (but not save them) in place of those incomplete forms.