### PR TITLE
KG - Forms Fixes

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -22,7 +22,6 @@ class FormsController < ApplicationController
   respond_to :json
 
   before_action :initialize_service_request
-  before_action :authorize_identity
 
   def index
     @forms  = params[:complete] == 'true' ? @service_request.completed_forms : @service_request.associated_forms

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -221,8 +221,8 @@ module Dashboard::SubServiceRequestsHelper
   def display_ssr_submissions(ssr)
     forms                     = ssr.forms_to_complete
     form_list                 = {}
-    form_list[:Organization]  = [] if forms.detect{ |f| f.surveyable_type == 'Organization' }
-    form_list[:Service]       = [] if forms.detect{ |f| f.surveyable_type == 'Service' }
+    form_list[:Organization]  = [] if forms.any?{ |f| f.surveyable_type == 'Organization' }
+    form_list[:Service]       = [] if forms.any?{ |f| f.surveyable_type == 'Service' }
 
     forms.each do |f|
       form_list[f.surveyable_type.to_sym] << [f.surveyable.name, f.surveyable.name, data: { type: 'Form', survey_id: f.id, respondable_id: ssr.id, respondable_type: 'SubServiceRequest' }]

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -41,15 +41,30 @@ class Form < Survey
   }
 
   scope :for_super_user, -> (identity) {
-    where(surveyable: Organization.authorized_for_super_user(identity.id))
+    orgs      = Organization.authorized_for_super_user(identity.id)
+    services  = Service.where(organization: orgs)
+
+    where(surveyable: orgs).
+    or(where(surveyable: services)).
+    or(where(surveyable: identity))
   }
 
   scope :for_service_provider, -> (identity) {
-    where(surveyable: Organization.authorized_for_service_provider(identity.id))
+    orgs      = Organization.authorized_for_service_provider(identity.id)
+    services  = Service.where(organization: orgs)
+
+    where(surveyable: orgs).
+    or(where(surveyable: services)).
+    or(where(surveyable: identity))
   }
 
   scope :for_catalog_manager, -> (identity) {
-    where(surveyable: Organization.authorized_for_catalog_manager(identity.id))
+    orgs      = Organization.authorized_for_catalog_manager(identity.id)
+    services  = Service.where(organization: orgs)
+
+    where(surveyable: orgs).
+    or(where(surveyable: services)).
+    or(where(surveyable: identity))
   }
 
   def self.yaml_klass

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -410,8 +410,8 @@ class ServiceRequest < ApplicationRecord
     forms = []
     # Because there can be multiple SSRs with the same services/organizations we need to loop over each one
     self.sub_service_requests.each do |ssr|
-      Form.where(surveyable: ssr.organization).active.each{ |f| forms << [f, ssr] }
-      Form.where(surveyable: ssr.services).active.each{ |f| forms << [f, ssr] }
+      ssr.organization_forms.each{ |f| forms << [f, ssr] }
+      ssr.service_forms.each{ |f| forms << [f, ssr] }
     end
     forms
   end
@@ -420,8 +420,8 @@ class ServiceRequest < ApplicationRecord
     forms = []
     # Because there can be multiple SSRs with the same services/organizations we need to loop over each one
     self.sub_service_requests.each do |ssr|
-      Form.where(surveyable: ssr.organization).active.joins(:responses).where(responses: { respondable: ssr }).each{ |f| forms << [f, ssr] }
-      Form.where(surveyable: ssr.services).active.joins(:responses).where(responses: { respondable: ssr }).each{ |f| forms << [f, ssr] }
+      ssr.organization_forms.joins(:responses).where(responses: { respondable: ssr }).each{ |f| forms << [f, ssr] }
+      ssr.service_forms.joins(:responses).where(responses: { respondable: ssr }).each{ |f| forms << [f, ssr] }
     end
     forms
   end

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -432,7 +432,7 @@ class SubServiceRequest < ApplicationRecord
   end
 
   def all_forms_completed?
-    (self.service_forms + self.organization_forms).count == self.responses.count
+    (self.service_forms + self.organization_forms).count == self.responses.joins(:survey).where(surveys: { type: 'Form' }).count
   end
 
   ##########################

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -942,6 +942,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_192700) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.boolean "access_empty_protocols", default: false
     t.index ["identity_id"], name: "index_super_users_on_identity_id"
     t.index ["organization_id"], name: "index_super_users_on_organization_id"
   end

--- a/spec/controllers/forms/get_index_spec.rb
+++ b/spec/controllers/forms/get_index_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe FormsController, type: :controller do
       expect(before_filters.include?(:initialize_service_request)).to eq(true)
     end
 
-    it 'should call before_filter #authorize_identity' do
-      expect(before_filters.include?(:authorize_identity)).to eq(true)
-    end
-
     context "params[:complete] == 'false'" do
       it 'should assign @forms to the service request\'s associated forms' do
         org       = create(:provider)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157749896

Issues Addressed:
- The scopes on the Form model incorrectly searched only for Forms associated with Organizations and not for Services
- In SPARCDashboard, the Forms column on the service requests table would display if the SSR had incomplete SURVEY responses, not just FORM responses
- In SPARCDashboard, the Forms table failed authorization and would redirect when calling `authorize_identity`, causing the table to be empty.