### PR TITLE
KG - Delete Line Item Bug

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -51,7 +51,7 @@ class LineItem < ApplicationRecord
   validates :units_per_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, on: :update, if: Proc.new { |li| li.service.one_time_fee }
 
   after_create :build_line_items_visits_if_pppv
-  before_destroy :destroy_arms_if_last_pppv_line_item
+  before_destroy :destroy_arms_if_last_pppv_line_item, if: Proc.new { |li| !li.one_time_fee }
 
   default_scope { order('line_items.id ASC') }
 
@@ -355,7 +355,7 @@ class LineItem < ApplicationRecord
 
   def destroy_arms_if_last_pppv_line_item
     if self.try(:protocol).try(:service_requests).try(:none?) { |sr| sr.has_per_patient_per_visit_services? }
-      self.service_request.try(:arms).try(:destroy_all)
+      self.service_request.protocol.try(:arms).try(:destroy_all)
     end
   end
 end


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/159014571

We delete arms when the user deletes the last PPPV line item, but we don't check that the line item is actually for a PPPV service. Similarly, Rails can't seem to perform the `destroy_all` by calling the `has_many, through` relationship between service_requests, protocols, and arms. Loading the arms directly through the protocol resolves this error.