### PR TITLE
ml-changes_to_Catalog_verbiage

### DIFF
--- a/config/locales/catalog_manager.en.yml
+++ b/config/locales/catalog_manager.en.yml
@@ -57,7 +57,7 @@ en:
         name_email: "Name, Email"
         super_user: "Super User"
         catalog_manager: "Catalog Manager"
-        edit_historic_data: "Edit Historic Data:"
+        edit_historic_data: "Edit Historical Data:"
         service_provider: "Service Provider"
         primary_contact: "Primary Contact:"
         hold_emails: "Hold Emails:"


### PR DESCRIPTION
In SPARCCatalog on all levels of User Rights, it says "Edit Historic Data" where it should say "Edit Historical Data" instead.

