### PR TITLE
KG - Export Consolidated Request Division Bug

### DIFF
--- a/app/views/dashboard/protocols/show.xlsx.axlsx
+++ b/app/views/dashboard/protocols/show.xlsx.axlsx
@@ -235,7 +235,7 @@ wb.insert_worksheet(0, name: "Summary") do |sheet|
   sheet.add_row ["Primary PI Name:", @protocol.primary_principal_investigator.full_name], :style => [bold_default, default]
   sheet.add_row ["Business Manager:", @protocol.billing_managers.map(&:full_name).try(:join, ', ')], :style => [bold_default, default]
   sheet.add_row ["Funding Source:", @protocol.display_funding_source_value], :style => [bold_default, default]
-  sheet.add_row ["Indirect Cost Rate:", @protocol.indirect_cost_rate / 100.0 || 0.0], style: [bold_default, percent]
+  sheet.add_row ["Indirect Cost Rate:", @protocol.indirect_cost_rate.try(:/, 100.0) || 0.0], style: [bold_default, percent]
   sheet.add_row ["Staff Fringe Rate:", 0], style: [bold_default, percent]
 
   indirect_cost_rate_row = sheet.rows.length


### PR DESCRIPTION
When a protocol's indirect cost rate is `nil`, the following error occurs:

![image](https://user-images.githubusercontent.com/12898988/43591957-219c95f6-963a-11e8-9993-aa66546fc581.png)