### PR TITLE
Migration bug [#161398312]

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -240,6 +240,16 @@
     "parent_value":   ""
   },
   {
+    "key":            "use_funding_module",
+    "value":          "false",
+    "friendly_name":  "Use SPARCFunding Module",
+    "description":    "This determines whether the application will use the SPARCFunding module.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "",
+    "parent_value":   ""
+  },
+  {
     "key":            "funding_admins",
     "value":          "[]",
     "friendly_name":  "Funding Admins",
@@ -824,16 +834,6 @@
     "value":          "false",
     "friendly_name":  "Use Feedback Link",
     "description":    "This determines whether the application will use an external resource for users to provide feedback. This has lower precedence than \"use_redcap_api\" when both are enabled.",
-    "group":          "",
-    "version":        "",
-    "parent_key":     "",
-    "parent_value":   ""
-  },
-  {
-    "key":            "use_funding_module",
-    "value":          "false",
-    "friendly_name":  "Use SPARCFunding Module",
-    "description":    "This determines whether the application will use the SPARCFunding module.",
     "group":          "",
     "version":        "",
     "parent_key":     "",


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/n/projects/1918597/stories/161398312

Errors occur only when running the setting populator where funding_admins and funding_org_ids already exist in the settings table without a parent_key (since V3.2.0), use_funding_module, as in the updated config/defaults.json. I have to move up the use_funding_module hash in defaults.json to fix the issue.