### PR TITLE
KG - View Response Likert Bug

### DIFF
--- a/app/assets/javascripts/likert.js.coffee
+++ b/app/assets/javascripts/likert.js.coffee
@@ -19,7 +19,5 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 $(document).ready ->
-  $(document). on 'click', '.likert-option', ->
+  $(document). on 'click', '.likert-group:not(.disabled) .likert-option', ->
     $(this).find('input').prop('checked', true)
-
-  $(".disable-likert *").prop('disabled',true)

--- a/app/views/surveyor/responses/form/_response_question.html.haml
+++ b/app/views/surveyor/responses/form/_response_question.html.haml
@@ -36,7 +36,7 @@
     .form-group
       %p.question-description
         = raw(question.description)
-  .question-options{ class: ['new', 'edit', 'preview'].include?(action_name) ? '' : 'disable-likert' }
+  .question-options
     = render "surveyor/responses/form/form_partials/#{question.question_type}_form_partial", qr: qr, question: question, question_response: question_response
   - if question.errors.any?
     .alert.alert-danger

--- a/app/views/surveyor/responses/form/form_partials/_likert_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_likert_form_partial.html.haml
@@ -17,7 +17,7 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.form-group.likert-group<
+.form-group.likert-group{ class: ['new', 'edit', 'preview'].include?(action_name) ? '' : 'disabled' }<
   - question.options.each_with_index do |option, index|
     .option.likert-option.no-padding{ style: "width: #{100.0 / question.options.count}%", data: { question_id: question.id, option_id: option.id } }>
       .col-sm-12.text-center.no-padding
@@ -31,5 +31,5 @@
         - if ['new', 'edit', 'preview'].include?(action_name)
           = qr.label :content, option.content, class: "radio-inline option no-padding", data: { question_id: question.id, option_id: option.id }
         - else
-          %label.radio-inline.option.no-padding.disabled
+          %label.radio-inline.option.no-padding
             = option.content

--- a/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
+++ b/spec/features/review/user_views_system_satisfaction_survey_response_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'User views a System Satisfaction Survey response', js: true do
 
     expect(page).to have_content('System Satisfaction Survey')
     expect(page).to have_selector('.question', count: 1)
-    expect(page).to have_selector('.disable-likert', count: 1)
+    expect(page).to have_selector('.likert-group.disabled', count: 1)
     expect(page).to have_selector('.likert input[checked="checked"]', count: 1)
   end
 end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/156545721

When viewing a response with a likert question, the user should not be able to click one of the other options to change it (this was purely front-end, no back-end changes).