### PR TITLE
KG - Incomplete Form Response State Filtering

### DIFF
--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -191,7 +191,7 @@ class Surveyor::ResponsesController < Surveyor::BaseController
       p.sub_service_requests.each do |ssr|
         ssr.forms_to_complete.select do |f|
           # Apply the State, Survey/Form, and Start/End Date filters manually
-          (@filterrific.with_state.try(&:empty?) || (@filterrific.with_state.try(&:any?) && @filterrific.with_state.include?(f.active))) &&
+          (@filterrific.with_state.try(&:empty?) || (@filterrific.with_state.try(&:any?) && @filterrific.with_state.include?(f.active ? 1 : 0))) &&
           (@filterrific.with_survey.try(&:empty?) || (@filterrific.with_survey.try(&:any?) && @filterrific.with_survey.include?(f.id)))
         end.each do |f|
           responses << Response.new(survey: f,respondable: ssr)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156401749

The State filter was not working as intended with incomplete forms. This is because filterrific passes this field as an integer - 1 or 0 - not a boolean. Converting `f.active` to a 1 or 0 fixes the issue.