### PR TITLE
KG - Select Survey/Form Filter Bug

### DIFF
--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -65,22 +65,23 @@ class Survey < ApplicationRecord
     'Multiple Dropdown': 'multiple_dropdown'
   }
   
-  def self.for_dropdown_select(filtered_states=nil)
-    self.all.order(:title).group_by(&:title).map{ |title, surveys|
+  def self.for_dropdown_select(filtered_states=nil, filtered_surveys=nil)
+    self.all.order(:title).group_by(&:title).map do |title, surveys|
       [
         title,
-        surveys.map{ |survey|
+        surveys.map do |survey|
           [
             "Version #{survey.version} (#{survey.active ? I18n.t(:surveyor)[:response_filters][:fields][:state_filters][:active] : I18n.t(:surveyor)[:response_filters][:fields][:state_filters][:inactive]})",
             survey.id,
             {
-              disabled: filtered_states && !filtered_states.include?(survey.active ? 1 : 0),
+              disabled: filtered_states && filtered_states.length > 1 && !filtered_states.include?(survey.active ? 1 : 0),
+              selected: filtered_surveys && filtered_surveys.include?(survey.id),
               data: { active: survey.active ? '1' : '0' }
             }
           ]
-        }
+        end
       ]
-    }
+    end
   end
 
   # Added because version could not be written as an attribute by FactoryBot. Possible keyword issue?

--- a/app/views/surveyor/responses/_filter_responses_form.html.haml
+++ b/app/views/surveyor/responses/_filter_responses_form.html.haml
@@ -40,11 +40,11 @@
       .form-group.row{ id: "for-#{Form.name}", class: filterrific.of_type == Form.name ? "" : "hidden" }
         = form.label :with_survey, Form.name, class: 'col-lg-3 control-label text-left'
         .col-lg-9
-          = form.select :with_survey, grouped_options_for_select(Form.for(current_user).for_dropdown_select(filterrific.with_state), filterrific.with_survey), {}, class: 'form-control selectpicker survey-select', multiple: true, data: { hide_disabled: 'true' }
+          = form.select :with_survey, grouped_options_for_select(Form.for(current_user).for_dropdown_select(filterrific.with_state, filterrific.with_survey)), {}, class: 'form-control selectpicker survey-select', multiple: true, data: { hide_disabled: 'true' }
       .form-group.row{ id: "for-#{SystemSurvey.name}", class: filterrific.of_type == SystemSurvey.name ? "" : "hidden" }
         = form.label :with_survey, Survey.name, class: 'col-lg-3 control-label text-left'
         .col-lg-9
-          = form.select :with_survey, grouped_options_for_select(SystemSurvey.unscoped.for_dropdown_select(filterrific.with_state), filterrific.with_survey), {}, class: 'form-control selectpicker survey-select', multiple: true, data: { hide_disabled: 'true' }
+          = form.select :with_survey, grouped_options_for_select(SystemSurvey.unscoped.for_dropdown_select(filterrific.with_state, filterrific.with_survey)), {}, class: 'form-control selectpicker survey-select', multiple: true, data: { hide_disabled: 'true' }
       .form-group.row
         .col-sm-12
           %label


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156401749

There were 2 issues found:

> When I selected TIN Version 1 and checked "Include Incomplete" it showed responses for all forms, not just TIN Version 1.

> When I clicked a saved filtered with TIN Version 1, it showed responses for all forms, not just TIN Version 1.

Both were caused by the same bugs.

First, you can't pass the survey ids to `grouped_options_for_select` to be used for the `selected` option. This has to be done when generated the grouped options.

Second, filterrific sometimes passed `with_state` as `[""]`, meaning that both active and inactive forms were hidden in the dropdown, and thus not filtered correctly.