### PR TITLE
KG - Hide Incomplete Response Date

### DIFF
--- a/app/views/surveyor/responses/index.json.jbuilder
+++ b/app/views/surveyor/responses/index.json.jbuilder
@@ -7,6 +7,6 @@ json.(@responses) do |response|
   json.title            response.survey.full_title
   json.by               response.identity.try(:full_name) || 'N/A'
   json.complete         complete_display(response)
-  json.completion_date  format_date(response.created_at)
+  json.completion_date  response.completed? ? format_date(response.created_at) : ""
   json.actions          response_options(response)
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159905501

Hide the date in the responses table for responses that aren't yet completed to avoid confusion.