### PR TITLE
SJ - Status creation defaults

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -411,8 +411,8 @@ class Organization < ApplicationRecord
   private
 
   def create_statuses
-    EditableStatus.import EditableStatus.types.map{|status| EditableStatus.new(organization: self, status: status)}
-    AvailableStatus.import AvailableStatus.types.map{|status| AvailableStatus.new(organization: self, status: status)}
+    EditableStatus.import PermissibleValue.where(category: 'status').map{|pv| EditableStatus.new(organization: self, status: pv.key, selected: pv.default)}
+    AvailableStatus.import PermissibleValue.where(category: 'status').map{|pv| AvailableStatus.new(organization: self, status: pv.key, selected: pv.default)}
   end
 
   def self.authorized_child_organization_ids(org_ids)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -398,8 +398,10 @@ class Organization < ApplicationRecord
   def get_editable_statuses
     if process_ssrs
       self.use_default_statuses ? AvailableStatus.defaults : self.editable_statuses.selected.pluck(:status)
-    else
+    elsif process_ssrs_parent
       process_ssrs_parent.get_editable_statuses
+    else
+      AvailableStatus.defaults
     end
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -411,8 +411,8 @@ class Organization < ApplicationRecord
   private
 
   def create_statuses
-    EditableStatus.import PermissibleValue.where(category: 'status').map{|pv| EditableStatus.new(organization: self, status: pv.key, selected: pv.default)}
-    AvailableStatus.import PermissibleValue.where(category: 'status').map{|pv| AvailableStatus.new(organization: self, status: pv.key, selected: pv.default)}
+    EditableStatus.import PermissibleValue.available.where(category: 'status').map{|pv| EditableStatus.new(organization: self, status: pv.key, selected: pv.default)}
+    AvailableStatus.import PermissibleValue.available.where(category: 'status').map{|pv| AvailableStatus.new(organization: self, status: pv.key, selected: pv.default)}
   end
 
   def self.authorized_child_organization_ids(org_ids)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -382,12 +382,14 @@ class Organization < ApplicationRecord
       else
         selected_statuses = available_statuses.selected.pluck(:status)
       end
-    else
+    elsif process_ssrs_parent
       if process_ssrs_parent.use_default_statuses
         selected_statuses = AvailableStatus.defaults
       else
         selected_statuses = process_ssrs_parent.available_statuses.selected.pluck(:status)
       end
+    else
+      selected_statuses = AvailableStatus.defaults
     end
 
     AvailableStatus.statuses.slice(*selected_statuses)

--- a/spec/controllers/search/get_services_spec.rb
+++ b/spec/controllers/search/get_services_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe SearchController do
 
     it 'should not return services from a locked organization' do
       sr    = create(:service_request_without_validations)
-      org   = create(:organization, use_default_statuses: false)
+      org   = create(:organization, use_default_statuses: false, process_ssrs: true)
       inst  = create(:institution)
       prvdr = create(:provider, parent: inst)
       org2  = create(:program, parent: prvdr, use_default_statuses: false)

--- a/spec/controllers/service_requests/get_obtain_research_pricing_spec.rb
+++ b/spec/controllers/service_requests/get_obtain_research_pricing_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     context 'editing a service request that has been previously submitted' do
       context 'ssr status is set to a locked status' do
         before :each do
-          @org     = create(:organization, use_default_statuses: false)
+          @org     = create(:organization, use_default_statuses: false, process_ssrs: true)
           service  = create(:service, organization: @org, one_time_fee: true)
           protocol = create(:protocol_federally_funded, primary_pi: logged_in_user, type: 'Study')
           @sr      = create(:service_request_without_validations, protocol: protocol, original_submitted_date: Time.now.yesterday)

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -100,11 +100,6 @@ FactoryBot.define do
       end
     end
 
-    after(:create) do |organization, evaluator|
-      organization.available_statuses.where(status: ['draft', 'submitted', 'get_a_cost_estimate']).update_all(selected: true)
-      organization.editable_statuses.where(status: ['draft', 'submitted', 'get_a_cost_estimate']).update_all(selected: true)
-    end
-
     factory :organization_with_process_ssrs, traits: [:process_ssrs, :with_pricing_setup]
     factory :organization_ctrc, traits: [:ctrc]
     factory :organization_without_validations, traits: [:without_validations]

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     description   { Faker::Lorem.paragraph(4) }
     abbreviation  { Faker::Lorem.word }
     ack_language  { Faker::Lorem.paragraph(4) }
-    process_ssrs  { false }
+    process_ssrs  { true }
     is_available  { true }
     use_default_statuses { true }
     order         { 1 }

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     description   { Faker::Lorem.paragraph(4) }
     abbreviation  { Faker::Lorem.word }
     ack_language  { Faker::Lorem.paragraph(4) }
-    process_ssrs  { true }
+    process_ssrs  { false }
     is_available  { true }
     use_default_statuses { true }
     order         { 1 }

--- a/spec/features/catalog_manager/organization_forms/status_options/user_manages_available_statuses_spec.rb
+++ b/spec/features/catalog_manager/organization_forms/status_options/user_manages_available_statuses_spec.rb
@@ -45,9 +45,6 @@ RSpec.describe 'User manages status options', js: true do
       end
 
       it 'should add the available status' do
-        puts '#' * 50
-        @provider.available_statuses.each{|status| puts "#{status.status}/#{status.selected}"}
-        puts '#' * 50
         first('.available-status-checkbox').click
         wait_for_javascript_to_finish
         expect(AvailableStatus.where(organization_id: @provider.id).first.selected).to eq(true)

--- a/spec/features/catalog_manager/organization_forms/status_options/user_manages_available_statuses_spec.rb
+++ b/spec/features/catalog_manager/organization_forms/status_options/user_manages_available_statuses_spec.rb
@@ -45,9 +45,11 @@ RSpec.describe 'User manages status options', js: true do
       end
 
       it 'should add the available status' do
+        puts '#' * 50
+        @provider.available_statuses.each{|status| puts "#{status.status}/#{status.selected}"}
+        puts '#' * 50
         first('.available-status-checkbox').click
         wait_for_javascript_to_finish
-
         expect(AvailableStatus.where(organization_id: @provider.id).first.selected).to eq(true)
         expect(first('.available-status-checkbox')).to_not be_disabled
       end

--- a/spec/features/dashboard/service_requests/user_views_ssrs_spec.rb
+++ b/spec/features/dashboard/service_requests/user_views_ssrs_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "User views SSR table", js: true do
       context 'for a locked SSR' do
         let!(:protocol)             { create(:unarchived_study_without_validations, primary_pi: jug2) }
         let!(:service_request)      { create(:service_request_without_validations, protocol: protocol, status: 'draft') }
-        let!(:organization)         { create(:organization,type: 'Institution', name: 'Megacorp', admin: bob, service_provider: bob, use_default_statuses: false) }
+        let!(:organization)         { create(:organization,type: 'Institution', name: 'Megacorp', admin: bob, service_provider: bob, use_default_statuses: false, process_ssrs: true) }
 
         scenario 'and sees View but not Edit' do
           organization.editable_statuses.where(status: 'on_hold').destroy_all

--- a/spec/features/service_calendar/user_checks_unchecks_column_spec.rb
+++ b/spec/features/service_calendar/user_checks_unchecks_column_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'User checks and unchecks calendar columns', js: true do
   fake_login_for_each_test
 
   before :each do
-    org       = create(:organization, use_default_statuses: false)
-    org2      = create(:organization, use_default_statuses: false)
+    org       = create(:organization, use_default_statuses: false, process_ssrs: true)
+    org2      = create(:organization, use_default_statuses: false, process_ssrs: true)
                 create(:pricing_setup, organization: org)
                 create(:pricing_setup, organization: org2)
     service   = create(:service, organization: org, one_time_fee: false, pricing_map_count: 1)

--- a/spec/features/service_calendar/user_checks_unchecks_row_spec.rb
+++ b/spec/features/service_calendar/user_checks_unchecks_row_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'User checks and unchecks calendar rows', js: true do
   fake_login_for_each_test
 
   before :each do
-    org       = create(:organization, use_default_statuses: false)
+    org       = create(:organization, use_default_statuses: false, process_ssrs: true)
                 create(:pricing_setup, organization: org)
     service   = create(:service, organization: org, one_time_fee: false, pricing_map_count: 1)
 

--- a/spec/features/service_calendar/user_views_locked_ssr_spec.rb
+++ b/spec/features/service_calendar/user_views_locked_ssr_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'User views a locked SSR', js: true do
   fake_login_for_each_test
 
   before :each do
-    org       = create(:organization, use_default_statuses: false)
+    org       = create(:organization, use_default_statuses: false, process_ssrs: true)
                 create(:pricing_setup, organization: org)
     pppv      = create(:service, organization: org, one_time_fee: false, pricing_map_count: 1)
     otf       = create(:service, organization: org, one_time_fee: true, pricing_map_count: 1)

--- a/spec/models/service_request/update_status_spec.rb
+++ b/spec/models/service_request/update_status_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe ServiceRequest, type: :model do
       context "past status is updatable ('get_a_cost_estimate')" do
         before :each do
           @org         = create(:organization_with_process_ssrs, use_default_statuses: false)
+          @org.available_statuses.where(status: "get_a_cost_estimate").first.update_attributes(selected: true)
           identity     = create(:identity)
           service     = create(:service, organization: @org, one_time_fee: true)
           protocol    = create(:protocol_federally_funded, primary_pi: identity, type: 'Study')

--- a/spec/models/sub_service_request/sub_service_request_spec.rb
+++ b/spec/models/sub_service_request/sub_service_request_spec.rb
@@ -201,15 +201,6 @@ RSpec.describe SubServiceRequest, type: :model do
 
     describe "sub service request status" do
 
-      let!(:org1)       { create(:organization) }
-      let!(:org2)       { create(:organization) }
-      let!(:ssr1)       { create(:sub_service_request, service_request_id: service_request.id, organization_id: org1.id) }
-      let!(:ssr2)       { create(:sub_service_request, service_request_id: service_request.id, organization_id: org2.id) }
-      let!(:service)    { create(:service, organization_id: org1.id) }
-      let!(:service2)   { create(:service, organization_id: org2.id) }
-      let!(:line_item1) { create(:line_item, sub_service_request_id: ssr1.id, service_request_id: service_request.id, service_id: service.id) }
-      let!(:line_item2) { create(:line_item, sub_service_request_id: ssr2.id, service_request_id: service_request.id, service_id: service2.id) }
-
       context "can be edited" do
 
         it "should return true if the status is draft" do
@@ -228,7 +219,7 @@ RSpec.describe SubServiceRequest, type: :model do
         end
 
         it "should return false if status is anything other than above states" do
-          sub_service_request.update_attributes(status: "on_hold")
+          sub_service_request.update_attributes(status: "incomplete")
           expect(sub_service_request.can_be_edited?).to eq(false)
         end
 

--- a/spec/models/sub_service_request/sub_service_request_spec.rb
+++ b/spec/models/sub_service_request/sub_service_request_spec.rb
@@ -214,6 +214,8 @@ RSpec.describe SubServiceRequest, type: :model do
         end
 
         it "should return true if the status is get a cost estimate" do
+          sub_service_request.organization.update_attributes(process_ssrs: true)
+          sub_service_request.organization.available_statuses.where(status: "get_a_cost_estimate").first.update_attributes(selected: true)
           sub_service_request.update_attributes(status: 'get_a_cost_estimate')
           expect(sub_service_request.can_be_edited?).to eq(true)
         end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -196,8 +196,10 @@ def build_service_request
 
   before :each do
     program.tag_list.add("ctrc")
-    program.available_statuses.where(status: ['draft', 'submitted', 'get_a_cost_estimate', 'administrative_review']).update_all(selected: true)
-    program.editable_statuses.where(status: ['draft', 'submitted', 'get_a_cost_estimate', 'administrative_review']).update_all(selected: true)
+    program.available_statuses.where(status: 'administrative_review').first.update_attributes(selected: true)
+
+    # program.available_statuses.where(status: ['draft', 'submitted', 'get_a_cost_estimate', 'administrative_review']).update_all(selected: true)
+    # program.editable_statuses.where(status: ['draft', 'submitted', 'get_a_cost_estimate', 'administrative_review']).update_all(selected: true)
 
     [program, core_13, core_15, core_16, core_17, core_62].each do |organization|
       organization.tag_list.add("clinical work fulfillment")

--- a/spec/support/permissible_values.rb
+++ b/spec/support/permissible_values.rb
@@ -45,22 +45,22 @@ def build_impact_areas
 end
 
 def build_statuses
-  FactoryBot.create(:permissible_value, category: 'status', key: 'ctrc_approved', value: 'Active')
-  FactoryBot.create(:permissible_value, category: 'status', key: 'administrative_review', value: 'Administrative Review')
-  FactoryBot.create(:permissible_value, category: 'status', key: 'approved', value: 'Approved')
+  FactoryBot.create(:permissible_value, category: 'status', key: 'ctrc_approved', value: 'Active', default: false)
+  FactoryBot.create(:permissible_value, category: 'status', key: 'administrative_review', value: 'Administrative Review', default: false)
+  FactoryBot.create(:permissible_value, category: 'status', key: 'approved', value: 'Approved', default: false)
   FactoryBot.create(:permissible_value, category: 'status', key: 'awaiting_pi_approval', value: 'Awaiting Requester Response', default: true)
   FactoryBot.create(:permissible_value, category: 'status', key: 'complete', value: 'Complete', default: true)
-  FactoryBot.create(:permissible_value, category: 'status', key: 'declined', value: 'Declined')
+  FactoryBot.create(:permissible_value, category: 'status', key: 'declined', value: 'Declined', default: false)
   FactoryBot.create(:permissible_value, category: 'status', key: 'draft', value: 'Draft', default: true)
-  FactoryBot.create(:permissible_value, category: 'status', key: 'get_a_cost_estimate', value: 'Get a Cost Estimate')
-  FactoryBot.create(:permissible_value, category: 'status', key: 'invoiced', value: 'Invoiced')
-  FactoryBot.create(:permissible_value, category: 'status', key: 'ctrc_review', value: 'In Admin review')
-  FactoryBot.create(:permissible_value, category: 'status', key: 'committee_review', value: 'In Committee Review')
-  FactoryBot.create(:permissible_value, category: 'status', key: 'fulfillment_queue', value: 'In Fulfillment Queue')
+  FactoryBot.create(:permissible_value, category: 'status', key: 'get_a_cost_estimate', value: 'Get a Cost Estimate', default: false)
+  FactoryBot.create(:permissible_value, category: 'status', key: 'invoiced', value: 'Invoiced', default: false)
+  FactoryBot.create(:permissible_value, category: 'status', key: 'ctrc_review', value: 'In Admin review', default: false)
+  FactoryBot.create(:permissible_value, category: 'status', key: 'committee_review', value: 'In Committee Review', default: false)
+  FactoryBot.create(:permissible_value, category: 'status', key: 'fulfillment_queue', value: 'In Fulfillment Queue', default: false)
   FactoryBot.create(:permissible_value, category: 'status', key: 'in_process', value: 'In Process', default: true)
   FactoryBot.create(:permissible_value, category: 'status', key: 'on_hold', value: 'On Hold', default: true)
   FactoryBot.create(:permissible_value, category: 'status', key: 'submitted', value: 'Submitted', default: true)
-  FactoryBot.create(:permissible_value, category: 'status', key: 'withdrawn', value: 'Withdrawn')
+  FactoryBot.create(:permissible_value, category: 'status', key: 'withdrawn', value: 'Withdrawn', default: false)
 end
 
 def build_user_roles


### PR DESCRIPTION
Statuses that come from "default" permissible values, should be "selected" when created. This was causing a bug where required statuses weren't selected on new orgs.

[#159835212]

https://www.pivotaltracker.com/story/show/159835212