### PR TITLE
KG - Admin Edit Export to Excel Bug

### DIFF
--- a/app/views/service_requests/request_report.xlsx.axlsx
+++ b/app/views/service_requests/request_report.xlsx.axlsx
@@ -342,15 +342,8 @@ wb.add_worksheet(name: "Review") do |sheet|
 
   end_column = "G"
 
-  alpha_array = ("A".."Z").to_a
-  additional_alpha_arrays_needed = ((visit_count*2 + 5 + @admin_offset.to_i)/26.0).ceil + 1 #add one since some columns get pushed over, safety.  doesn't matter if we have extra here
-
-  additional_alpha_arrays = []
-  additional_alpha_arrays_needed.times do |n|
-    additional_alpha_arrays << alpha_array.map{|char| alpha_array[n] + char}
-  end
-
-  alpha_array = alpha_array + additional_alpha_arrays.flatten
+  num_cols = (visit_count*2 + 8 + @admin_offset.to_i)
+  alpha_array = sheet.get_headers(num_cols)
 
   end_column = alpha_array[visit_count*2 + 7 + @admin_offset.to_i]
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159284875

The number of columns being generated was incorrect and causing `nil` to be used for calculations. 

[This commit](https://github.com/sparc-request/sparc-request/commit/2d44fbc3b1b8b95329fc48d3faaada08c73ec575) added a nice way to generate the alpha array, so I used it in the same way @jwiel86 did.

One thing that I noticed was that I had to change `+ 5` to `+ 8` because the alpha array was too short for what the report required and caused Excel to complain that the report was unreadable. This is likely due to new columns being added and previously the alpha array had extra columns added on for "safety" so the calculations were off by 3 columns in the report.