### PR TITLE
KG - Random Survey Spec Failures

### DIFF
--- a/spec/factories/form.rb
+++ b/spec/factories/form.rb
@@ -21,7 +21,7 @@
 FactoryBot.define do
   factory :form do
     title                     { Faker::Lorem.word }
-    access_code               { Faker::Lorem.word }
+    sequence(:access_code)    { |n| "survey-#{n}" }
     sequence(:version)        { |n| n }
     active                    { false }
     type                      { 'Form' }

--- a/spec/factories/system_survey.rb
+++ b/spec/factories/system_survey.rb
@@ -21,7 +21,7 @@
 FactoryBot.define do
   factory :system_survey do
     title                     { Faker::Lorem.word }
-    access_code               { Faker::Lorem.word }
+    sequence(:access_code)    { |n| "survey-#{n}" }
     sequence(:version)        { |n| n }
     active                    { false }
     type                      { 'SystemSurvey' }

--- a/spec/features/surveyor/surveys/user_takes_survey_spec.rb
+++ b/spec/features/surveyor/surveys/user_takes_survey_spec.rb
@@ -298,15 +298,17 @@ RSpec.describe 'User takes a survey', js: true do
     scenario 'and sees correctly saved value' do
       @q_date = create(:question, section: @section, question_type: 'date', content: 'Date Question')
 
-      visit new_surveyor_response_path(type: @survey.class.name, survey_id: @survey.id, respondable_id: @ssr.id, respondable_type: @ssr.class.name)
-      wait_for_javascript_to_finish
+      Timecop.freeze do
+        visit new_surveyor_response_path(type: @survey.class.name, survey_id: @survey.id, respondable_id: @ssr.id, respondable_type: @ssr.class.name)
+        wait_for_javascript_to_finish
 
-      first('input').click
+        first('input').click
 
-      click_button 'Submit'
-      wait_for_javascript_to_finish
+        click_button 'Submit'
+        wait_for_javascript_to_finish
 
-      expect(QuestionResponse.find_by(question_id: @q_date.id).content).to eq(Date.today.strftime("%m/%d/%Y"))
+        expect(QuestionResponse.find_by(question_id: @q_date.id).content).to eq(Date.today.strftime("%m/%d/%Y"))
+      end
     end
   end
 
@@ -441,9 +443,8 @@ RSpec.describe 'User takes a survey', js: true do
 
     scenario 'and sees correctly saved value' do
       @q_time = create(:question, section: @section, question_type: 'time', content: 'Time Question')
-      time = Time.now
-      
-      Timecop.freeze(time) do
+
+      Timecop.freeze do
         visit new_surveyor_response_path(type: @survey.class.name, survey_id: @survey.id, respondable_id: @ssr.id, respondable_type: @ssr.class.name)
         wait_for_javascript_to_finish
 
@@ -452,7 +453,7 @@ RSpec.describe 'User takes a survey', js: true do
         click_button 'Submit'
         wait_for_javascript_to_finish
         
-        expect(Time.parse(QuestionResponse.find_by(question_id: @q_time.id).content).strftime("%I:%M %p")).to eq(time.strftime("%I:%M %p"))
+        expect(Time.parse(QuestionResponse.find_by(question_id: @q_time.id).content).strftime("%I:%M %p")).to eq(Time.now.strftime("%I:%M %p"))
       end
     end
   end


### PR DESCRIPTION
We prevoously made the `factories/survey.rb` factory use a sequential access_code, but it turns out that we needed to instead use sequencing on the SystemSurvey and Form models.

There are also 2 specs that needed to properly utilize Timecop for time and date questions. The Time question spec already had Timecop, however the time was being taken outside of the freeze.