### PR TITLE
Short interaction institution migration [#159531739]

### DIFF
--- a/app/models/professional_organization.rb
+++ b/app/models/professional_organization.rb
@@ -30,6 +30,8 @@ class ProfessionalOrganization < ApplicationRecord
     parent ? (parent.parents + [parent]) : []
   end
 
+  scope :institutions, -> { where(org_type: 'institution').order(:name) }
+
   # Returns collection like [greatgrandparent, grandparent, parent, self].
   def parents_and_self
     parents + [self]

--- a/app/models/short_interaction.rb
+++ b/app/models/short_interaction.rb
@@ -24,8 +24,4 @@ class ShortInteraction < ApplicationRecord
     interaction_type.nil? ? "" : "#{PermissibleValue.get_value('interaction_type', interaction_type)}"
   end
 
-  def display_institution
-    institution.nil? ? "" : "#{PermissibleValue.get_value('institution', institution)}"
-  end
-
 end

--- a/app/reports/short_interactions.rb
+++ b/app/reports/short_interactions.rb
@@ -48,7 +48,7 @@ class ShortInteractionsReport < ReportingModule
     attrs["Duration in minutes"] = :duration_in_minutes
     attrs["Investigator Name"] = :name
     attrs["Investigator Email"] = :email
-    attrs["Investigator Institution"] = :display_institution
+    attrs["Investigator Institution"] = :institution
     attrs["Notes"] = :note
     
     attrs

--- a/app/views/service_requests/right_navigation/_short_interaction_modal.html.haml
+++ b/app/views/service_requests/right_navigation/_short_interaction_modal.html.haml
@@ -52,7 +52,7 @@
           .form-group.row
             = f.label :institution, t(:proper)[:right_navigation][:short_interaction][:institution], class: 'col-lg-4 control-label'
             .col-lg-8
-              = f.select :institution, options_for_select(INSTITUTIONS), { prompt: t(:proper)[:right_navigation][:short_interaction][:institution_select]}, class: 'form-control'
+              = f.select :institution, options_for_select(ProfessionalOrganization.institutions.pluck(:name)), { prompt: t(:proper)[:right_navigation][:short_interaction][:institution_select]}, class: 'form-control'
           .form-group.row
             = f.label :note, t(:proper)[:right_navigation][:short_interaction][:note], class: 'col-lg-4 control-label required'
             .col-lg-8

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -112,17 +112,6 @@ epic_rights: { 'view_rights': 'View Research Studies',
 
 epic_rights_info: 'Once the study is "completed" in Epic, it cannot be moved back to "Active or Inactive" Completing the study will inhibit new participants to be enrolled and associated with the study. Please select only one member of your study team that will be authorized to change a study status to Active/Complete.'
 
-institutions: { "University of South Carolina": "university_of_south_carolina",
-                "Health Sciences South Carolina": "health_sciences_south_carolina",
-                "Clemson University": "clemson_university",
-                "South Carolina State University": "south_carolina_state_university",
-                "Claflin University": "claflin_university",
-                "Greenwood Genetic Center": "greenwood_genetic_center",
-                "South Carolina Research Authority": "south_carolina_research_authority",
-                "VA Medical Centers": "va_medical_centers",
-                "Other": "other",
-                "Medical University of South Carolina": "medical_university_of_south_carolina" }
-
 study_type_answers: {  '1' : [true, true,   ~,     ~,     ~,     ~],
                        '2' : [true, false, true,   ~,     ~,     ~],
                        '3' : [true, false, false, false, true, true],

--- a/db/migrate/20180628192745_add_short_interaction_permissible_values.rb
+++ b/db/migrate/20180628192745_add_short_interaction_permissible_values.rb
@@ -20,13 +20,5 @@ class AddShortInteractionPermissibleValues < ActiveRecord::Migration[5.2]
       PermissibleValue.create(category: 'interaction_subject', key: 'regulatory_question', value: 'Regulatory Question')
       PermissibleValue.where(category: 'interaction_subject').update_all(is_available: true)
     end
-
-    ## move institutions from constant.yml to permissible_values
-    unless PermissibleValue.where(category: 'institution').exists?
-      INSTITUTIONS.each do |name, key|
-        PermissibleValue.create(category: 'institution', key: key, value: name)
-      end
-      PermissibleValue.where(category: 'institution').update_all(is_available: true)
-    end
   end
 end

--- a/db/migrate/20180803190614_delete_institution_permissible_values.rb
+++ b/db/migrate/20180803190614_delete_institution_permissible_values.rb
@@ -1,0 +1,12 @@
+class DeleteInstitutionPermissibleValues < ActiveRecord::Migration[5.2]
+  def change
+    # update existing short interaction institution field
+    ShortInteraction.all.each do |si|
+      si.update_attribute(:institution, si.institution.titleize)
+    end
+
+    # delete permissible values 'institution' category
+    institutions = PermissibleValue.where(category: 'institution')
+    institutions.destroy_all if institutions
+  end
+end

--- a/spec/features/catalog/provider_adds_short_interaction_spec.rb
+++ b/spec/features/catalog/provider_adds_short_interaction_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Service Provider clicks Short Interaction', js: true do
     institution    = create(:institution, name: "Institution")
     provider       = create(:provider, name: "Provider", parent: institution)
     create(:service_provider, identity_id: jug2.id, organization_id: provider.id)
+    other_institution = ProfessionalOrganization.create(name: "Other Institution", org_type: "institution")
   end
 
   scenario 'and sees the short interaction modal' do
@@ -32,7 +33,7 @@ RSpec.describe 'Service Provider clicks Short Interaction', js: true do
       fill_in 'short_interaction_name', with: 'Tester'
       fill_in 'short_interaction_email', with: 'test@abc.com'
       fill_in 'short_interaction_note', with: 'testing'
-      select('Other', from: 'short_interaction_institution')
+      select('Other Institution', from: 'short_interaction_institution')
       select('General Question', from: 'short_interaction_subject')
       select('Email', from: 'short_interaction_interaction_type')
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/159531739

The institutions used in the "Short Interaction" function is currently pulling from constants.yml.
Please 1). migrate that to be using the institutions from professional_organizations in the database instead, and 2)remove the old attributes from constants.yml.