### PR TITLE
KG - SPARCForms Table Optimization

### DIFF
--- a/app/helpers/surveyor/responses_helper.rb
+++ b/app/helpers/surveyor/responses_helper.rb
@@ -26,22 +26,19 @@ module Surveyor::ResponsesHelper
     content_tag(:h4, content_tag(:span, '', class: klass))
   end
 
-  def response_options(response, identity)
+  def response_options(response, identity, accessible_surveys, is_site_admin)
     view_permissions =
-      if response.survey.is_a?(SystemSurvey)
-        if response.survey.system_satisfaction?
-          identity.is_site_admin?
-        else
-          response.survey.authorized_for_super_user?(identity)
-        end
+      if response.survey.is_a?(SystemSurvey) && response.survey.system_satisfaction?
+        is_site_admin
       else
-        Form.for(identity).where(id: response.survey_id).any?
+        accessible_surveys.include?(response.survey)
       end
+
     edit_permissions =
       if response.survey.is_a?(SystemSurvey)
-        identity.is_site_admin?
+        is_site_admin
       else
-        Form.for(identity).where(id: response.survey_id).any?
+        accessible_surveys.include?(response.survey)
       end
 
     [ view_response_button(response, view_permissions),

--- a/app/models/system_survey.rb
+++ b/app/models/system_survey.rb
@@ -27,15 +27,11 @@ class SystemSurvey < Survey
     Survey.name
   end
 
+  def self.for_super_user(identity)
+    Survey.where(id: AssociatedSurvey.where(associable: Organization.authorized_for_super_user(identity.id)).pluck(:survey_id))
+  end
+
   def system_satisfaction?
     self.access_code == 'system-satisfaction-survey'
-  end
-
-  def authorized_for_super_user?(identity)
-    Organization.authorized_for_super_user(identity.id).joins(:associated_surveys).where(associated_surveys: { survey: self }).any?
-  end
-
-  def authorized_for_service_provider?(identity)
-    Organization.authorized_for_service_provider(identity.id).joins(:associated_surveys).where(associated_surveys: { survey: self }).any?
   end
 end

--- a/app/views/surveyor/responses/index.json.jbuilder
+++ b/app/views/surveyor/responses/index.json.jbuilder
@@ -1,3 +1,11 @@
+if @type == 'Form'
+  accessible_surveys = Form.for(current_user)
+  is_site_admin = false
+else
+  accessible_surveys = SystemSurvey.for_super_user(current_user)
+  is_site_admin = current_user.is_site_admin?
+end
+
 json.(@responses) do |response|
   srid = response.try(:respondable).try(:display_id) || response.try(:respondable).try(:protocol_id) || 'N/A'
 
@@ -8,5 +16,5 @@ json.(@responses) do |response|
   json.by               response.identity.try(:full_name) || 'N/A'
   json.complete         complete_display(response)
   json.completion_date  response.completed? ? format_date(response.created_at) : ""
-  json.actions          response_options(response, current_user)
+  json.actions response_options(response, current_user, accessible_surveys, is_site_admin)
 end

--- a/spec/helpers/surveyor/responses_helper_spec.rb
+++ b/spec/helpers/surveyor/responses_helper_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
 
           context 'user is a site admin' do
             it 'should return enabled button' do
-              expect(helper.response_options(response, site_admin).split("</a>").first.include?('disabled')).to eq(false)
+              expect(helper.response_options(response, site_admin, [], true).split("</a>").first.include?('disabled')).to eq(false)
             end
           end
 
           context 'user is not a site admin' do
             it 'should return disabled button' do
-              expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(true)
+              expect(helper.response_options(response, user, [], false).split("</a>").first.include?('disabled')).to eq(true)
             end
           end
         end
@@ -64,13 +64,13 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
             let!(:su) { create(:super_user, organization: organization, identity: user) }
 
             it 'should return enabled button' do
-              expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(false)
+              expect(helper.response_options(response, user, [survey], false).split("</a>").first.include?('disabled')).to eq(false)
             end
           end
 
           context 'user is not a super user' do
             it 'should return disabled button' do
-              expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(true)
+              expect(helper.response_options(response, user, [], false).split("</a>").first.include?('disabled')).to eq(true)
             end
           end
         end
@@ -84,7 +84,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").first.include?('disabled')).to eq(true)
           end
         end
       end
@@ -101,7 +101,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return enabled button' do
-            expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(false)
+            expect(helper.response_options(response, user, [form], false).split("</a>").first.include?('disabled')).to eq(false)
           end
         end
 
@@ -113,7 +113,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return enabled button' do
-            expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(false)
+            expect(helper.response_options(response, user, [form], false).split("</a>").first.include?('disabled')).to eq(false)
           end
         end
 
@@ -123,7 +123,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").first.include?('disabled')).to eq(true)
           end
         end
 
@@ -133,7 +133,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").first.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").first.include?('disabled')).to eq(true)
           end
         end
       end
@@ -150,7 +150,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return enabled button' do
-            expect(helper.response_options(response, site_admin).split("</a>").last.include?('disabled')).to eq(false)
+            expect(helper.response_options(response, site_admin, [], true).split("</a>").last.include?('disabled')).to eq(false)
           end
         end
 
@@ -160,7 +160,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").last.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").last.include?('disabled')).to eq(true)
           end
         end
 
@@ -170,7 +170,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").last.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").last.include?('disabled')).to eq(true)
           end
         end
       end
@@ -187,7 +187,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return enabled button' do
-            expect(helper.response_options(response, user).split("</a>").last.include?('disabled')).to eq(false)
+            expect(helper.response_options(response, user, [form], false).split("</a>").last.include?('disabled')).to eq(false)
           end
         end
 
@@ -199,7 +199,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return enabled button' do
-            expect(helper.response_options(response, user).split("</a>").last.include?('disabled')).to eq(false)
+            expect(helper.response_options(response, user, [form], false).split("</a>").last.include?('disabled')).to eq(false)
           end
         end
 
@@ -209,7 +209,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").last.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").last.include?('disabled')).to eq(true)
           end
         end
 
@@ -219,7 +219,7 @@ RSpec.describe Surveyor::ResponsesHelper, type: :helper do
           end
 
           it 'should return disabled button' do
-            expect(helper.response_options(response, user).split("</a>").last.include?('disabled')).to eq(true)
+            expect(helper.response_options(response, user, [], false).split("</a>").last.include?('disabled')).to eq(true)
           end
         end
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157749896

As a result of #1523 there are now several N+1 queries being made when loading the responses table in SPARCForms. I've optimized the code to remove these N+1 queries entirely, significantly increasing the performance of the table.