### PR TITLE
Jl - Status sorting bug

### DIFF
--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -277,7 +277,8 @@ module Dashboard::SubServiceRequestsHelper
   private
 
   def statuses_with_classes(ssr)
-    ssr.organization.get_available_statuses.invert.map do |status|
+    
+    sorted_by_permissible_values(ssr.organization.get_available_statuses).invert.map do |status|
       if in_finished_status?(status)
         status.push(:class=> 'finished-status')
       else
@@ -288,7 +289,7 @@ module Dashboard::SubServiceRequestsHelper
 
   def finished_statuses(ssr)
     new_statuses = []
-    ssr.organization.get_available_statuses.invert.map do |status|
+    sorted_by_permissible_values(ssr.organization.get_available_statuses).invert.map do |status|
       if in_finished_status?(status)
         new_statuses << status
       end
@@ -301,6 +302,18 @@ module Dashboard::SubServiceRequestsHelper
 
   def in_finished_status?(status)
     Setting.find_by_key("finished_statuses").value.include?(status.last)
+  end
+
+  def sorted_by_permissible_values(statuses)
+    values = PermissibleValue.order(:sort_order).get_hash('status')
+    sorted_hash = {}
+    values.each do |k, v|
+      if statuses.has_key?(k)
+        sorted_hash[k] = v
+      end
+    end
+
+    sorted_hash
   end
 end
 

--- a/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
+++ b/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
 
       expect(response).to have_tag("select#sub_service_request_status") do
         with_option("Draft")
-        with_option("NotDraft")
+        with_option("Invoiced")
       end
     end
   end
@@ -254,7 +254,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
   end
 
   def stub_organization(opts = {})
-    default_statuses = { "draft" => "Draft", "not_draft" => "NotDraft" }
+    default_statuses = { "draft" => "Draft", "invoiced" => "Invoiced" }
     instance_double(Organization,
       name: "MegaCorp",
       abbreviation: "MC",


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/156819921

I had to compare the sorted permissible values hash (in the status category) with the correctly filtered hash given by the 'get_available_statuses' method on organization to ultimately get what I needed for the dropdown.