### PR TITLE
KG - Yes/No Question Missing Options

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -39,7 +39,7 @@ class Question < ActiveRecord::Base
 
   accepts_nested_attributes_for :options, allow_destroy: true
   
-  after_update :update_options_based_on_question_type, if: :question_type_changed?
+  before_update :update_options_based_on_question_type, if: :question_type_changed?
 
   def previous_questions
     self.survey.questions.select{ |q| q.id < self.id }
@@ -52,7 +52,9 @@ class Question < ActiveRecord::Base
   private
 
   def update_options_based_on_question_type
-    self.options.destroy_all
+    unless ['radio_button', 'likert', 'checkbox', 'dropdown', 'multiple_dropdown'].include?(self.question_type)
+      self.options.destroy_all
+    end
 
     if self.question_type == 'yes_no'
       self.options.create(content: 'Yes')

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -26,10 +26,16 @@ FactoryBot.define do
     question_type { 'text' }
     required      { false }
 
-    after(:create) do |question|
+    transient do
+      option_count 0
+    end
+
+    after(:create) do |question, evaluator|
       if question.question_type == 'yes_no'
         create(:option, question: question, content: 'Yes')
         create(:option, question: question, content: 'No')
+      elsif evaluator.option_count > 0
+        create_list(:option, evaluator.option_count, question: question)
       end
     end
 

--- a/spec/models/question/question_spec.rb
+++ b/spec/models/question/question_spec.rb
@@ -41,4 +41,27 @@ RSpec.describe Question, type: :model do
   it { is_expected.to accept_nested_attributes_for(:options) }
 
   it { is_expected.to delegate_method(:survey).to(:section) }
+
+  # Callbacks
+  describe 'update_options_based_on_question_type' do
+    it 'should be called on update' do
+      @question = create(:question, question_type: 'text')
+      expect(@question).to receive(:update_options_based_on_question_type)
+      @question.update_attribute(:question_type, 'email')
+    end
+
+    it 'should destroy options when if not a type with options' do
+      @question = create(:question, question_type: 'likert', option_count: 2)
+      expect(@question.options.count).to eq(2)
+      @question.update_attribute(:question_type, 'text')
+      expect(@question.options.count).to eq(0)
+    end
+
+    it 'should create yes/no options' do
+      @question = create(:question, question_type: 'text')
+      expect(@question.options.count).to eq(0)
+      @question.update_attribute(:question_type, 'yes_no')
+      expect(@question.options.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159341815

Rails now doesn't track `#{attribute}_changed?` after committing changes so this callback no longer worked on `after_save`.

Docs: https://api.rubyonrails.org/classes/ActiveModel/Dirty.html