### PR TITLE
JM - (SPARCDashboard & SPARCFulfillment) Go to Fulfillment Button Error Message

### DIFF
--- a/app/api/v1/entities/full.rb
+++ b/app/api/v1/entities/full.rb
@@ -206,7 +206,8 @@ module V1
             :routing,
             :org_tree_display,
             :grand_total,
-            :service_requester_id
+            :service_requester_id,
+            :imported_to_fulfillment
 
     expose  :formatted_status, as: :status
 

--- a/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
+++ b/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
@@ -55,6 +55,15 @@ $(document).ready ->
       data: data
       error: (xhr, ajaxOptions, thrownError) ->
         swal('Error', 'This protocol has failed to be sent to SPARCFulfillment because of failed validation. Please make sure the service calendar is intact before trying again.', 'error')
+      success: ->
+        refresh = window.setInterval((->
+          imported_to_fulfillment = $('.fulfillment_status').data('imported-to-fulfillment')
+          if imported_to_fulfillment == false
+            $("#ssr_fulfillment_status").load(location.href + " .fulfillment_status")
+          else
+            window.clearInterval refresh
+          return
+        ), 5000)
 
   $(document).on 'click', '#send_to_epic_button', ->
     $(this).prop( "disabled", true )

--- a/app/controllers/dashboard/sub_service_requests_controller.rb
+++ b/app/controllers/dashboard/sub_service_requests_controller.rb
@@ -212,6 +212,7 @@ private
         :service_requester_id,
         :requester_contacted_date,
         :submitted_at,
+        :imported_to_fulfillment,
         line_items_attributes: [:service_request_id,
           :sub_service_request_id,
           :service_id,

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -73,8 +73,13 @@ module Dashboard::SubServiceRequestsHelper
     if sub_service_request.ready_for_fulfillment?
       if sub_service_request.in_work_fulfillment?
         if user.go_to_cwf_rights?(sub_service_request.organization)
-          # In fulfillment, and user has rights to view in Fulfillment
-          display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], "#{Setting.get_value("clinical_work_fulfillment_url")}/sub_service_request/#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md"
+          if sub_service_request.imported_to_fulfillment?
+            # In fulfillment, and user has rights to view in Fulfillment
+            display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], "#{Setting.get_value("clinical_work_fulfillment_url")}/sub_service_request/#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md fulfillment_status"
+          else
+            # Pending button displayed until ssr is imported to fulfillment
+            display += button_tag t(:dashboard)[:sub_service_requests][:header][:fulfillment][:pending], data: { imported_to_fulfillment: sub_service_request.imported_to_fulfillment? }, class: "btn btn-primary btn-md form-control fulfillment_status", disabled: true
+          end
         else
           # In fulfillment, but user has no rights to view in Fulfillment
           display += button_tag t(:dashboard)[:sub_service_requests][:header][:fulfillment][:in_fulfillment], class: "btn btn-primary btn-md form-control", disabled: true

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -59,6 +59,7 @@ class SubServiceRequest < ApplicationRecord
   validates :ssr_id, presence: true, uniqueness: { scope: :service_request_id }
 
   scope :in_work_fulfillment, -> { where(in_work_fulfillment: true) }
+  scope :imported_to_fulfillment, -> { where(imported_to_fulfillment: true) }
 
   def consult_arranged_date=(date)
     write_attribute(:consult_arranged_date, date.present? ? Time.strptime(date, "%m/%d/%Y") : nil)

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -369,6 +369,7 @@ en:
           header: "Fulfillment"
           go_to_fulfillment: "Go to Fulfillment"
           in_fulfillment: "In Fulfillment"
+          pending: "Pending"
           send_to_fulfillment: "Send to Fulfillment"
           not_enabled: "Not enabled in SPARCCatalog."
         cost: "Cost"

--- a/db/migrate/20181029150447_add_imported_to_fulfillment_flag_to_ssr.rb
+++ b/db/migrate/20181029150447_add_imported_to_fulfillment_flag_to_ssr.rb
@@ -1,0 +1,7 @@
+class AddImportedToFulfillmentFlagToSsr < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sub_service_requests, :imported_to_fulfillment, :boolean, default: false
+
+    SubServiceRequest.in_work_fulfillment.update_all imported_to_fulfillment: true
+  end
+end

--- a/spec/factories/sub_service_request.rb
+++ b/spec/factories/sub_service_request.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
     service_requester_id { Random.rand(1000) }
     sequence(:ssr_id) { |n| "000#{n}" }
     status "draft"
+    imported_to_fulfillment true
 
     trait :without_validations do
       to_create { |instance| instance.save(validate: false) }

--- a/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
+++ b/spec/views/dashboard/sub_service_requests/_header.html.haml_spec.rb
@@ -102,25 +102,48 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
     context "SubServiceRequest ready for fulfillment" do
       context "and in fulfillment" do
         context "user has go to cwf rights" do
-          it "should display the 'Go to Fulfillment' button, linking to CWF" do
-            protocol = stub_protocol
-            organization = stub_organization
-            sub_service_request = stub_sub_service_request(protocol: protocol,
-              organization: organization,
-              status: "draft")
-            allow(sub_service_request).to receive_messages(ready_for_fulfillment?: true,
-              in_work_fulfillment?: true)
-            logged_in_user = build_stubbed(:identity)
-            allow(logged_in_user).to receive_messages(unread_notification_count: 12345,
-              go_to_cwf_rights?: true)
-            stub_current_user(logged_in_user)
-            allow(sub_service_request).to receive(:notes).and_return(["1"])
-            allow(sub_service_request).to receive(:is_complete?).and_return(false)
+          context "ssr has been imported to fulfillment" do
+            it "should display the 'Go to Fulfillment' button, linking to CWF" do
+              protocol = stub_protocol
+              organization = stub_organization
+              sub_service_request = stub_sub_service_request(protocol: protocol,
+                organization: organization,
+                status: "draft")
+              allow(sub_service_request).to receive_messages(ready_for_fulfillment?: true,
+                in_work_fulfillment?: true, imported_to_fulfillment?: true)
+              logged_in_user = build_stubbed(:identity)
+              allow(logged_in_user).to receive_messages(unread_notification_count: 12345,
+                go_to_cwf_rights?: true)
+              stub_current_user(logged_in_user)
+              allow(sub_service_request).to receive(:notes).and_return(["1"])
+              allow(sub_service_request).to receive(:is_complete?).and_return(false)
 
-            render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
+              render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
 
-            expect(response).to have_tag("a", text: "Go to Fulfillment",
-              with: { href: "#{Setting.get_value("clinical_work_fulfillment_url")}/sub_service_request/#{sub_service_request.id}" })
+              expect(response).to have_tag("a", text: "Go to Fulfillment",
+                with: { href: "#{Setting.get_value("clinical_work_fulfillment_url")}/sub_service_request/#{sub_service_request.id}" })
+            end
+          end
+          context "ssr has not yet been imported to fulfillment" do
+            it "should display the 'Pending' button" do
+              protocol = stub_protocol
+              organization = stub_organization
+              sub_service_request = stub_sub_service_request(protocol: protocol,
+                organization: organization,
+                status: "draft")
+              allow(sub_service_request).to receive_messages(ready_for_fulfillment?: true,
+                in_work_fulfillment?: true, imported_to_fulfillment?: false)
+              logged_in_user = build_stubbed(:identity)
+              allow(logged_in_user).to receive_messages(unread_notification_count: 12345,
+                go_to_cwf_rights?: true)
+              stub_current_user(logged_in_user)
+              allow(sub_service_request).to receive(:notes).and_return(["1"])
+              allow(sub_service_request).to receive(:is_complete?).and_return(false)
+
+              render "dashboard/sub_service_requests/header", sub_service_request: sub_service_request
+
+              expect(response).to have_tag("button", text: "Pending", with: {disabled: "disabled"})
+            end
           end
         end
 
@@ -260,6 +283,7 @@ RSpec.describe 'dashboard/sub_service_requests/_header', type: :view do
       ssr_id: "0001",
       status: opts[:status] || "NotDraft",             # default "NotDraft"
       candidate_owners: opts[:candidate_owners] || [], # default []
+      imported_to_fulfillment?: opts[:imported_to_fulfillment?].nil? || opts[:imported_to_fulfillment?], # default true
       ready_for_fulfillment?: opts[:ready_for_fulfillment?].nil? || opts[:ready_for_fulfillment?], # default true
       in_work_fulfillment?: opts[:in_work_fulfillment?].nil? || opts[:in_work_fulfillment?])       # default true
 


### PR DESCRIPTION
*** Related sparc-fulfillment story:  https://github.com/sparc-request/sparc-fulfillment/pull/381 ***
https://www.pivotaltracker.com/story/show/161349235

In order to avoid this error message:
A new flag (imported_to_fulfillment) has been added to SSR.  This flag is set to true in the lib/importers/protocol_importer.rb on the fulfillment side.  When a user clicks "Send to Fulfillment", a "Pending" button will show.  This button will continue refreshing until the imported_to_fulfillment flag is set to true, at which point the "Go to Fulfillment" button is displayed. 