### PR TITLE
KG - Export Consolidated Request Money Formatting Bug

### DIFF
--- a/app/views/dashboard/protocols/show.xlsx.axlsx
+++ b/app/views/dashboard/protocols/show.xlsx.axlsx
@@ -25,8 +25,8 @@ centered = wb.styles.add_style alignment: {horizontal: :center}
 # centered = wb.styles.add_style alignment: { horizontal: :center }
 # bordered = wb.styles.add_style :border=> {:style => :thin, :color => "00000000"}
 # centered_bordered = wb.styles.add_style :border => {:style => :thin, :color => "00000000"}, :alignment => {:horizontal => :center}
-money = wb.styles.add_style :format_code => '$* #,##0.00_);[Red]-$*#,###.00;$* -??_;'
-bold_money = wb.styles.add_style :format_code => '$#,##0.00_);[Red]-$#,###.00;$* -??_;', b: true
+money = wb.styles.add_style :format_code => '$* #,##0.00_);[Red]$* - #,###.00;$* - ??_;'
+bold_money = wb.styles.add_style :format_code => '$* #,##0.00_);[Red]$* - #,###.00;$* - ??_;', b: true
 percent = wb.styles.add_style :num_fmt => 9, b: true, alignment: { horizontal: :left }
 hide_zeros = wb.styles.add_style format_code: '#;[Red]-#; ;', alignment: { horizontal: :center }
 row_header_style = wb.styles.add_style b: true


### PR DESCRIPTION
Notice the adding `#`s in the screenshot below

![image](https://user-images.githubusercontent.com/12898988/44424227-16010d80-a54e-11e8-95e0-365d537909dc.png)

There was a space missing in the negative portion of the formatter which caused excel to pad the cell with `#`s rather than spaces. Similarly, the bold money was not up-to-date with the money formatter, so I updated that.