### PR TITLE
KG - Update Table Charsets and Collation

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -25,6 +25,7 @@ class Protocol < ApplicationRecord
   include SanitizedData
   sanitize_setter :short_title, :special_characters, :squish
   sanitize_setter :title, :special_characters, :squish
+  sanitize_setter :brief_description, :special_characters, :squish
 
   audited
 

--- a/db/migrate/20180905143632_convert_tables_to_utf8.rb
+++ b/db/migrate/20180905143632_convert_tables_to_utf8.rb
@@ -1,0 +1,26 @@
+class ConvertTablesToUtf8 < ActiveRecord::Migration[5.2]
+  def up
+    # SOURCE: https://gist.github.com/tjh/1711329#gistcomment-1699805
+
+    db = ActiveRecord::Base.connection
+
+    execute "ALTER DATABASE `#{db.current_database}` CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+    db.tables.each do |table|
+      execute "ALTER TABLE `#{table}` CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+
+      db.columns(table).each do |column|
+        case column.sql_type
+          when /([a-z]*)text/i
+            default = (column.default.nil?) ? '' : "DEFAULT '#{column.default}'"
+            null = (column.null) ? '' : 'NOT NULL'
+            execute "ALTER TABLE `#{table}` MODIFY `#{column.name}` #{column.sql_type.upcase} CHARACTER SET utf8 COLLATE utf8_unicode_ci #{default} #{null};"
+          when /varchar\(([0-9]+)\)/i
+            sql_type = column.sql_type.upcase
+            default = (column.default.nil?) ? '' : "DEFAULT '#{column.default}'"
+            null = (column.null) ? '' : 'NOT NULL'
+            execute "ALTER TABLE `#{table}` MODIFY `#{column.name}` #{sql_type} CHARACTER SET utf8 COLLATE utf8_unicode_ci #{default} #{null};"
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_17_181258) do
+ActiveRecord::Schema.define(version: 2018_09_05_143632) do
 
-  create_table "admin_rates", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
-    t.integer "line_item_id"
+  create_table "admin_rates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "line_item_id"
     t.integer "admin_cost"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "affiliations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "protocol_id"
+  create_table "affiliations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "protocol_id"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -28,56 +28,56 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["protocol_id"], name: "index_affiliations_on_protocol_id"
   end
 
-  create_table "alerts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "alerts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "alert_type"
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "approvals", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "service_request_id"
-    t.integer "identity_id"
+  create_table "approvals", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "service_request_id"
+    t.bigint "identity_id"
     t.datetime "approval_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.string "approval_type", default: "Resource Approval"
-    t.integer "sub_service_request_id"
+    t.bigint "sub_service_request_id"
     t.index ["identity_id"], name: "index_approvals_on_identity_id"
     t.index ["service_request_id"], name: "index_approvals_on_service_request_id"
     t.index ["sub_service_request_id"], name: "index_approvals_on_sub_service_request_id"
   end
 
-  create_table "arms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "arms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.integer "visit_count", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "subject_count", default: 1
-    t.integer "protocol_id"
+    t.bigint "protocol_id"
     t.boolean "new_with_draft", default: false
     t.integer "minimum_visit_count", default: 0
     t.integer "minimum_subject_count", default: 0
     t.index ["protocol_id"], name: "index_arms_on_protocol_id"
   end
 
-  create_table "associated_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.integer "associable_id"
+  create_table "associated_surveys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "associable_id"
     t.string "associable_type"
-    t.integer "survey_id"
+    t.bigint "survey_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["associable_id"], name: "index_associated_surveys_on_associable_id"
     t.index ["survey_id"], name: "index_associated_surveys_on_survey_id"
   end
 
-  create_table "audits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.integer "auditable_id"
+  create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "auditable_id"
     t.string "auditable_type"
-    t.integer "associated_id"
+    t.bigint "associated_id"
     t.string "associated_type"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "user_type"
     t.string "username"
     t.string "action"
@@ -94,8 +94,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table "available_statuses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.integer "organization_id"
+  create_table "available_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "organization_id"
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -103,9 +103,9 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["organization_id"], name: "index_available_statuses_on_organization_id"
   end
 
-  create_table "catalog_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "identity_id"
-    t.integer "organization_id"
+  create_table "catalog_managers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "identity_id"
+    t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
@@ -114,9 +114,9 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["organization_id"], name: "index_catalog_managers_on_organization_id"
   end
 
-  create_table "charges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "service_request_id"
-    t.integer "service_id"
+  create_table "charges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "service_request_id"
+    t.bigint "service_id"
     t.decimal "charge_amount", precision: 12, scale: 4
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -125,24 +125,24 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["service_request_id"], name: "index_charges_on_service_request_id"
   end
 
-  create_table "clinical_providers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.integer "identity_id"
-    t.integer "organization_id"
+  create_table "clinical_providers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "identity_id"
+    t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["identity_id"], name: "index_clinical_providers_on_identity_id"
     t.index ["organization_id"], name: "index_clinical_providers_on_organization_id"
   end
 
-  create_table "cover_letters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "cover_letters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "content"
-    t.integer "sub_service_request_id"
+    t.bigint "sub_service_request_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["sub_service_request_id"], name: "index_cover_letters_on_sub_service_request_id"
   end
 
-  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", limit: 4294967295, null: false
@@ -157,7 +157,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "documents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "documents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "deleted_at"
     t.string "doc_type"
     t.datetime "created_at", null: false
@@ -167,63 +167,54 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "document_file_size"
     t.datetime "document_updated_at"
     t.string "doc_type_other"
-    t.integer "protocol_id"
+    t.bigint "protocol_id"
     t.index ["protocol_id"], name: "index_documents_on_protocol_id"
   end
 
-  create_table "documents_sub_service_requests", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
-    t.integer "document_id"
-    t.integer "sub_service_request_id"
+  create_table "documents_sub_service_requests", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "document_id"
+    t.bigint "sub_service_request_id"
   end
 
-  create_table "editable_statuses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
-    t.integer "organization_id"
-    t.string "status", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "selected", default: false
-    t.index ["organization_id"], name: "index_editable_statuses_on_organization_id"
-  end
-
-  create_table "epic_queue_records", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "epic_queue_records", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "protocol_id"
     t.string "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "origin"
     t.integer "identity_id"
   end
 
-  create_table "epic_queues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "epic_queues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "protocol_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "identity_id"
     t.boolean "attempted_push", default: false
     t.boolean "user_change", default: false
   end
 
-  create_table "epic_rights", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "epic_rights", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "project_role_id"
     t.string "right"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "excluded_funding_sources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "subsidy_map_id"
     t.string "funding_source"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["subsidy_map_id"], name: "index_excluded_funding_sources_on_subsidy_map_id"
   end
 
-  create_table "feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "message"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "fulfillments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
@@ -231,8 +222,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "timeframe"
     t.string "time"
     t.datetime "date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "unit_type"
     t.string "quantity_type"
@@ -249,8 +240,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "submission_type"
     t.datetime "irb_approval_date"
     t.datetime "irb_expiration_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.boolean "approval_pending"
     t.string "nct_number"
@@ -266,8 +257,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "credentials"
     t.string "subspecialty"
     t.string "phone"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.boolean "catalog_overlord"
     t.string "credentials_other"
@@ -295,8 +286,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "impact_areas", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "protocol_id"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "other_text"
     t.index ["protocol_id"], name: "index_impact_areas_on_protocol_id"
@@ -307,8 +298,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "ind_number"
     t.boolean "ind_on_hold"
     t.string "inv_device_number"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "exemption_type", default: ""
     t.index ["protocol_id"], name: "index_investigational_products_info_on_protocol_id"
@@ -318,8 +309,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "protocol_id"
     t.string "patent_number"
     t.text "inventors"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["protocol_id"], name: "index_ip_patents_info_on_protocol_id"
   end
@@ -332,8 +323,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "quantity"
     t.datetime "complete_date"
     t.datetime "in_process_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.integer "units_per_quantity", default: 1
     t.index ["service_id"], name: "index_line_items_on_service_id"
@@ -341,12 +332,12 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["sub_service_request_id"], name: "index_line_items_on_sub_service_request_id"
   end
 
-  create_table "line_items_visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "line_items_visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "arm_id"
     t.integer "line_item_id"
     t.integer "subject_count"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["arm_id"], name: "index_line_items_visits_on_arm_id"
     t.index ["line_item_id"], name: "index_line_items_visits_on_line_item_id"
   end
@@ -362,8 +353,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "from"
     t.string "email"
     t.text "body"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["from"], name: "index_messages_on_from"
     t.index ["notification_id"], name: "index_messages_on_notification_id"
     t.index ["to"], name: "index_messages_on_to"
@@ -372,8 +363,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "identity_id"
     t.text "body"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "notable_id"
     t.string "notable_type"
     t.index ["identity_id"], name: "index_notes_on_identity_id"
@@ -384,8 +375,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "sub_service_request_id"
     t.integer "originator_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "subject"
     t.integer "other_user_id"
     t.boolean "read_by_originator"
@@ -394,7 +385,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["sub_service_request_id"], name: "index_notifications_on_sub_service_request_id"
   end
 
-  create_table "options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "question_id"
     t.text "content", null: false
     t.datetime "created_at", null: false
@@ -413,8 +404,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.text "ack_language"
     t.boolean "process_ssrs", default: false
     t.boolean "is_available", default: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.boolean "use_default_statuses", default: true
     t.index ["is_available"], name: "index_organizations_on_is_available"
@@ -425,15 +416,15 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "sub_service_request_id"
     t.string "status"
     t.datetime "date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.integer "changed_by_id"
     t.index ["changed_by_id"], name: "index_past_statuses_on_changed_by_id"
     t.index ["sub_service_request_id"], name: "index_past_statuses_on_sub_service_request_id"
   end
 
-  create_table "past_subsidies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "past_subsidies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "sub_service_request_id"
     t.integer "total_at_approval"
     t.integer "approved_by"
@@ -445,18 +436,18 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["sub_service_request_id"], name: "index_past_subsidies_on_sub_service_request_id"
   end
 
-  create_table "payment_uploads", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "payment_uploads", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "payment_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string "file_file_name"
     t.string "file_content_type"
-    t.integer "file_file_size"
+    t.bigint "file_file_size"
     t.datetime "file_updated_at"
     t.index ["payment_id"], name: "index_payment_uploads_on_payment_id"
   end
 
-  create_table "payments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "payments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "sub_service_request_id"
     t.date "date_submitted"
     t.decimal "amount_invoiced", precision: 12, scale: 4
@@ -464,13 +455,13 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.date "date_received"
     t.string "payment_method"
     t.text "details"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.float "percent_subsidy"
     t.index ["sub_service_request_id"], name: "index_payments_on_sub_service_request_id"
   end
 
-  create_table "permissible_values", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "permissible_values", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "value"
     t.string "concept_code"
@@ -495,8 +486,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.decimal "federal_rate", precision: 12, scale: 4
     t.decimal "corporate_rate", precision: 12, scale: 4
     t.date "effective_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.date "display_date"
     t.decimal "other_rate", precision: 12, scale: 4
@@ -528,7 +519,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["organization_id"], name: "index_pricing_setups_on_organization_id"
   end
 
-  create_table "professional_organizations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "professional_organizations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "name"
     t.string "org_type"
     t.integer "parent_id"
@@ -539,8 +530,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "identity_id"
     t.string "project_rights"
     t.string "role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "role_other"
     t.boolean "epic_access", default: false
@@ -548,7 +539,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["protocol_id"], name: "index_project_roles_on_protocol_id"
   end
 
-  create_table "protocol_filters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "protocol_filters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "identity_id"
     t.string "search_name"
     t.boolean "show_archived"
@@ -582,8 +573,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "federal_grant_code_id"
     t.string "federal_non_phs_sponsor"
     t.string "federal_phs_sponsor"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "potential_funding_source_other"
     t.string "funding_source_other"
@@ -610,14 +601,14 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["next_ssr_id"], name: "index_protocols_on_next_ssr_id"
   end
 
-  create_table "protocols_study_phases", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "protocols_study_phases", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "protocol_id", null: false
     t.integer "study_phase_id", null: false
     t.index ["protocol_id", "study_phase_id"], name: "index_protocols_study_phases_on_protocol_id_and_study_phase_id"
     t.index ["study_phase_id", "protocol_id"], name: "index_protocols_study_phases_on_study_phase_id_and_protocol_id"
   end
 
-  create_table "question_responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "question_responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "question_id"
     t.integer "response_id"
     t.text "content"
@@ -628,7 +619,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["response_id"], name: "index_question_responses_on_response_id"
   end
 
-  create_table "questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "section_id"
     t.boolean "is_dependent", null: false
     t.text "content", null: false
@@ -642,23 +633,23 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["section_id"], name: "index_questions_on_section_id"
   end
 
-  create_table "quick_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "quick_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "to"
     t.string "from"
     t.text "body"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "sub_service_request_id"
     t.string "xlsx_file_name"
     t.string "xlsx_content_type"
-    t.integer "xlsx_file_size"
+    t.bigint "xlsx_file_size"
     t.datetime "xlsx_updated_at"
     t.string "report_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "research_types_info", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
@@ -667,13 +658,13 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.boolean "vertebrate_animals"
     t.boolean "investigational_products"
     t.boolean "ip_patents"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["protocol_id"], name: "index_research_types_info_on_protocol_id"
   end
 
-  create_table "response_filters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "response_filters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "identity_id"
     t.string "name"
     t.string "of_type"
@@ -686,7 +677,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "responses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "survey_id"
     t.integer "identity_id"
     t.datetime "created_at", null: false
@@ -698,18 +689,18 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["survey_id"], name: "index_responses_on_survey_id"
   end
 
-  create_table "revenue_code_ranges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "revenue_code_ranges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "from"
     t.integer "to"
     t.float "percentage"
     t.integer "applied_org_id"
     t.string "vendor"
     t.integer "version"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "survey_id"
     t.string "title"
     t.text "description"
@@ -722,8 +713,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "identity_id"
     t.integer "organization_id"
     t.boolean "is_primary_contact"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean "hold_emails"
     t.datetime "deleted_at"
     t.index ["identity_id"], name: "index_service_providers_on_identity_id"
@@ -734,8 +725,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "service_id"
     t.integer "related_service_id"
     t.boolean "optional"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.boolean "linked_quantity", default: false
     t.integer "linked_quantity_total"
@@ -748,8 +739,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "status"
     t.boolean "approved"
     t.datetime "submitted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.date "original_submitted_date"
     t.index ["protocol_id"], name: "index_service_requests_on_protocol_id"
@@ -768,8 +759,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "revenue_code"
     t.integer "organization_id"
     t.string "order_code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.boolean "send_to_epic", default: false
     t.integer "revenue_code_range_id"
@@ -785,13 +776,13 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "settings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.text "value"
     t.string "data_type"
@@ -806,7 +797,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["key"], name: "index_settings_on_key", unique: true
   end
 
-  create_table "short_interactions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "short_interactions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "identity_id"
     t.string "name"
     t.string "email"
@@ -820,7 +811,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["identity_id"], name: "index_short_interactions_on_identity_id"
   end
 
-  create_table "study_phases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "study_phases", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "order"
     t.string "phase"
     t.integer "version", default: 1
@@ -828,35 +819,35 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "study_type_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "study_type_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "protocol_id"
     t.integer "study_type_question_id"
     t.boolean "answer"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "study_type_question_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "study_type_question_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "version"
     t.boolean "active", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_type_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "study_type_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "order"
     t.text "question"
     t.string "friendly_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "study_type_question_group_id"
   end
 
   create_table "study_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "protocol_id"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["protocol_id"], name: "index_study_types_on_protocol_id"
   end
@@ -867,8 +858,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "owner_id"
     t.string "ssr_id"
     t.string "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.datetime "consult_arranged_date"
     t.datetime "requester_contacted_date"
@@ -880,7 +871,7 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "routing"
     t.text "org_tree_display"
     t.integer "service_requester_id"
-    t.datetime "submitted_at"
+    t.timestamp "submitted_at"
     t.integer "protocol_id"
     t.index ["organization_id"], name: "index_sub_service_requests_on_organization_id"
     t.index ["owner_id"], name: "index_sub_service_requests_on_owner_id"
@@ -894,15 +885,15 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "submission_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "organization_id"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["organization_id"], name: "index_submission_emails_on_organization_id"
   end
 
   create_table "subsidies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.boolean "overridden"
     t.integer "sub_service_request_id"
@@ -918,8 +909,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "organization_id"
     t.decimal "max_dollar_cap", precision: 12, scale: 4, default: "0.0"
     t.decimal "max_percentage", precision: 5, scale: 2, default: "0.0"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.float "default_percentage", default: 0.0
     t.text "instructions"
@@ -929,14 +920,14 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "super_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "identity_id"
     t.integer "organization_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["identity_id"], name: "index_super_users_on_identity_id"
     t.index ["organization_id"], name: "index_super_users_on_organization_id"
   end
 
-  create_table "surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
     t.string "access_code", null: false
@@ -950,12 +941,12 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["surveyable_id", "surveyable_type"], name: "index_surveys_on_surveyable_id_and_surveyable_type"
   end
 
-  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "tag_id"
-    t.integer "taggable_id"
     t.string "taggable_type"
-    t.integer "tagger_id"
+    t.integer "taggable_id"
     t.string "tagger_type"
+    t.integer "tagger_id"
     t.string "context", limit: 128
     t.datetime "created_at"
     t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
@@ -963,8 +954,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.string "name", collation: "utf8_bin"
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.string "name"
     t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
@@ -975,8 +966,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "sending_class"
     t.integer "sending_class_id"
     t.string "message"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["sending_class_id"], name: "index_toast_messages_on_sending_class_id"
   end
 
@@ -984,8 +975,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.integer "service_request_id"
     t.integer "identity_id"
     t.string "token"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["identity_id"], name: "index_tokens_on_identity_id"
     t.index ["service_request_id"], name: "index_tokens_on_service_request_id"
@@ -1007,17 +998,17 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.string "name_of_iacuc"
     t.datetime "iacuc_approval_date"
     t.datetime "iacuc_expiration_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.index ["protocol_id"], name: "index_vertebrate_animals_info_on_protocol_id"
   end
 
-  create_table "visit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "visit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.integer "arm_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "position"
     t.integer "day"
     t.integer "window_before", default: 0
@@ -1028,8 +1019,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
   create_table "visits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "quantity", default: 0
     t.string "billing"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "deleted_at"
     t.integer "research_billing_qty", default: 0
     t.integer "insurance_billing_qty", default: 0
@@ -1041,7 +1032,6 @@ ActiveRecord::Schema.define(version: 2018_07_17_181258) do
     t.index ["visit_group_id"], name: "index_visits_on_visit_group_id"
   end
 
-  add_foreign_key "editable_statuses", "organizations"
   add_foreign_key "options", "questions"
   add_foreign_key "question_responses", "questions"
   add_foreign_key "question_responses", "responses"


### PR DESCRIPTION
### Original Story
https://www.pivotaltracker.com/story/show/158462095

```
An ActiveRecord::StatementInvalid occurred in protocols#update:

  Mysql2::Error: Incorrect string value: '\xEF\xAC\x81ndi...' for column 'audited_changes' at row 1: INSERT INTO `audits` (`auditable_id`, `auditable_type`, `user_id`, `user_type`, `action`, `audited_changes`, `version`, `remote_address`, `created_at`, `request_uuid`) VALUES (12220, 'Protocol', 55655, 'Identity', 'update', '---\nbrief_description:\n- \'The Alliance For Full Acceptance (AFFA) has partnered with The College of Charleston,\n  the Community Assistance Program, the Joseph P. Riley Center for Livable Communities\n  and the Medical University of South Carolina to conduct a Community Needs Assessment\n  (CNA) survey of the lesbian, gay, bisexual, transgender and queer (LGBTQ) community\n  in the Charleston SC tri-county (Charleston, Berkeley, and Dorchester) area. The\n  data will be used to inform programming initiatives for AFFA.  \'\n- \'The Alliance For Full Acceptance (AFFA) has partnered with The College of Charleston,\n  the Community Assistance Program, the Joseph P. Riley Center for Livable Communities\n  and the Medical University of South Carolina to conduct a Community Needs Assessment\n  (CNA) survey of the lesbian, gay, bisexual, transgender and queer (LGBTQ) community\n  in the Charleston SC tri-county (Charleston, Berkeley, and Dorchester) area. The\n  data will be used to inform programming initiatives for AFFA.   The ﬁndings from\n  the CNA will be utilized by AFFA in setting priorities for program initiatives and\n  advocacy for the LGBTQ community.  \'\n', 6, '128.23.228.203', '2018-06-18 20:07:55', 'e454d879-f74f-4a0f-bc63-87cf5b398f86')
  app/lib/remotely_notifiable.rb:68:in `notify_remote_around_update'
```

### Solution

While searching for the issue, I came across threads talking about converting the DB charsets to utf8. We already use `utf8` for the database (see database.yml), however I noticed that many tables - including the `audits` table that was giving the issue - were not using `utf8` character encoding. I added a migration to update all tables (and various text/varchar columns) to use `utf8` character encoding and `utf8_unicode_ci` collation to make them consistent. This, combined with adding a sanitizer for the `brief_description` field, allowed me to enter the user's description with no issues.

In addition, several bigint changes were automatically generated in the schema, so I decided to leave those in as well.