### PR TITLE
KG - Custom Epic Queue Record Report

### DIFF
--- a/app/assets/stylesheets/dashboard/epic_queues.sass
+++ b/app/assets/stylesheets/dashboard/epic_queues.sass
@@ -28,13 +28,18 @@
 th.text-primary
   color: #fff
 
-.epic-queue-records-table
+#epic-queue-panel
+  .export
+    .dropdown-toggle
+      .caret
+        display: none
 
-  .black-note
-    color: black
+  .epic-queue-records-table
+    .black-note
+      color: black
 
-  .blue-note
-    color: blue
+    .blue-note
+      color: blue
 
-  .blue-badge
-    background-color: blue
+    .blue-badge
+      background-color: blue

--- a/app/controllers/dashboard/epic_queue_records_controller.rb
+++ b/app/controllers/dashboard/epic_queue_records_controller.rb
@@ -27,6 +27,9 @@ class Dashboard::EpicQueueRecordsController < Dashboard::BaseController
 
     respond_to do |format|
       format.json
+      format.xlsx {
+        response.headers['Content-Disposition'] = "attachment; filename=\"#{@type} Epic Queue Records.xlsx\""
+      }
     end
   end
 

--- a/app/views/dashboard/epic_queue_records/index.xlsx.axlsx
+++ b/app/views/dashboard/epic_queue_records/index.xlsx.axlsx
@@ -18,36 +18,21 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$(document).ready ->
+wb      = xlsx_package.workbook
+header  = wb.styles.add_style alignment: { horizontal: :center, vertical: :center }, b: true
 
-  $('.epic-queue-table').bootstrapTable()
-  $('.epic-queue-records-table').bootstrapTable()
+wb.add_worksheet(name: "Epic Queue Records") do |sheet|
+  sheet.add_row [t(:epic_queues)[:sent_protocols], t(:epic_queues)[:notes], t(:epic_queues)[:PIs], t(:epic_queues)[:date], t(:epic_queues)[:status], t(:epic_queues)[:type], t(:epic_queues)[:by]], style: [header, header, header, header, header, header, header]
 
-  $(document).on 'click', '.delete-epic-queue-button', ->
-    if confirm(I18n['epic_queues']['confirm'])
-      eq_id = $(this).data('epic-queue-id')
-      $.ajax
-        type: 'DELETE'
-        url: "/dashboard/epic_queues/#{eq_id}.js"
-
-  $('.epic-queue-table').on 'click-cell.bs.table', (field, value, row, $element) ->
-    if value == 'protocol'
-      protocolId = $element.protocol_id
-      window.open("/dashboard/protocols/#{protocolId}")
-
-  $('.epic-queue-records-table').on 'click-cell.bs.table', (field, value, row, $element) ->
-    if value == 'protocol'
-      protocolId = $element.protocol_id
-      window.open("/dashboard/protocols/#{protocolId}")
-
-  $(document).on 'click', '.push-to-epic', (e) ->
-    e.preventDefault()
-    protocol_id = $(this).data('protocol-id')
-    eq_id = $(this).data('eq-id')
-    $.ajax
-      type: 'GET'
-      url: "/protocols/#{protocol_id}/push_to_epic.js?from_portal=true&&eq_id=#{eq_id}"
-
-  $(document).on 'click', '#epic-queue-panel .export button', ->
-    $(this).parent().removeClass('open')
-    window.location = '/dashboard/epic_queue_records.xlsx'
+  @epic_queue_records.each do |eqr|
+    sheet.add_row [
+      format_protocol(eqr.protocol),
+      eqr.notes.length,
+      format_pis(eqr.protocol),
+      format_epic_queue_created_at(eqr),
+      eqr.status.capitalize,
+      eqr.origin.try(:titleize),
+      eqr.try(:identity).try(:full_name)
+    ]
+  end
+end

--- a/app/views/dashboard/epic_queues/_epic_queue_records_table.html.haml
+++ b/app/views/dashboard/epic_queues/_epic_queue_records_table.html.haml
@@ -20,7 +20,7 @@
 
 .bootstrap-table-dropdown-overflow
   #epic-queues-custom-toolbar
-  %table.epic-queue-records-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', 'show-export' => 'true', "export-types" => ['excel'], pagination: 'true', side_pagination: 'server', url: dashboard_epic_queue_records_path, striped: 'true', toolbar: '#epic-queues-custom-toolbar' } }
+  %table.epic-queue-records-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', 'show-toggle' => 'true', 'show-export' => 'true', pagination: 'true', side_pagination: 'server', url: dashboard_epic_queue_records_path, striped: 'true', toolbar: '#epic-queues-custom-toolbar' } }
     %thead.primary-header
       %tr
         %th{data: { field: "protocol", align: "left", sortable: 'true', class: 'text-primary' } }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157629044

Since paginating the epic queues tables with server-side pagination to improve load times, the table export only shows the records for the current page in the table. This is because the export is front-end only, so it only takes into account the records that it already has. This custom excel export simply mimics the current export format.