### PR TITLE
KG - Form Builder Access Code Modal "Enter" Closes Modal

### DIFF
--- a/app/views/surveyor/surveys/_new_form.haml
+++ b/app/views/surveyor/surveys/_new_form.haml
@@ -14,6 +14,6 @@
           .col-sm-9
             = f.text_field :access_code, class: 'form-control'
       .modal-footer
-        %button.btn.btn-default{ data: { dismiss: 'modal' } }
+        %button.btn.btn-default{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]
         = f.submit t(:actions)[:create], class: 'btn btn-primary'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160325909

This bug was caused by the way HTML5 handles form submission. It was trying to submit via the first button inside the form - i.e. the close button. Adding the `type: 'button` attribute resolves the issue.