### PR TITLE
Account approval/disapproval email notification improvement [#161488360]

### DIFF
--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -22,13 +22,17 @@ class IdentitiesController < ApplicationController
 
   def approve_account
     @identity = Identity.find params[:id]
-    @identity.update_attribute(:approved, true)
-    Notifier.account_status_change(@identity, true).deliver unless @identity.email.blank?
+    unless @identity.try(:approved)
+      @identity.update_attribute(:approved, true)
+      Notifier.account_status_change(@identity, true).deliver unless @identity.email.blank?
+    end
   end
 
   def disapprove_account
     @identity = Identity.find params[:id]
-    @identity.update_attribute(:approved, false)
-    Notifier.account_status_change(@identity, false).deliver unless @identity.email.blank?
+    unless @identity.try(:approved) == false
+      @identity.update_attribute(:approved, false)
+      Notifier.account_status_change(@identity, false).deliver unless @identity.email.blank?
+    end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -67,7 +67,7 @@ class ReportsController < ApplicationController
 
     # generate excel
     tempfile = @report.to_excel
-    send_file tempfile.path, :filename => 'report.xlsx', :disposition => 'inline', :type =>  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    send_file tempfile.path, :filename => "#{Time.now.strftime('%F')} #{@report.title}.xlsx", :disposition => 'inline', :type =>  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
     # generate csv
     #tempfile = @report.to_csv

--- a/db/migrate/20181114225543_remove_identity_approved_default.rb
+++ b/db/migrate/20181114225543_remove_identity_approved_default.rb
@@ -1,0 +1,6 @@
+class RemoveIdentityApprovedDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :identities, :approved, true
+    change_column_default :identities, :approved, nil
+  end
+end

--- a/spec/controllers/identities/get_approve_account_spec.rb
+++ b/spec/controllers/identities/get_approve_account_spec.rb
@@ -34,26 +34,6 @@ RSpec.describe IdentitiesController do
       expect(assigns(:identity)).to eq(identity)
     end
 
-    it 'should update approved status' do
-      identity = create(:identity)
-
-      get :approve_account, params: {
-        id: identity.id
-      }, xhr: true
-
-      expect(identity.reload.approved).to eq(true)      
-    end
-
-    it 'should send notifications' do
-      identity = create(:identity)
-
-      expect {
-        get :approve_account, params: {
-          id: identity.id
-        }, xhr: true
-      }.to change(ActionMailer::Base.deliveries, :count).by(1)
-    end
-
     it 'should render template' do
       identity = create(:identity)
 
@@ -72,6 +52,64 @@ RSpec.describe IdentitiesController do
       }, xhr: true
 
       expect(controller).to respond_with(:ok)
+    end
+
+    context 'Identity.approved is true' do
+      it 'should not send notifications' do
+        identity = create(:identity, approved: true)
+
+        expect {
+          get :approve_account, params: {
+            id: identity.id
+          }, xhr: true
+        }.to change(ActionMailer::Base.deliveries, :count).by(0)
+      end
+    end
+
+    context 'Identity.approved is false' do
+
+      it 'should send notifications' do
+        identity = create(:identity, approved: false)
+
+        expect {
+          get :approve_account, params: {
+            id: identity.id
+          }, xhr: true
+        }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      it 'should update approved status' do
+        identity = create(:identity, approved: false)
+
+        get :approve_account, params: {
+          id: identity.id
+        }, xhr: true
+
+        expect(identity.reload.approved).to eq(true)
+      end
+
+    end
+
+    context 'Identity.approved is nil' do
+      it 'should send notifications' do
+        identity = create(:identity)
+
+        expect {
+          get :approve_account, params: {
+            id: identity.id
+          }, xhr: true
+        }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      it 'should update approved status' do
+        identity = create(:identity)
+
+        get :approve_account, params: {
+          id: identity.id
+        }, xhr: true
+
+        expect(identity.reload.approved).to eq(true)
+      end
     end
   end
 end

--- a/spec/controllers/identities/get_disapprove_account_spec.rb
+++ b/spec/controllers/identities/get_disapprove_account_spec.rb
@@ -34,26 +34,6 @@ RSpec.describe IdentitiesController do
       expect(assigns(:identity)).to eq(identity)
     end
 
-    it 'should update approved status' do
-      identity = create(:identity)
-
-      get :disapprove_account, params: {
-        id: identity.id
-      }, xhr: true
-
-      expect(identity.reload.approved).to eq(false)      
-    end
-
-    it 'should send notifications' do
-      identity = create(:identity)
-
-      expect {
-        get :disapprove_account, params: {
-          id: identity.id
-        }, xhr: true
-      }.to change(ActionMailer::Base.deliveries, :count).by(1)
-    end
-
     it 'should render template' do
       identity = create(:identity)
 
@@ -73,5 +53,62 @@ RSpec.describe IdentitiesController do
 
       expect(controller).to respond_with(:ok)
     end
+
+    context 'identity.approved is false' do
+      it 'should send not notifications' do
+        identity = create(:identity, approved: false)
+
+        expect {
+          get :disapprove_account, params: {
+            id: identity.id
+          }, xhr: true
+        }.to change(ActionMailer::Base.deliveries, :count).by(0)
+      end
+    end
+
+    context 'identity.approved is true' do
+      it 'should send notifications' do
+        identity = create(:identity, approved: true)
+
+        expect {
+          get :disapprove_account, params: {
+            id: identity.id
+          }, xhr: true
+        }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+
+      it 'should update approved status' do
+        identity = create(:identity, approved: true)
+
+        get :disapprove_account, params: {
+            id: identity.id
+        }, xhr: true
+
+        expect(identity.reload.approved).to eq(false)
+      end
+    end
+
+    context 'Identity.approved is nil' do
+      it 'should update approved status' do
+      identity = create(:identity)
+
+        get :disapprove_account, params: {
+            id: identity.id
+        }, xhr: true
+
+        expect(identity.reload.approved).to eq(false)
+      end
+
+      it 'should send notifications' do
+      identity = create(:identity)
+
+        expect {
+          get :approve_account, params: {
+            id: identity.id
+          }, xhr: true
+        }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Currently for the account approval/disapproval, an email goes to the account requester every time approve and/or disapprove is clicked (from an admin). Could we improve the notification process to only notify the requester the first time approve or disapprove is clicked?

PivotalTracker:  https://www.pivotaltracker.com/n/projects/1918597/stories/161488360