### PR TITLE
wth - (SPARCDashboard, SPARCRequest & Data) Admin Rate Label Change a…

### DIFF
--- a/app/assets/javascripts/dashboard/study_level_activities.js.coffee
+++ b/app/assets/javascripts/dashboard/study_level_activities.js.coffee
@@ -47,15 +47,6 @@ $ ->
       url: "/dashboard/line_items/#{line_item_id}/edit"
       data: data
 
-  $(document).on 'change', '.your-cost-edit', ->
-    row_index   = $(this).parents('tr').data('index')
-    line_item_id = $(this).parents('table.study_level_activities').bootstrapTable('getData')[row_index].id
-    data = 'line_item': 'displayed_cost' : $(this).val().replace('$', '')
-    $.ajax
-      type: 'PATCH'
-      url: "/dashboard/line_items/#{line_item_id}"
-      data: data
-
   $(document).on 'click', '.otf_delete', ->
     row_index   = $(this).parents('tr').data('index')
     line_item_id = $(this).parents('table.study_level_activities').bootstrapTable('getData')[row_index].id
@@ -105,3 +96,12 @@ $ ->
       $.ajax
         type: 'DELETE'
         url: "/dashboard/fulfillments/#{fulfillment_id}"
+
+  $(document).on 'load-success.bs.table', '.study_level_activities', ->
+    setup_xeditable_fields()
+
+  $('body').tooltip(
+    selector: '[data-title]'
+    delay: {show: 500}
+  )
+

--- a/app/assets/javascripts/service_calendar.js.coffee
+++ b/app/assets/javascripts/service_calendar.js.coffee
@@ -314,6 +314,20 @@ $(document).ready ->
       $('#sub_service_request_header').html(data['header'])
       $('.selectpicker').selectpicker()
 
+  $('.your-cost').editable
+    display: (value) ->
+      # display field as currency, edit as quantity
+      $(this).text("$" + parseFloat(value).toFixed(2))
+    params: (params) ->
+      {
+        line_item:
+          displayed_cost: params.value
+        service_request_id: getSRId()
+      }
+    success: (response, newValue) ->
+      $('.study_level_activities').bootstrapTable('refresh', silent: true)
+
+
   $('.edit-subject-count').editable
     params: (params) ->
       {

--- a/app/helpers/dashboard/study_level_activities_helper.rb
+++ b/app/helpers/dashboard/study_level_activities_helper.rb
@@ -41,7 +41,9 @@ module Dashboard::StudyLevelActivitiesHelper
   end
 
   def sla_your_cost_field line_item
-    raw( text_field(:line_item, :service, class: 'your-cost-edit', value: number_with_precision(Service.cents_to_dollars(line_item.applicable_rate), precision: 2)) )
+    link_to 'javascript:void(0);', class: [("your-cost editable"), ('text-danger' if line_item.admin_rates.present?)], data: { url: dashboard_line_item_path(line_item), title: line_item.admin_rates.present? ? t(:dashboard)[:study_level_activities][:tooltips][:modified_rate] : t(:dashboard)[:study_level_activities][:tooltips][:admin_rate] }do
+      number_with_precision(Service.cents_to_dollars(line_item.applicable_rate), precision: 2)
+    end
   end
 
   def sla_options_buttons line_item

--- a/app/models/available_status.rb
+++ b/app/models/available_status.rb
@@ -32,11 +32,11 @@ class AvailableStatus < ApplicationRecord
   end
 
   def self.statuses
-    @statuses ||= PermissibleValue.get_hash('status')
+    @statuses ||= PermissibleValue.order(:sort_order).get_hash('status')
   end
 
   def self.defaults
-    @defaults ||= PermissibleValue.get_key_list('status', true)
+    @defaults ||= PermissibleValue.order(:sort_order).get_key_list('status', true)
   end
 
   def humanize

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -354,6 +354,8 @@ en:
         cost: "Cost:"
       tooltips:
         add_non_clinical_services: "Add Non-clinical services related to selected organization"
+        modified_rate: 'Modified Rate'
+        admin_rate: 'Admin Rate'
 
     ##########################
     #  SUB SERVICE REQUESTS  #

--- a/spec/features/dashboard/admin_edit/admin_edits_service_calendar_fields_spec.rb
+++ b/spec/features/dashboard/admin_edit/admin_edits_service_calendar_fields_spec.rb
@@ -126,18 +126,14 @@ RSpec.describe 'User sets each Service Calendar field', js: true do
 
       context 'your cost' do
         before :each do
-          find('.edit-your-cost.editable', match: :first).click
+          find('.your-cost.editable', match: :first).click
           find('.editable-input input').set(100)
           find('.editable-submit').click
           wait_for_javascript_to_finish
         end
 
         it 'updates your cost' do
-          expect(page).to have_css('.edit-your-cost', text: '$100.00')
-        end
-
-        it 'should update header total cost' do
-          expect(page).to have_css('.display_cost', text: '$1,001.00')
+          expect(page).to have_css('.your-cost', text: '$100.00')
         end
       end
     end
@@ -154,24 +150,6 @@ RSpec.describe 'User sets each Service Calendar field', js: true do
         it 'should throw error' do
           expect(page).to have_selector('.editable-error-block', visible: true)
           expect(page).to have_content('Subject Count is not a number')
-        end
-
-        it 'should not update header total' do
-          expect(page).to have_css('.display_cost', text: '$11.00')
-        end
-      end
-
-      context 'your cost' do
-        before :each do
-          find('.edit-your-cost.editable', match: :first).click
-          find('.editable-input input').set('a number')
-          find('.editable-submit').click
-          wait_for_javascript_to_finish
-        end
-
-        it 'should throw error' do
-          expect(page).to have_selector('.editable-error-block', visible: true)
-          expect(page).to have_content('Displayed Cost must be a number')
         end
 
         it 'should not update header total' do


### PR DESCRIPTION
…nd Visual Cue

Background: Currently, the admin rate is an attribute on Line Item level. When an admin user set an admin rate on a service in a request, and then add the same service in SPARCFulfillment (which was not pushed from SPARCRequest), SPARCFulfillment considers it as a service with the normal rate rather than admin rate.

Please:

1). Make the format of the "Non-clinical Service" "Your Cost" editable field consistent with the other ones in SPARCDashboard Admin Edit Section “Clinical Services” Tab (see 2nd screenshot attached);

2). Add a visual cue (such as "(Modified)" sign or "M" icon with "Modified Rate" tooltip next to the cost in green color) for admin rate (SPARCRequest & SPARCDashboard).

The corresponding SPARCFulfillment story can be found here: https://www.pivotaltracker.com/story/show/156286625

[#156275541]

Story - https://www.pivotaltracker.com/story/show/156275541