### PR TITLE
KG - Settings Populator YML Loading Bug

### DIFF
--- a/app/lib/settings_populator.rb
+++ b/app/lib/settings_populator.rb
@@ -69,8 +69,8 @@ class SettingsPopulator
 
       @data[namespace]    = JSON.parse(File.read(Rails.root.join('config', 'settings', "#{filename}")))
       @config[namespace]  =
-        if File.exists?(Rails.root.join('config', "#{namespace}.yml"))
-          YAML.load_file(Rails.root.join('config', "#{namespace}.yml"))[Rails.env]
+        if File.exists?(Rails.root.join('config', "#{filename}.yml"))
+          YAML.load_file(Rails.root.join('config', "#{filename}.yml"))[Rails.env]
         else
           {}
         end


### PR DESCRIPTION
The Settings Populator should be pulling YML files using the filename, not namespace. This was causing `epic.yml`, `ldap.yml`, and `application.yml` to not be loaded.