### PR TITLE
Allow subdirectory deployment

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -34,4 +34,6 @@ require ::File.expand_path('../config/environment',  __FILE__)
 #  Rails.backtrace_cleaner.remove_filters!
 #end
 
-run SparcRails::Application
+map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do
+  run SparcRails::Application
+end


### PR DESCRIPTION
Not all organizations deploy applications at the root of a domain and require it
to be hosted in a subdirectory. Based on the following links this is a supported
practice.

https://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root
https://gist.github.com/ebeigarts/5450422

This patch allows sites to deploy it either at the root or under a subdirectory.