### PR TITLE
KG - Epic Queue Table Search

### DIFF
--- a/app/controllers/dashboard/epic_queue_records_controller.rb
+++ b/app/controllers/dashboard/epic_queue_records_controller.rb
@@ -23,7 +23,7 @@ class Dashboard::EpicQueueRecordsController < Dashboard::BaseController
   def index
     @epic_queue_records = EpicQueueRecord.with_valid_protocols.
                             eager_load(:identity, :notes, protocol: :principal_investigators).
-                            ordered(params[:sort], params[:order])
+                            search(params[:search]).ordered(params[:sort], params[:order])
 
     respond_to do |format|
       format.json

--- a/app/controllers/dashboard/epic_queues_controller.rb
+++ b/app/controllers/dashboard/epic_queues_controller.rb
@@ -36,7 +36,7 @@ class Dashboard::EpicQueuesController < Dashboard::BaseController
           else
             EpicQueue.where(attempted_push: false, user_change: false)
           end.eager_load(:identity, protocol: :principal_investigators).
-              ordered(params[:sort], params[:order])
+              search(params[:search]).ordered(params[:sort], params[:order])
       }
     end
   end

--- a/app/models/epic_queue.rb
+++ b/app/models/epic_queue.rb
@@ -24,6 +24,34 @@ class EpicQueue < ApplicationRecord
   belongs_to :protocol
   belongs_to :identity
 
+  scope :search, -> (term) {
+    return if term.blank?
+
+    records = includes(:protocol).where(
+      Protocol.arel_table[:type].matches("%#{term}%")
+    ).or(
+      includes(:protocol).where(Protocol.arel_table[:id].matches(term))
+    ).or(
+      includes(:protocol).where(Protocol.arel_table[:short_title].matches("%#{term}%"))
+    ).or(
+      includes(:protocol).where(Protocol.arel_table[:last_epic_push_status].matches("%#{term}%"))
+    )
+
+    identity_records = includes(:identity).where(
+      Identity.arel_table[:first_name].matches("%#{term}%")
+    ).or(
+      includes(:identity).where(Identity.arel_table[:last_name].matches("%#{term}%"))
+    )
+
+    pi_records = unscoped.joins(protocol: :principal_investigators).where(
+      Identity.arel_table[:first_name].matches("%#{term}%")
+    ).or(
+      unscoped.joins(protocol: :principal_investigators).where(Identity.arel_table[:last_name].matches("%#{term}%"))
+    )
+
+    where(id: records + identity_records + pi_records).distinct
+  }
+
   scope :ordered, -> (sort, order) {
     if sort
       case sort

--- a/app/models/epic_queue_record.rb
+++ b/app/models/epic_queue_record.rb
@@ -26,6 +26,36 @@ class EpicQueueRecord < ApplicationRecord
   
   audited
 
+  scope :search, -> (term) {
+    return if term.blank?
+
+    records = includes(:protocol).where(
+      self.arel_table[:status].matches("%#{term}%")
+    ).or(
+      includes(:protocol).where(self.arel_table[:origin].matches("%#{term}%"))
+    ).or(
+      includes(:protocol).where(Protocol.arel_table[:type].matches("%#{term}%"))
+    ).or(
+      includes(:protocol).where(Protocol.arel_table[:id].matches(term))
+    ).or(
+      includes(:protocol).where(Protocol.arel_table[:short_title].matches("%#{term}%"))
+    )
+
+    identity_records = includes(:identity).where(
+      Identity.arel_table[:first_name].matches("%#{term}%")
+    ).or(
+      includes(:identity).where(Identity.arel_table[:last_name].matches("%#{term}%"))
+    )
+
+    pi_records = unscoped.joins(protocol: :principal_investigators).where(
+      Identity.arel_table[:first_name].matches("%#{term}%")
+    ).or(
+      unscoped.joins(protocol: :principal_investigators).where(Identity.arel_table[:last_name].matches("%#{term}%"))
+    )
+
+    where(id: records + identity_records + pi_records).distinct
+  }
+
   scope :ordered, -> (sort, order) {
     if sort
       case sort


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/157629044

After changing the Epic Queue tables to use server-side pagination, the built-in Bootstrap table search no longer works. I added search scopes for both models.
