### PR TITLE
KG - Resend Surveys Button Missing

### DIFF
--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -452,7 +452,7 @@ class SubServiceRequest < ApplicationRecord
     self.line_items.
       eager_load(service: [:associated_surveys, :organization]).
       map{ |li| li.service.available_surveys }.flatten.compact.uniq.
-      all?{ |s| s.responses.where(respondable_id: self.id, respondable_type: self.class.name).any? }
+      all?{ |s| s.responses.where(respondable: self).joins(:question_responses).any? }
   end
 
   ###############################


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159905501

Because survey responses are generated ahead-of-time by the SSR completion emails, we don't want to check if responses exist, but rather if those responses have been actually answered.