### PR TITLE
ml - Past Status Data Cleanup

### DIFF
--- a/lib/tasks/clean_up_past_status_data.rake
+++ b/lib/tasks/clean_up_past_status_data.rake
@@ -1,0 +1,31 @@
+# Copyright © 2011-2018 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+namespace :data do
+  task clean_up_past_statuses: :environment do
+    include ActiveModel::AttributeAssignment
+
+    PastStatus.where("status LIKE ?", "% %").each do |past_status|
+      old_status = past_status.status
+      past_status.update_attributes(status: old_status.parameterize.underscore)
+      puts "Fixed past status: #{past_status.id}. Changed status from: #{old_status} to: #{old_status.parameterize.underscore}"
+    end
+  end
+end


### PR DESCRIPTION
In the past_statuses table, there are a lot of historical records that have missing underscores.

The past statuses table should be saving the "machine name" of a status, not the "humanized name."

For example, "on_hold" is showing as "on hold", "in _process" is showing as "in process" etc, which was causing reporting issues.

Please write a script to clean up the historical data.
