### PR TITLE
KG - Hide Tags Select if No Tags Present

### DIFF
--- a/app/views/catalog_manager/organizations/_general_info_form.html.haml
+++ b/app/views/catalog_manager/organizations/_general_info_form.html.haml
@@ -75,11 +75,11 @@
           %label.radio-inline.btn.btn-default
             = radio_button_tag 'all_services_availability', 'true', false, class: 'hidden'
             = 'Enable All'
-  - unless organization.type == 'Institution'
+  - unless organization.type == 'Institution' || (tags = Tag.for_organization(organization)).empty?
     .form-group
       = f.label :tag_list, t(:catalog_manager)[:organization_form][:tag_list], class: 'col-sm-3 control-label'
       .col-sm-9
-        = f.select :tag_list, options_from_collection_for_select(Tag.for_organization(organization), :name, :humanized_name, organization.tags.pluck(:name)), {}, class: 'form-control selectpicker', multiple: true, data: { none_selected_text: t(:constants)[:prompts][:none] }
+        = f.select :tag_list, options_from_collection_for_select(tags, :name, :humanized_name, organization.tags.pluck(:name)), {}, class: 'form-control selectpicker', multiple: true, data: { none_selected_text: t(:constants)[:prompts][:none] }
 
   %hr
   .pull-right

--- a/app/views/catalog_manager/services/_general_info_form.html.haml
+++ b/app/views/catalog_manager/services/_general_info_form.html.haml
@@ -58,10 +58,11 @@
       - elsif service.pricing_maps.empty?
         %span{style: "padding-left: 15px;"}
           = t(:catalog_manager)[:service_form][:no_pricing_maps]
-  .form-group
-    = f.label :tag_list, t(:catalog_manager)[:organization_form][:tag_list], class: 'col-sm-3 control-label'
-    .col-sm-9
-      = f.select :tag_list, options_from_collection_for_select(Tag.for_services, :name, :humanized_name, service.tags.pluck(:name)), {}, class: 'form-control selectpicker', multiple: true, data: { none_selected_text: t(:constants)[:prompts][:none]}
+  - if (tags = Tag.for_services).any?
+    .form-group
+      = f.label :tag_list, t(:catalog_manager)[:organization_form][:tag_list], class: 'col-sm-3 control-label'
+      .col-sm-9
+        = f.select :tag_list, options_from_collection_for_select(tags, :name, :humanized_name, service.tags.pluck(:name)), {}, class: 'form-control selectpicker', multiple: true, data: { none_selected_text: t(:constants)[:prompts][:none]}
 
   %hr
   .pull-right


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158267449

Based on discussion, it was decided that if no tags are present, we should just hide the tags select. This wasn't an issue previously, but now that some tags are being hidden, non-split/notify orgs have no tags.