### PR TITLE
KG - Broken LDAP/Directory.rb

### DIFF
--- a/app/lib/directory.rb
+++ b/app/lib/directory.rb
@@ -41,18 +41,18 @@ class Directory
         ldap_config = Hash.new
         ldap_settings.each{|setting| ldap_config[setting.key] = setting.value}
         begin
-          LDAP_HOST       = ldap_config['ldap_host']
-          LDAP_PORT       = ldap_config['ldap_port']
-          LDAP_BASE       = ldap_config['ldap_base']
-          LDAP_ENCRYPTION = ldap_config['ldap_encryption'].to_sym
-          DOMAIN          = ldap_config['ldap_domain']
-          LDAP_UID        = ldap_config['ldap_uid']
-          LDAP_LAST_NAME  = ldap_config['ldap_last_name']
-          LDAP_FIRST_NAME = ldap_config['ldap_first_name']
-          LDAP_EMAIL      = ldap_config['ldap_email']
-          LDAP_AUTH_USERNAME      = ldap_config['ldap_auth_username']
-          LDAP_AUTH_PASSWORD      = ldap_config['ldap_auth_password']
-          LDAP_FILTER      = ldap_config['ldap_filter']
+          LDAP_HOST           = ldap_config['ldap_host']
+          LDAP_PORT           = ldap_config['ldap_port']
+          LDAP_BASE           = ldap_config['ldap_base']
+          LDAP_ENCRYPTION     = ldap_config['ldap_encryption'].to_sym
+          DOMAIN              = ldap_config['ldap_domain']
+          LDAP_UID            = ldap_config['ldap_uid']
+          LDAP_LAST_NAME      = ldap_config['ldap_last_name']
+          LDAP_FIRST_NAME     = ldap_config['ldap_first_name']
+          LDAP_EMAIL          = ldap_config['ldap_email']
+          LDAP_AUTH_USERNAME  = ldap_config['ldap_auth_username']
+          LDAP_AUTH_PASSWORD  = ldap_config['ldap_auth_password']
+          LDAP_FILTER         = ldap_config['ldap_filter']
         rescue
           raise "ldap settings incorrect, unable to load ldap configuration"
         end
@@ -125,7 +125,7 @@ class Directory
            port: LDAP_PORT,
            base: base,
            encryption: LDAP_ENCRYPTION)
-        ldap.auth LDAP_AUTH_USERNAME, LDAP_AUTH_PASSWORD unless !LDAP_AUTH_USERNAME || !LDAP_AUTH_PASSWORD
+        ldap.auth LDAP_AUTH_USERNAME, LDAP_AUTH_PASSWORD if LDAP_AUTH_USERNAME.present? && LDAP_AUTH_PASSWORD.present?
         # use LDAP_FILTER to override default filter with custom string
         filter = (LDAP_FILTER && LDAP_FILTER.gsub('#{term}', term)) || fields.map { |f| Net::LDAP::Filter.contains(f, term) }.inject(:|)
         res = ldap.search(:attributes => fields, :filter => filter)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -32,7 +32,7 @@ class Setting < ApplicationRecord
   validate :parent_value_matches_parent_data_type, if: Proc.new{ self.parent_key.present? }
 
   def self.get_value(key)
-    value           = Setting.find_by_key(key).try(:value)
+    value = Setting.find_by_key(key).try(:value)
   end
 
   # Needed to correctly write boolean true and false as value in specs

--- a/config/ldap.yml.example
+++ b/config/ldap.yml.example
@@ -21,7 +21,7 @@
 # production:
 #   ldap_host:          "authldap.musc.edu"
 #   ldap_port:          "636"
-#   ldap_base:          "['ou=people,dc=musc,dc=edu']"
+#   ldap_base:          '["ou=people,dc=musc,dc=edu"]'
 #   ldap_encryption:    "simple_tls"
 #   ldap_domain:        "musc.edu"
 #   ldap_uid:           "uid"
@@ -35,7 +35,7 @@
 # staging:
 #   ldap_host:          "authldap.musc.edu"
 #   ldap_port:          "636"
-#   ldap_base:          "['ou=people,dc=musc,dc=edu']"
+#   ldap_base:          '["ou=people,dc=musc,dc=edu"]'
 #   ldap_encryption:    "simple_tls"
 #   ldap_domain:        "musc.edu"
 #   ldap_uid:           "uid"
@@ -49,7 +49,7 @@
 # testing:
 #   ldap_host:          "authldap.musc.edu"
 #   ldap_port:          "636"
-#   ldap_base:          "['ou=people,dc=musc,dc=edu']"
+#   ldap_base:          '["ou=people,dc=musc,dc=edu"]'
 #   ldap_encryption:    "simple_tls"
 #   ldap_domain:        "musc.edu"
 #   ldap_uid:           "uid"
@@ -63,7 +63,7 @@
 development:
   ldap_host:          "authldap.musc.edu"
   ldap_port:          "636"
-  ldap_base:          "['ou=people,dc=musc,dc=edu']"
+  ldap_base:          '["ou=people,dc=musc,dc=edu"]'
   ldap_encryption:    "simple_tls"
   ldap_domain:        "musc.edu"
   ldap_uid:           "uid"
@@ -77,7 +77,7 @@ development:
 test:
   ldap_host:          "authldap.musc.edu"
   ldap_port:          "636"
-  ldap_base:          "['ou=people,dc=musc,dc=edu']"
+  ldap_base:          '["ou=people,dc=musc,dc=edu"]'
   ldap_encryption:    "simple_tls"
   ldap_domain:        "musc.edu"
   ldap_uid:           "uid"


### PR DESCRIPTION
There were 2 issues here:
1. `ldap_base` as it was defined in `ldap.yml.example` was invalid. The formatting needs to be as such in order to be considered valid JSON when evaluating the Setting's value.
2. Directory incorrectly applied the `ldap_auth_username` and `ldap_auth_password` when they were blank. `!""` returns `true`. Checking that both values are `.present?` correctly evaluates a blank username and password to false and prevents LDAP from applying the authorization.