### PR TITLE
KG - Change eIRB Date Data Type

### DIFF
--- a/db/migrate/20181025193140_change_human_subject_eirb_dates.rb
+++ b/db/migrate/20181025193140_change_human_subject_eirb_dates.rb
@@ -1,0 +1,7 @@
+class ChangeHumanSubjectEirbDates < ActiveRecord::Migration[5.2]
+  def change
+    change_column :human_subjects_info, :initial_irb_approval_date, :date
+    change_column :human_subjects_info, :irb_approval_date, :date
+    change_column :human_subjects_info, :irb_expiration_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_03_143643) do
+ActiveRecord::Schema.define(version: 2018_10_25_193140) do
 
   create_table "admin_rates", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "line_item_id"
@@ -247,9 +247,9 @@ ActiveRecord::Schema.define(version: 2018_10_03_143643) do
     t.string "pro_number"
     t.string "irb_of_record"
     t.string "submission_type"
-    t.datetime "initial_irb_approval_date"
-    t.datetime "irb_approval_date"
-    t.datetime "irb_expiration_date"
+    t.date "initial_irb_approval_date"
+    t.date "irb_approval_date"
+    t.date "irb_expiration_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160263256

For this RMID story, it was asked that the eIRB dates use the `DATE` data type instead of `DATETIME`.