### PR TITLE
KG - Prompt Survey/Form Access Code

### DIFF
--- a/spec/controllers/surveyor/surveys/post_create_spec.rb
+++ b/spec/controllers/surveyor/surveys/post_create_spec.rb
@@ -40,49 +40,31 @@ RSpec.describe Surveyor::SurveysController, type: :controller do
     end
 
     context "params[:type] == 'SystemSurvey'" do
-      it 'should assign @survey to a new SystemSurvey' do
+      it 'should assign create a new SystemSurvey' do
         expect{
-          post :create, xhr: true, params: { type: 'SystemSurvey' }
+          post :create, xhr: true, params: { type: 'SystemSurvey', system_survey: { access_code: 'test' } }
         }.to change{ SystemSurvey.count }.by(1)
-        expect(assigns(:survey)).to be_a(SystemSurvey)
       end
 
       it 'should redirect to edit' do
-        post :create, xhr: true, params: { type: 'SystemSurvey' }
+        post :create, xhr: true, params: { type: 'SystemSurvey', system_survey: { access_code: 'test' } }
 
-        expect(controller).to redirect_to(edit_surveyor_survey_path(assigns(:survey), type: 'SystemSurvey'))
-      end
-
-      it 'should respond ok' do
-        post :create, xhr: true, params: { type: 'SystemSurvey' }
-
-        expect(controller).to respond_with(302)
+        expect(controller).to redirect_to(edit_surveyor_survey_path(Survey.first, type: 'SystemSurvey'))
       end
     end
 
     context "params[:type] == 'Form'" do
-      it 'should assign @survey to a new SystemSurvey' do
+      it 'should assign create a new Form' do
         expect{
-          post :create, xhr: true, params: { type: 'Form' }
+          post :create, xhr: true, params: { type: 'Form', form: { access_code: 'test'  } }
         }.to change{ Form.count }.by(1)
-        expect(assigns(:survey)).to be_a(Form)
-      end
-
-      it 'should associate the new Form to the current user' do
-        post :create, xhr: true, params: { type: 'Form' }
-        expect(assigns(:survey).surveyable).to eq(logged_in_user)
+        expect(Survey.first.surveyable).to eq(logged_in_user)
       end
 
       it 'should redirect to edit' do
-        post :create, xhr: true, params: { type: 'Form' }
+        post :create, xhr: true, params: { type: 'Form', form: { access_code: 'test' } }
 
         expect(controller).to redirect_to(edit_surveyor_survey_path(assigns(:survey), type: 'Form'))
-      end
-
-      it 'should respond ok' do
-        post :create, xhr: true, params: { type: 'Form' }
-
-        expect(controller).to respond_with(302)
       end
     end
   end

--- a/spec/features/surveyor/surveys/user_creates_survey_spec.rb
+++ b/spec/features/surveyor/surveys/user_creates_survey_spec.rb
@@ -30,12 +30,16 @@ RSpec.describe 'User creates a survey', js: true do
     before :each do
       visit surveyor_surveys_path
       wait_for_javascript_to_finish
-    end
 
-    scenario 'and sees the newly created survey' do
       click_link 'New Survey'
       wait_for_javascript_to_finish
 
+      fill_in 'system_survey_access_code', with: 'test-survey'
+      click_button 'Create'
+      wait_for_javascript_to_finish
+    end
+
+    scenario 'and sees the newly created survey' do
       expect(page).to have_selector('#survey-modal', visible: true)
       expect(SystemSurvey.count).to eq(1)
     end
@@ -45,12 +49,16 @@ RSpec.describe 'User creates a survey', js: true do
     before :each do
       visit surveyor_surveys_path
       wait_for_javascript_to_finish
-    end
 
-    scenario 'and sees the newly created form' do
       click_link 'New Form'
       wait_for_javascript_to_finish
 
+      fill_in 'form_access_code', with: 'test-survey'
+      click_button 'Create'
+      wait_for_javascript_to_finish
+    end
+
+    scenario 'and sees the newly created form' do
       expect(page).to have_selector('#form-modal', visible: true)
       expect(Form.count).to eq(1)
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155990205

Users should be prompted to enter an access code before creating a Survey or Form.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/12898988/44591940-a759c500-a784-11e8-957f-c613b3178299.png">

If a user enters the access code of an existing survey/form, the latest version of that survey/form will be used to populate the title, description, and version of the new survey/form.
