### PR TITLE
KG - Response Filter Incomplete Forms

### DIFF
--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -192,9 +192,7 @@ class Surveyor::ResponsesController < Surveyor::BaseController
         ssr.forms_to_complete.select do |f|
           # Apply the State, Survey/Form, and Start/End Date filters manually
           (@filterrific.with_state.try(&:empty?) || (@filterrific.with_state.try(&:any?) && @filterrific.with_state.include?(f.active))) &&
-          (@filterrific.with_survey.try(&:empty?) || (@filterrific.with_survey.try(&:any?) && @filterrific.with_survey.include?(f.id))) &&
-          (@filterrific.start_date.nil? || (@filterrific.start_date && f.updated_at >= @filterrific.start_date)) &&
-          (@filterrific.end_date.nil? || (@filterrific.end_date && f.updated_at <= @filterrific.end_date))
+          (@filterrific.with_survey.try(&:empty?) || (@filterrific.with_survey.try(&:any?) && @filterrific.with_survey.include?(f.id)))
         end.each do |f|
           responses << Response.new(survey: f,respondable: ssr)
         end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156401749

Filters were being applied, but now incomplete forms were not showing. This is because 1. you can't filter the response dates because the responses don't exist, and 2. I was filtering by the survey dates, not the response dates.