### PR TITLE
KG - Protocol Filter Search by Email

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -186,30 +186,23 @@ class Protocol < ApplicationRecord
     # Searches protocols based on 'Authorized User', 'HR#', 'PI', 'Protocol ID', 'PRO#', 'RMID', 'Short/Long Title', OR 'Search All'
     # Protects against SQL Injection with ActiveRecord::Base::sanitize
     # inserts ! so that we can escape special characters
-    escaped_search_term = search_attrs[:search_text].to_s.gsub(/[!%_]/) { |x| '!' + x }
-
-    escaped_search_term = search_attrs[:search_text].to_s.gsub(/[!%_]/) { |x| '!' + x }
-
-    like_search_term = ActiveRecord::Base.connection.quote("%#{escaped_search_term}%")
-    exact_search_term = ActiveRecord::Base.connection.quote(search_attrs[:search_text])
+    escaped_search_term = search_attrs[:search_text].to_s.gsub(/[!%_]/, '')
+    like_search_term    = "%#{escaped_search_term}%"
 
     ### SEARCH QUERIES ###
-    authorized_user_query  = "CONCAT(identities.first_name, ' ', identities.last_name) LIKE #{like_search_term} escape '!'"
-    hr_query               = "human_subjects_info.hr_number LIKE #{like_search_term} escape '!'"
-    pi_query               = "CONCAT(identities.first_name, ' ', identities.last_name) LIKE #{like_search_term} escape '!'"
-    protocol_id_query      = "protocols.id = #{exact_search_term}"
-    pro_num_query          = "human_subjects_info.pro_number LIKE #{like_search_term} escape '!'"
-    rmid_query             = "protocols.research_master_id = #{exact_search_term}"
-    title_query            = ["protocols.short_title LIKE #{like_search_term} escape '!'", "protocols.title LIKE #{like_search_term} escape '!'"]
+    identity_query    = Arel::Nodes::NamedFunction.new('concat', [Identity.arel_table[:first_name], Arel::Nodes.build_quoted(' '), Identity.arel_table[:last_name]]).matches(like_search_term).or(Identity.arel_table[:email].matches(like_search_term))
+    hr_query          = HumanSubjectsInfo.arel_table[:hr_number].matches(like_search_term)
+    protocol_id_query = Protocol.arel_table[:id].eq(search_attrs[:search_text])
+    pro_num_query     = HumanSubjectsInfo.arel_table[:pro_number].matches(like_search_term)
+    rmid_query        = Protocol.arel_table[:research_master_id].eq(search_attrs[:search_text])
+    title_query       = Protocol.arel_table[:short_title].matches(like_search_term).or(Protocol.arel_table[:title].matches(like_search_term))
     ### END SEARCH QUERIES ###
-    hr_pro_ids = HumanSubjectsInfo.where([hr_query, pro_num_query].join(' OR ')).pluck(:protocol_id)
-    hr_protocol_id_query = hr_pro_ids.empty? ? nil : "protocols.id in (#{hr_pro_ids.join(', ')})"
 
     case search_attrs[:search_drop]
     when "Authorized User"
       # To prevent overlap between the for_identity or for_admin scope, run the query unscoped
       # and combine with the old scope's values
-      unscoped  = self.unscoped.joins(:non_pi_authorized_users).joins(:identities).where(authorized_user_query)
+      unscoped  = self.unscoped.joins(non_pi_authorized_users: :identity).where(identity_query)
       others    = self.current_scope
 
       where(id: others & unscoped).distinct
@@ -217,7 +210,7 @@ class Protocol < ApplicationRecord
       joins(:human_subjects_info).
         where(hr_query).distinct
     when "PI"
-      unscoped  = self.unscoped.joins(:principal_investigators).where(pi_query)
+      unscoped  = self.unscoped.joins(:principal_investigators).where(identity_query)
       others    = self.current_scope
 
       where(id: others & unscoped).distinct
@@ -229,11 +222,10 @@ class Protocol < ApplicationRecord
     when "RMID"
       where(rmid_query).distinct
     when "Short/Long Title"
-      where(title_query.join(' OR ')).distinct
+      where(title_query).distinct
     when ""
-      all_query = [authorized_user_query, pi_query, protocol_id_query, title_query, hr_protocol_id_query, rmid_query]
-      joins(:identities).
-        where(all_query.compact.join(' OR ')).
+      joins(:identities, :human_subjects_info).
+        where(identity_query.or(protocol_id_query).or(title_query).or(hr_query).or(pro_num_query).or(rmid_query)).
         distinct
     end
   }

--- a/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_admin_protocols_with_search_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_admin_protocols_with_search_spec.rb
@@ -263,9 +263,9 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
 
 
   context "RMID search" do
-    context 'Setting.find_by_key("research_master_enabled").update_attribute(:value, true)' do
+    context 'RMID enabled' do
+      stub_config('research_master_enabled', true)
       before :each do
-        Setting.find_by_key("research_master_enabled").update_attribute(:value, true)
         @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
         @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
         @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", research_master_id: 1234)
@@ -297,9 +297,9 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
       end
     end
 
-    context 'Setting.find_by_key("research_master_enabled").update_attribute(:value, false)' do
-       before :each do
-        Setting.find_by_key("research_master_enabled").update_attribute(:value, false)
+    context 'RMID disabled' do
+      stub_config('research_master_enabled', false)
+      before :each do
         @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
         @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
         @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", research_master_id: 1234)
@@ -378,7 +378,7 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
 
     it "should not have any HR# matches" do
       bootstrap_select '#filterrific_search_query_search_drop', 'HR#'
-      fill_in 'filterrific_search_query_search_text', with: '11111111111'
+      fill_in 'filterrific_search_query_search_text', with: '123123'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 
@@ -425,7 +425,7 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
 
     it "should not have any PRO# matches" do
       bootstrap_select '#filterrific_search_query_search_drop', 'PRO#'
-      fill_in 'filterrific_search_query_search_text', with: '11111111111'
+      fill_in 'filterrific_search_query_search_text', with: '123123'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 
@@ -647,7 +647,7 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
       end
 
       it "should not have any HR# matches" do
-        fill_in 'filterrific_search_query_search_text', with: '11111111111'
+        fill_in 'filterrific_search_query_search_text', with: '123123'
         find('#apply-filter-button').click
         wait_for_javascript_to_finish
 
@@ -673,7 +673,7 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
       end
 
       it "should not have any PRO# matches" do
-        fill_in 'filterrific_search_query_search_text', with: '11111111111'
+        fill_in 'filterrific_search_query_search_text', with: '123123'
         find('#apply-filter-button').click
         wait_for_javascript_to_finish
 
@@ -686,7 +686,7 @@ RSpec.describe "Admin User filters My Admin Protocols using Search functionality
     end
 
     it 'should return projects and not just studies' do
-      fill_in 'filterrific_search_query_search_text', with: '101010101'
+      fill_in 'filterrific_search_query_search_text', with: '101010'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 

--- a/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_protocols_with_search_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/admin_user_filters_my_protocols_with_search_spec.rb
@@ -263,9 +263,9 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
 
 
   context "RMID search" do
-    context 'Setting.find_by_key("research_master_enabled").update_attribute(:value, true)' do
+    context 'RMID enabled' do
+      stub_config('research_master_enabled', true)
       before :each do
-        Setting.find_by_key("research_master_enabled").update_attribute(:value, true)
         @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
         @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
         @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", research_master_id: 1234)
@@ -297,9 +297,9 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
       end
     end
 
-    context 'Setting.find_by_key("research_master_enabled").update_attribute(:value, false)' do
+    context 'RMID disabled' do
+      stub_config('research_master_enabled', false)
       before :each do
-        Setting.find_by_key("research_master_enabled").update_attribute(:value, false)
         @protocol1 = create(:study_without_validations, primary_pi: jug2, title: "title%", short_title: "Protocol1")
         @protocol2 = create(:study_without_validations, primary_pi: jug2, title: "xTitle", short_title: "Protocol2")
         @protocol3 = create(:study_without_validations, primary_pi: jug2, title: "a%a", short_title: "Protocol3", research_master_id: 1234)
@@ -376,7 +376,7 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
 
     it "should not have any HR# matches" do
       bootstrap_select '#filterrific_search_query_search_drop', 'HR#'
-      fill_in 'filterrific_search_query_search_text', with: '11111111111
+      fill_in 'filterrific_search_query_search_text', with: '123123'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 
@@ -423,7 +423,7 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
 
     it "should not have any PRO# matches" do
       bootstrap_select '#filterrific_search_query_search_drop', 'PRO#'
-      fill_in 'filterrific_search_query_search_text', with: '11111111111
+      fill_in 'filterrific_search_query_search_text', with: '123123'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 
@@ -644,7 +644,7 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
       end
 
       it "should not have any HR# matches" do
-        fill_in 'filterrific_search_query_search_text', with: '11111111111'
+        fill_in 'filterrific_search_query_search_text', with: '123123'
         find('#apply-filter-button').click
         wait_for_javascript_to_finish
 
@@ -670,7 +670,7 @@ RSpec.describe "Admin User filters My Protocols using Search functionality", js:
       end
 
       it "should not have any PRO# matches" do
-        fill_in 'filterrific_search_query_search_text', with: '11111111111'
+        fill_in 'filterrific_search_query_search_text', with: '123123'
         find('#apply-filter-button').click
         wait_for_javascript_to_finish
 

--- a/spec/features/dashboard/protocols/index/filters/general_user_filters_with_search_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/general_user_filters_with_search_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe "General User filters using Search functionality", js: :true do
 
     it "should not have any HR# matches" do
       bootstrap_select '#filterrific_search_query_search_drop', 'HR#'
-      fill_in 'filterrific_search_query_search_text', with: '11111111111'
+      fill_in 'filterrific_search_query_search_text', with: '123123'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 
@@ -385,7 +385,7 @@ RSpec.describe "General User filters using Search functionality", js: :true do
 
     it "should not have any PRO# matches" do
       bootstrap_select '#filterrific_search_query_search_drop', 'PRO#'
-      fill_in 'filterrific_search_query_search_text', with: '11111111111'
+      fill_in 'filterrific_search_query_search_text', with: '123123'
       find('#apply-filter-button').click
       wait_for_javascript_to_finish
 
@@ -602,7 +602,7 @@ RSpec.describe "General User filters using Search functionality", js: :true do
       end
 
       it "should not have any HR# matches" do
-        fill_in 'filterrific_search_query_search_text', with: '11111111111'
+        fill_in 'filterrific_search_query_search_text', with: '123123'
         find('#apply-filter-button').click
         wait_for_javascript_to_finish
 
@@ -628,7 +628,7 @@ RSpec.describe "General User filters using Search functionality", js: :true do
       end
 
       it "should not have any PRO# matches" do
-        fill_in 'filterrific_search_query_search_text', with: '11111111111'
+        fill_in 'filterrific_search_query_search_text', with: '123123'
         find('#apply-filter-button').click
         wait_for_javascript_to_finish
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/159523840

Allows users to search for authorized users/pis by email. I converted the queries to use Arel statements instead of strings because it protects against SQL injection and is the standard way to do these kinds of queries in Rails 5.