### PR TITLE
KG - Fix Catalog Pricing Styling

### DIFF
--- a/app/assets/javascripts/catalog.js.coffee
+++ b/app/assets/javascripts/catalog.js.coffee
@@ -71,7 +71,7 @@ $(document).ready ->
       limit: 100,
       templates: {
         suggestion: Handlebars.compile('<button class="service text-left" data-container="body" data-placement="right" data-toggle="tooltip" data-animation="false" data-html="true" title="{{description}}">
-                                          <h4 class="service-name no-margin-top"><span class="text-service">Service</span><span>: {{label}}</span></h4>
+                                          <h4 class="service-name col-sm-12 no-padding no-margin-top"><span class="text-service">Service</span><span>: {{label}}</span></h4>
                                           <span class="col-sm-12 no-padding">{{{breadcrumb}}}</span>
                                           <span class="col-sm-12 no-padding"><strong>Abbreviation:</strong> {{abbreviation}}</span>
                                           {{#if cpt_code_text}}

--- a/app/assets/javascripts/catalog_manager/catalog.js.coffee
+++ b/app/assets/javascripts/catalog_manager/catalog.js.coffee
@@ -129,7 +129,7 @@ initialize_org_search = () ->
       limit: 100,
       templates: {
         suggestion: Handlebars.compile('<button class="service text-left">
-                                          <h4 class="service-name no-margin-top"><span class="{{text_color}}">{{type}}</span><span>: {{name}}</span> <small class="text-danger">{{inactive_tag}}</small></h4>
+                                          <h4 class="service-name col-sm-12 no-padding no-margin-top"><span class="{{text_color}}">{{type}}</span><span>: {{name}}</span> <small class="text-danger">{{inactive_tag}}</small></h4>
                                           <span class="col-sm-12 no-padding">{{{breadcrumb}}}</span>
                                           <span class="col-sm-12 no-padding"><strong>Abbreviation:</strong> {{abbreviation}}</span>
                                           {{#if cpt_code_text}}

--- a/app/assets/stylesheets/twitter_typeahead.sass
+++ b/app/assets/stylesheets/twitter_typeahead.sass
@@ -62,3 +62,13 @@
 
   .service-name
     margin-bottom: 3px
+
+  .service-pricing-container
+    display: flex
+    flex-wrap: wrap
+
+    .pricing-subcontainer
+      display: flex
+      justify-content: space-between
+      flex: 1 auto
+

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -23,14 +23,18 @@ module ServicesHelper
   include ActionView::Context
 
   def cpt_code_text(service)
-    content_tag(:span, class: 'col-sm-3 no-padding text-black') do
-      content_tag(:strong, "CPT Code: ") + (service.cpt_code.blank? ? "N/A" : service.cpt_code)
+    unless service.cpt_code.blank?
+      content_tag(:span, class: 'col-sm-3 no-padding text-black') do
+        content_tag(:strong, "#{t(:catalog_manager)[:organization_form][:cpt_code]}: #{service.cpt_code}")
+      end
     end
   end
 
   def eap_id_text(service)
-    content_tag(:span, class: 'col-sm-3 no-padding text-black') do
-      content_tag(:strong, "EAP ID: ") + (service.eap_id.blank? ? "N/A" : service.eap_id)
+    unless service.eap_id.blank?
+      content_tag(:span, class: 'col-sm-3 no-padding text-black') do
+        content_tag(:strong, "#{t(:catalog_manager)[:organization_form][:eap_id]}: #{service.eap_id}")
+      end
     end
   end
 

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -23,25 +23,39 @@ module ServicesHelper
   include ActionView::Context
 
   def cpt_code_text(service)
-    content_tag(:span, class: 'col-sm-3 no-padding') do
+    content_tag(:span, class: 'col-sm-3 no-padding text-black') do
       content_tag(:strong, "CPT Code: ") + (service.cpt_code.blank? ? "N/A" : service.cpt_code)
     end
   end
 
   def eap_id_text(service)
-    content_tag(:span, class: 'col-sm-3 no-padding') do
+    content_tag(:span, class: 'col-sm-3 no-padding text-black') do
       content_tag(:strong, "EAP ID: ") + (service.eap_id.blank? ? "N/A" : service.eap_id)
     end
   end
 
   def service_pricing_text(service)
     if current_user.present?
-      content_tag(:span, class: 'service-pricing-container') do
-        raw(service.displayed_pricing_map.true_rate_hash.map do |label, value|
-          content_tag(:span, class: ['no-padding', label == :full ? 'col-sm-12' : 'col-sm-3']) do
-            content_tag(:strong, "#{Service::RATE_TYPES[label]}: ") + "$#{'%.2f' % (value/100)}"
+      rates = service.displayed_pricing_map.true_rate_hash
+
+      content_tag(:div, class: 'service-pricing-container col-sm-12 no-padding text-black') do
+        content_tag(:span, class: 'col-sm-12 no-padding') do
+          content_tag(:strong, "#{Service::RATE_TYPES[:full].gsub(' Rate', '')}: ") + "$#{'%.2f' % (rates[:full]/100)}"
+        end +
+        content_tag(:span, class: 'col-sm-3 no-padding') do
+          content_tag(:strong, "#{Service::RATE_TYPES[:federal].gsub(' Rate', '')}: ") + "$#{'%.2f' % (rates[:federal]/100)}"
+        end +
+        content_tag(:div, class: 'pricing-subcontainer') do
+          content_tag(:span) do
+            content_tag(:strong, "#{Service::RATE_TYPES[:corporate].gsub(' Rate', '')}: ") + "$#{'%.2f' % (rates[:corporate]/100)}"
+          end +
+          content_tag(:span) do
+            content_tag(:strong, "#{Service::RATE_TYPES[:member].gsub(' Rate', '')}: ") + "$#{'%.2f' % (rates[:member]/100)}"
+          end +
+          content_tag(:span) do
+            content_tag(:strong, "#{Service::RATE_TYPES[:other].gsub(' Rate', '')}: ") + "$#{'%.2f' % (rates[:other]/100)}"
           end
-        end.join(''))
+        end
       end
     end
   end

--- a/app/views/catalogs/accordion/_services.html.haml
+++ b/app/views/catalogs/accordion/_services.html.haml
@@ -20,15 +20,11 @@
 - services.each do |service|
   .service-view.col-sm-12.no-padding-x
     = link_to 'javascript:void(0)', class: ["service service-#{service.id} add-service no-padding", action_name == 'update_description' ?  'col-sm-10' : 'col-sm-12'], title: organization_description_display(service), data: { id: service.id, toggle: 'tooltip', placement: 'left', delay: '{"show":"500"}' } do
-      %h4.service-name.no-margin-top
+      %h4.service-name.col-sm-12.no-padding.no-margin-top
         = service.display_service_name
-      %small.text-black
-        = raw cpt_code_text(service)
-      %small.text-black
-        = raw eap_id_text(service)
-      - if current_user.present?
-        %small.service-pricing.text-black
-          = raw service_pricing_text(service)
+      = cpt_code_text(service)
+      = eap_id_text(service)
+      = raw service_pricing_text(service)
     - if action_name == 'update_description'
       .col-sm-2
         %button.add-service.pull-right.btn.btn-success{ data: { id: service.id } }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158927375

The styling of the service details was not acting consistently. It took a bit more work in the helper methods, but I was able to make the styling look consistent between the epic fields and the pricing.

Another requested feature was to hide the EAP ID and CPT Code if epic is turned off. This caused a large number of n+1 Settings queries. To solve this, I added caching on the Setting model that loads all of the settings during a request to the server so that only 1 database call is ever made.