### PR TITLE
JM - (SPARCDashboard & SPARCFulfillment) Go to Fulfillment Button Error Message

### DIFF
--- a/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
+++ b/app/assets/javascripts/dashboard/sub_service_requests.js.coffee
@@ -19,7 +19,21 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 $(document).ready ->
+  refreshFulfillmentButton = ->
+   refresh = window.setInterval((->
+      imported_to_fulfillment = $('.fulfillment_status').data('imported-to-fulfillment')
+      if imported_to_fulfillment == false
+        $("#nprogress").hide()
+        $("#ssr_fulfillment_status").load(location.href + " .fulfillment_status")
+        $("#nprogress").hide()
+      else
+        window.clearInterval refresh
+      return
+    ), 5000)
+   
   # SERVICE REQUEST INFO LISTENERS BEGIN
+  if $('#pending_fulfillment_status').is(':visible')
+    refreshFulfillmentButton()
 
   $(document).on 'change', '#sub_service_request_owner', ->
     ssr_id = $(this).data('sub_service_request_id')
@@ -56,14 +70,7 @@ $(document).ready ->
       error: (xhr, ajaxOptions, thrownError) ->
         swal('Error', 'This protocol has failed to be sent to SPARCFulfillment because of failed validation. Please make sure the service calendar is intact before trying again.', 'error')
       success: ->
-        refresh = window.setInterval((->
-          imported_to_fulfillment = $('.fulfillment_status').data('imported-to-fulfillment')
-          if imported_to_fulfillment == false
-            $("#ssr_fulfillment_status").load(location.href + " .fulfillment_status")
-          else
-            window.clearInterval refresh
-          return
-        ), 5000)
+        refreshFulfillmentButton()
 
   $(document).on 'click', '#send_to_epic_button', ->
     $(this).prop( "disabled", true )

--- a/app/assets/stylesheets/dashboard/admin_edit.sass
+++ b/app/assets/stylesheets/dashboard/admin_edit.sass
@@ -1,0 +1,23 @@
+/* Copyright © 2011-2018 MUSC Foundation for Research Development*/
+/* All rights reserved.*/
+
+/* Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:*/
+
+/* 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.*/
+
+/* 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following*/
+/* disclaimer in the documentation and/or other materials provided with the distribution.*/
+
+/* 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products*/
+/* derived from this software without specific prior written permission.*/
+
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,*/
+/* BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT*/
+/* SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL*/
+/* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS*/
+/* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR*/
+/* TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
+
+#pending_fulfillment_status
+  vertical-align: top
+  width: 12%

--- a/app/assets/stylesheets/dashboard/application.scss
+++ b/app/assets/stylesheets/dashboard/application.scss
@@ -21,6 +21,7 @@
 @import 'bootstrap-custom';
 
 // replaced require_tree .
+@import 'admin_edit';
 @import 'cover_letters';
 @import 'documents';
 @import 'epic_queues';

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -78,7 +78,10 @@ module Dashboard::SubServiceRequestsHelper
             display += link_to t(:dashboard)[:sub_service_requests][:header][:fulfillment][:go_to_fulfillment], "#{Setting.get_value("clinical_work_fulfillment_url")}/sub_service_request/#{sub_service_request.id}", target: "_blank", class: "btn btn-primary btn-md fulfillment_status"
           else
             # Pending button displayed until ssr is imported to fulfillment
-            display += button_tag t(:dashboard)[:sub_service_requests][:header][:fulfillment][:pending], data: { imported_to_fulfillment: sub_service_request.imported_to_fulfillment? }, class: "btn btn-primary btn-md form-control fulfillment_status", disabled: true
+            display += content_tag(:button, data: { imported_to_fulfillment: sub_service_request.imported_to_fulfillment? }, class: "btn btn-primary btn-md form-control fulfillment_status", disabled: true) do
+              content = content_tag(:span, "Pending")
+              content.concat image_tag 'spinner.gif', id: 'pending_fulfillment_status', class: 'pull-right'
+            end
           end
         else
           # In fulfillment, but user has no rights to view in Fulfillment


### PR DESCRIPTION
@Stuart-Johnson These are additions to https://www.pivotaltracker.com/story/show/161349235
Per stand-up on 12/12:
- Progress bar has been removed.  
- A spinner icon has been added to the pending button 

I tested the following test cases:

#1 Click "Send to Fulfillment" -> button changes to "Pending" ->(ssr imported into fulfillment) -> button changes to "Go To Fulfillment" all while remaining on the page

#2 Click "Send to Fulfillment" -> button changes to "Pending" -> Click back into the protocol -> Click "Admin Edit" on the SSR you just clicked to send to fulfillment -> button is still pending -> (ssr imported into fulfillment) -> button changes to "Go To Fulfillment"

#3 Click "Send to Fulfillment" -> button changes to "Pending" -> Click back into the protocol -> (while you're on this page, ssr has been imported into fulfillment) -> Click "Admin Edit" on the SSR you just clicked to send to fulfillment -> Button is displayed as "Go To Fulfillment"