### PR TITLE
KG - Fix SPARCForms Permissions

### DIFF
--- a/app/assets/stylesheets/surveyor/responses.sass
+++ b/app/assets/stylesheets/surveyor/responses.sass
@@ -77,9 +77,14 @@
     align-items: center
     padding: 10px 15px
     background: $sparc-blue
-    
+  
     .columns
       order: 3
+
+      .export
+        .dropdown-toggle
+          .caret
+            display: none
 
     .bars
       flex-grow: 1

--- a/app/helpers/surveyor/responses_helper.rb
+++ b/app/helpers/surveyor/responses_helper.rb
@@ -27,9 +27,13 @@ module Surveyor::ResponsesHelper
   end
 
   def response_options(response, accessible_surveys)
+    # See https://www.pivotaltracker.com/story/show/157749896 for scenarios
+
     view_permissions =
       if response.survey.is_a?(SystemSurvey) && response.survey.system_satisfaction?
         current_user.is_site_admin?
+      elsif response.survey.is_a?(SystemSurvey)
+        current_user.is_site_admin? || accessible_surveys.include?(response.survey)
       else
         accessible_surveys.include?(response.survey)
       end
@@ -42,8 +46,7 @@ module Surveyor::ResponsesHelper
       end
 
     [ view_response_button(response, view_permissions),
-      edit_response_button(response, edit_permissions)#,
-      # download_response_button(response)
+      edit_response_button(response, edit_permissions)
     ].join('')
   end
 

--- a/app/models/system_survey.rb
+++ b/app/models/system_survey.rb
@@ -23,12 +23,15 @@ class SystemSurvey < Survey
   # 2 surveys can't have the same access code and both be active
   validates_uniqueness_of :active, scope: [:type, :access_code], if: -> { self.active }
 
+  scope :for_super_user, -> (identity) {
+    joins(:associated_surveys).
+    where(associated_surveys: {
+      associable: Organization.authorized_for_super_user(identity.id)
+    })
+  }
+
   def self.yaml_klass
     Survey.name
-  end
-
-  def self.for_super_user(identity)
-    Survey.where(id: AssociatedSurvey.where(associable: Organization.authorized_for_super_user(identity.id)).pluck(:survey_id))
   end
 
   def system_satisfaction?

--- a/app/views/surveyor/responses/index.json.jbuilder
+++ b/app/views/surveyor/responses/index.json.jbuilder
@@ -1,5 +1,5 @@
 if @type == 'Form'
-  accessible_surveys = Form.for(current_user)
+  accessible_surveys = Form.for_super_user(current_user).or(Form.for_service_provider(current_user))
 else
   accessible_surveys = SystemSurvey.for_super_user(current_user)
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157749896

Fixes a few issues with permissions in SPARCForms.

- Who should be able to view non-System Satisfaction Survey survey responses?*
  - Super Users only whose organization is associated to the SSR ( tested and problematic X)
  - The site admins should also be have the View access, b/c currently they have Edit but not View, which doesn't make sense, see screenshot 1

- Who should be able to view Form responses?
  - Super Users and Service Providers whose organization is associated to the Form (didn't pass tests X)
  - I found this logic didn't work as long as I am an catalog manager; see screenshot 2

- Who should be able to edit Form responses?
  - Super Users and Service Providers whose organization is associated to the Form (didn't pass tests X)
  - same as 5