### PR TITLE
KG - Epic Queue Protocol Link Bug

### DIFF
--- a/app/assets/javascripts/dashboard/epic_queues.js.coffee
+++ b/app/assets/javascripts/dashboard/epic_queues.js.coffee
@@ -30,12 +30,7 @@ $(document).ready ->
         type: 'DELETE'
         url: "/dashboard/epic_queues/#{eq_id}.js"
 
-  $('.epic-queue-table').on 'click-cell.bs.table', (field, value, row, $element) ->
-    if value == 'protocol'
-      protocolId = $element.protocol_id
-      window.open("/dashboard/protocols/#{protocolId}")
-
-  $('.epic-queue-records-table').on 'click-cell.bs.table', (field, value, row, $element) ->
+  $(document).on 'click-cell.bs.table', '.epic-queue-table, .epic-queue-records-table', (field, value, row, $element) ->
     if value == 'protocol'
       protocolId = $element.protocol_id
       window.open("/dashboard/protocols/#{protocolId}")

--- a/app/views/dashboard/epic_queue_records/index.json.jbuilder
+++ b/app/views/dashboard/epic_queue_records/index.json.jbuilder
@@ -1,12 +1,13 @@
 json.total @epic_queue_records.count
 json.rows do
   json.(@epic_queue_records.limit(params[:limit]).offset(params[:offset])) do |eqr|
-    json.protocol format_protocol(eqr.protocol)
-    json.notes    notes_button(eqr)
-    json.pis      format_pis(eqr.protocol)
-    json.date     format_epic_queue_created_at(eqr)
-    json.status   eqr.status.capitalize
-    json.type     eqr.origin.try(:titleize)
-    json.by       eqr.try(:identity).try(:full_name)
+    json.protocol_id  eqr.protocol_id
+    json.protocol     format_protocol(eqr.protocol)
+    json.notes        notes_button(eqr)
+    json.pis          format_pis(eqr.protocol)
+    json.date         format_epic_queue_created_at(eqr)
+    json.status       eqr.status.capitalize
+    json.type         eqr.origin.try(:titleize)
+    json.by           eqr.try(:identity).try(:full_name)
   end
 end

--- a/app/views/dashboard/epic_queues/index.json.jbuilder
+++ b/app/views/dashboard/epic_queues/index.json.jbuilder
@@ -1,13 +1,14 @@
 json.total @epic_queues.count
 json.rows do
   json.(@epic_queues.limit(params[:limit]).offset(params[:offset])) do |eq|
-    json.protocol         format_protocol(eq.protocol)
-    json.pis              format_pis(eq.protocol)
-    json.date             format_epic_queue_date(eq.protocol)
-    json.status           format_status(eq.protocol)
-    json.delete           epic_queue_delete_button(eq)
-    json.created_at       format_epic_queue_created_at(eq)
-    json.name             eq.identity.full_name
-    json.send             epic_queue_send_button(eq)
+    json.protocol_id  eq.protocol_id
+    json.protocol     format_protocol(eq.protocol)
+    json.pis          format_pis(eq.protocol)
+    json.date         format_epic_queue_date(eq.protocol)
+    json.status       format_status(eq.protocol)
+    json.delete       epic_queue_delete_button(eq)
+    json.created_at   format_epic_queue_created_at(eq)
+    json.name         eq.identity.full_name
+    json.send         epic_queue_send_button(eq)
   end
 end


### PR DESCRIPTION
The protocol links in the Epic Queue/Epic Queue Records tables did not work because they were missing the JSON attribute `protocol_id`.