### PR TITLE
KG - Fix Viewport Width

### DIFF
--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -100,3 +100,6 @@
 
 label.required:after
   content: "*"
+
+.no-margin
+  margin: 0 !important

--- a/app/assets/stylesheets/proper/layout.sass
+++ b/app/assets/stylesheets/proper/layout.sass
@@ -62,9 +62,6 @@
   padding-left: 0 !important
   padding-right: 0 !important
 
-.no-margin
-  margin: 0 !important
-
 .no-margin-x
   margin-left: 0 !important
   margin-right: 0 !important


### PR DESCRIPTION
The `no-margin` class was missing from catalog manager and causing the header to overflow to the side. Moving the class to the general layout sass file fixes the issue.