### PR TITLE
KG - Survey Access Code Random Failures

### DIFF
--- a/spec/factories/survey.rb
+++ b/spec/factories/survey.rb
@@ -21,7 +21,7 @@
 FactoryBot.define do
   factory :survey do
     title                     { Faker::Lorem.word }
-    access_code               { Faker::Lorem.word }
+    sequence(:access_code)    { |n| "survey-#{n}" }
     sequence(:version)        { |n| n }
     active                    { false }
 


### PR DESCRIPTION
We kept getting specs randomly failing because of `another version of this survey is already active` errors. To fix this, make `access_code` a sequence, that way we don't end up with duplicates trying to be active and causing the random failures.