### PR TITLE
ml-view_consolidated_req_dropdown_bug

### DIFF
--- a/app/views/dashboard/service_requests/_service_requests.html.haml
+++ b/app/views/dashboard/service_requests/_service_requests.html.haml
@@ -34,16 +34,16 @@
               %li
                 %a.view-full-calendar-button{ data: { protocol_id: protocol.id, statuses_hidden: %w(draft first_draft) } }
                   = t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts]
-            .dropdown
-              %button.btn.btn-primary.btn-sm.dropdown-toggle.export-consolidated{ data: { protocol_id: protocol.id, toggle: 'dropdown', placement: 'top', delay: '{"show":"500"}' }, title: t(:dashboard)[:protocols][:service_requests][:tooltips][:export_consolidated_request] }
-                = t(:dashboard)[:protocols][:service_requests][:export_consolidated]
-              %ul.dropdown-menu
-                %li
-                  = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_all],
-                    dashboard_protocol_path(protocol, statuses_hidden: ['first_draft'], format: :xlsx)
-                %li
-                  = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts],
-                    dashboard_protocol_path(protocol, statuses_hidden: %w(draft first_draft), format: :xlsx)
+          .dropdown
+            %button.btn.btn-primary.btn-sm.dropdown-toggle.export-consolidated{ data: { protocol_id: protocol.id, toggle: 'dropdown', placement: 'top', delay: '{"show":"500"}' }, title: t(:dashboard)[:protocols][:service_requests][:tooltips][:export_consolidated_request] }
+              = t(:dashboard)[:protocols][:service_requests][:export_consolidated]
+            %ul.dropdown-menu
+              %li
+                = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_all],
+                  dashboard_protocol_path(protocol, statuses_hidden: ['first_draft'], format: :xlsx)
+              %li
+                = link_to t(:dashboard)[:protocols][:service_requests][:consolidated_exclude_drafts],
+                  dashboard_protocol_path(protocol, statuses_hidden: %w(draft first_draft), format: :xlsx)
           .dropdown
             %button.btn.btn-success.btn-sm.dropdown-toggle.coverage-analysis-report{ data: { protocol_id: protocol.id, toggle: 'dropdown', placement: 'top', delay: '{"show":"500"}' }, title: t(:dashboard)[:service_requests][:tooltips][:coverage_report] }
               = t(:dashboard)[:protocols][:service_requests][:coverage_report]


### PR DESCRIPTION
In Dashboard, when clicking on view consolidated report button, the dropdown is appearing under export consolidated. 

