### PR TITLE
wth - (SPARCDashboard) Edit Non-clinical Service Quantity Bug

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -46,7 +46,7 @@ class LineItem < ApplicationRecord
   validates :service_id, numericality: true, presence: true
   validates :service_request_id, numericality:  true
 
-  validates :quantity, numericality: { only_integer: true }, on: :update, if: Proc.new { |li| li.service.one_time_fee }
+  validates :quantity, numericality: true, on: :update, if: Proc.new { |li| li.service.one_time_fee }
   validate :quantity_must_be_smaller_than_max_and_greater_than_min, on: :update, if: Proc.new { |li| li.service.one_time_fee }
   validates :units_per_quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, on: :update, if: Proc.new { |li| li.service.one_time_fee }
 


### PR DESCRIPTION
To maintain consistency with SPARCRequest and SPARCDashboard Add non-clinical service functions , the quantity entered when Edit Non-clinical services on SPARCDashboard should allow the format of "1.0, 5.0, etc" without error message, but removes the ".0" partial automatically.

See related story here: https://www.pivotaltracker.com/story/show/158772507

[#159234181]

Story - https://www.pivotaltracker.com/story/show/159234181