### PR TITLE
KG - Limit Primary Contact Bugs

### DIFF
--- a/app/assets/javascripts/catalog_manager/form.js.coffee
+++ b/app/assets/javascripts/catalog_manager/form.js.coffee
@@ -75,13 +75,6 @@ $ ->
       type: if checked then 'POST' else 'DELETE'
       url: "/catalog_manager/service_provider?service_provider[identity_id]=#{identity_id}&service_provider[organization_id]=#{organization_id}"
 
-      success: ->
-        $("#sp-is-primary-contact-#{identity_id}").prop('disabled', !checked)
-        $("#sp-hold-emails-#{identity_id}").prop('disabled', !checked)
-        if !checked
-          $("#sp-is-primary-contact-#{identity_id}").prop('checked', false)
-          $("#sp-hold-emails-#{identity_id}").prop('checked', false)
-
   $(document).on 'change', '.cm-edit-historic-data', ->
     identity_id = $(this).data('identity-id')
     organization_id = $(this).data('organization-id')

--- a/app/views/catalog_manager/organizations/refresh_user_rights_row.js.coffee
+++ b/app/views/catalog_manager/organizations/refresh_user_rights_row.js.coffee
@@ -19,7 +19,6 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 $("#user-rights-row-<%= j @identity.id.to_s %>").replaceWith("<%= j render '/catalog_manager/organizations/user_rights_row', organization: @organization, user_rights: @user_rights, user: @identity %>")
-
 $("#flashes_container").html("<%= escape_javascript(render( 'shared/flash' )) %>")
-
 $('[data-toggle="tooltip"]').tooltip()
+togglePrimaryContactChecks()

--- a/app/views/catalog_manager/organizations/remove_user_rights_row.js.coffee
+++ b/app/views/catalog_manager/organizations/remove_user_rights_row.js.coffee
@@ -18,6 +18,8 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#user-rights-row-<%= escape_javascript(@identity_id) %>").fadeOut(1000, () -> $(this).remove())
-
+$("#user-rights-row-<%= escape_javascript(@identity_id) %>").fadeOut(1000, () ->
+  $(this).remove()
+  togglePrimaryContactChecks()
+)
 $("#flashes_container").html("<%= escape_javascript(render( 'shared/flash' )) %>")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157887413

There were a few cases that were causing issues with disabling the checkboxes.

1. If you deleted a primary contact, the checkboxes would not be re-enabled.
2. If you made a user a service provider, the checkbox would not be disabled.