### PR TITLE
KG - Prompt Survey/Form Access Code

### DIFF
--- a/app/controllers/surveyor/surveys_controller.rb
+++ b/app/controllers/surveyor/surveys_controller.rb
@@ -40,26 +40,26 @@ class Surveyor::SurveysController < Surveyor::BaseController
     end
   end
 
+  def new
+    @survey = Survey.new(type: params[:type])
+  end
+
+  def create
+    @survey = build_survey
+
+    if @survey.save
+      redirect_to edit_surveyor_survey_path(@survey, type: params[:type]), format: :js
+    else
+      @errors = @survey.errors
+    end
+  end
+
   def edit
     @survey = Survey.eager_load(sections: { questions: :options }).find(params[:id])
 
     respond_to do |format|
       format.js
     end
-  end
-
-  def create
-    klass = params[:type].constantize.yaml_klass
-    @survey = Survey.new(
-                type: params[:type],
-                title: "New #{klass}",
-                access_code: "new-#{klass.downcase}",
-                version: 1,
-                active: false,
-                surveyable: klass == 'Form' ? current_user : nil
-              )
-    @survey.save(validate: false)
-    redirect_to edit_surveyor_survey_path(@survey, type: params[:type]), format: :js
   end
 
   def destroy
@@ -121,5 +121,36 @@ class Surveyor::SurveysController < Surveyor::BaseController
     }
 
     render json: results.to_json
+  end
+
+  private
+
+  def build_survey
+    klass = params[:type].constantize
+
+    if existing = klass.where(survey_params).last
+      @survey = klass.new(
+        title: existing.title,
+        description: existing.description,
+        access_code: survey_params[:access_code],
+        version: existing.version + 1,
+        active: false,
+        surveyable: klass == Form ? current_user : nil
+      )
+    else
+      @survey = klass.new(
+        title: "New #{klass.yaml_klass}",
+        access_code: survey_params[:access_code],
+        version: 1,
+        active: false,
+        surveyable: klass == Form ? current_user : nil
+      )
+    end
+  end
+
+  def survey_params
+    params.require(params[:type].underscore).permit(
+      :access_code
+    )
   end
 end

--- a/app/views/surveyor/surveys/_new_form.haml
+++ b/app/views/surveyor/surveys/_new_form.haml
@@ -1,0 +1,19 @@
+.modal-dialog
+  .modal-content
+    = form_for survey, url: surveyor_surveys_path(survey, type: survey.type), method: :post, remote: true, html: { class: 'form-horizontal' } do |f|
+      .modal-header
+        %button.close{type: 'button', data: {dismiss: 'modal'}}
+          %span{aria: {hidden:'true'}} &times;
+          %span.sr-only &times;
+        %h4.modal-title.text-center
+          = I18n.t('surveyor.surveys.new_form.header', klass: survey.class.yaml_klass)
+      .modal-body
+        #modal_errors
+        .form-group
+          = f.label :access_code, t(:surveyor)[:surveys][:form][:survey_information][:access_code], class: 'control-label required col-sm-3'
+          .col-sm-9
+            = f.text_field :access_code, class: 'form-control'
+      .modal-footer
+        %button.btn.btn-default{ data: { dismiss: 'modal' } }
+          = t(:actions)[:close]
+        = f.submit t(:actions)[:create], class: 'btn btn-primary'

--- a/app/views/surveyor/surveys/create.js.coffee
+++ b/app/views/surveyor/surveys/create.js.coffee
@@ -1,0 +1,21 @@
+# Copyright © 2011-2018 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+$("#modal_errors").html("<%= j render 'shared/modal_errors', errors: @errors %>")

--- a/app/views/surveyor/surveys/index.html.haml
+++ b/app/views/surveyor/surveys/index.html.haml
@@ -25,7 +25,7 @@
     .panel-body
       .bootstrap-table-dropdown-overflow
         #surveys-custom-toolbar
-          = link_to t(:surveyor)[:systemsurveys][:new], surveyor_surveys_path(type: 'SystemSurvey'), method: :post, remote: true, class: "btn btn-success", id: "new-survey-button"
+          = link_to t(:surveyor)[:systemsurveys][:new], new_surveyor_survey_path(type: 'SystemSurvey'), remote: true, class: "btn btn-success", id: "new-survey-button"
         %table.survey-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: surveyor_surveys_path(type: 'SystemSurvey'), striped: 'true', toolbar: '#surveys-custom-toolbar', pagination: 'true', page_size: '20' } }
           %thead.primary-header
             %tr
@@ -48,7 +48,7 @@
     .panel-body
       .bootstrap-table-dropdown-overflow
         #forms-custom-toolbar
-          = link_to t(:surveyor)[:forms][:new], surveyor_surveys_path(type: 'Form'), method: :post, remote: true, class: "btn btn-success", id: "new-form-button"
+          = link_to t(:surveyor)[:forms][:new], new_surveyor_survey_path(type: 'Form'), remote: true, class: "btn btn-success", id: "new-form-button"
         %table.form-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', url: surveyor_surveys_path(type: 'Form'), striped: 'true', toolbar: '#forms-custom-toolbar', pagination: 'true', page_size: '20' } }
           %thead.primary-header
             %tr

--- a/app/views/surveyor/surveys/new.js.coffee
+++ b/app/views/surveyor/surveys/new.js.coffee
@@ -1,0 +1,22 @@
+# Copyright © 2011-2018 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+$('#modal_place').html("<%= j render 'surveyor/surveys/new_form', survey: @survey %>")
+$('#modal_place').modal('show')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
     cancel: "Cancel"
     close: "Close"
     continue: "Continue"
+    create: "Create"
     delete: "Delete"
     edit: "Edit"
     filter: "Filter"

--- a/config/locales/surveyor.en.yml
+++ b/config/locales/surveyor.en.yml
@@ -98,6 +98,8 @@ en:
 
 
     surveys:
+      new_form:
+        header: "New %{klass}"
       form:
         header: "Live Editing %{klass}"
         survey_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ SparcRails::Application.routes.draw do
   resources :services
 
   namespace :surveyor do
-    resources :surveys, only: [:index, :edit, :create, :destroy] do
+    resources :surveys, only: [:index, :new, :create, :edit, :destroy] do
       get :preview
       get :update_dependents_list
     end

--- a/spec/controllers/surveyor/surveys/post_create_spec.rb
+++ b/spec/controllers/surveyor/surveys/post_create_spec.rb
@@ -40,49 +40,31 @@ RSpec.describe Surveyor::SurveysController, type: :controller do
     end
 
     context "params[:type] == 'SystemSurvey'" do
-      it 'should assign @survey to a new SystemSurvey' do
+      it 'should assign create a new SystemSurvey' do
         expect{
-          post :create, xhr: true, params: { type: 'SystemSurvey' }
+          post :create, xhr: true, params: { type: 'SystemSurvey', system_survey: { access_code: 'test' } }
         }.to change{ SystemSurvey.count }.by(1)
-        expect(assigns(:survey)).to be_a(SystemSurvey)
       end
 
       it 'should redirect to edit' do
-        post :create, xhr: true, params: { type: 'SystemSurvey' }
+        post :create, xhr: true, params: { type: 'SystemSurvey', system_survey: { access_code: 'test' } }
 
-        expect(controller).to redirect_to(edit_surveyor_survey_path(assigns(:survey), type: 'SystemSurvey'))
-      end
-
-      it 'should respond ok' do
-        post :create, xhr: true, params: { type: 'SystemSurvey' }
-
-        expect(controller).to respond_with(302)
+        expect(controller).to redirect_to(edit_surveyor_survey_path(Survey.first, type: 'SystemSurvey'))
       end
     end
 
     context "params[:type] == 'Form'" do
-      it 'should assign @survey to a new SystemSurvey' do
+      it 'should assign create a new Form' do
         expect{
-          post :create, xhr: true, params: { type: 'Form' }
+          post :create, xhr: true, params: { type: 'Form', form: { access_code: 'test'  } }
         }.to change{ Form.count }.by(1)
-        expect(assigns(:survey)).to be_a(Form)
-      end
-
-      it 'should associate the new Form to the current user' do
-        post :create, xhr: true, params: { type: 'Form' }
-        expect(assigns(:survey).surveyable).to eq(logged_in_user)
+        expect(Survey.first.surveyable).to eq(logged_in_user)
       end
 
       it 'should redirect to edit' do
-        post :create, xhr: true, params: { type: 'Form' }
+        post :create, xhr: true, params: { type: 'Form', form: { access_code: 'test' } }
 
         expect(controller).to redirect_to(edit_surveyor_survey_path(assigns(:survey), type: 'Form'))
-      end
-
-      it 'should respond ok' do
-        post :create, xhr: true, params: { type: 'Form' }
-
-        expect(controller).to respond_with(302)
       end
     end
   end

--- a/spec/features/surveyor/surveys/user_creates_survey_spec.rb
+++ b/spec/features/surveyor/surveys/user_creates_survey_spec.rb
@@ -30,12 +30,16 @@ RSpec.describe 'User creates a survey', js: true do
     before :each do
       visit surveyor_surveys_path
       wait_for_javascript_to_finish
-    end
 
-    scenario 'and sees the newly created survey' do
       click_link 'New Survey'
       wait_for_javascript_to_finish
 
+      fill_in 'system_survey_access_code', with: 'test-survey'
+      click_button 'Create'
+      wait_for_javascript_to_finish
+    end
+
+    scenario 'and sees the newly created survey' do
       expect(page).to have_selector('#survey-modal', visible: true)
       expect(SystemSurvey.count).to eq(1)
     end
@@ -45,12 +49,16 @@ RSpec.describe 'User creates a survey', js: true do
     before :each do
       visit surveyor_surveys_path
       wait_for_javascript_to_finish
-    end
 
-    scenario 'and sees the newly created form' do
       click_link 'New Form'
       wait_for_javascript_to_finish
 
+      fill_in 'form_access_code', with: 'test-survey'
+      click_button 'Create'
+      wait_for_javascript_to_finish
+    end
+
+    scenario 'and sees the newly created form' do
       expect(page).to have_selector('#form-modal', visible: true)
       expect(Form.count).to eq(1)
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155990205

Users should be prompted to enter an access code before creating a Survey or Form.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/12898988/44591940-a759c500-a784-11e8-957f-c613b3178299.png">

If a user enters the access code of an existing survey/form, the latest version of that survey/form will be used to populate the title, description, and version of the new survey/form.
