### PR TITLE
KG - Pre-populate RMID Data When Editing Protocol

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -18,6 +18,29 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+(exports ? this).updateRmidFields = () ->
+  rmId = $('.research-master-field').val()
+  unless rmId == ''
+    $.ajax
+      url: "#{gon.rm_id_api_url}research_masters/#{rmId}.json"
+      type: 'GET'
+      headers: {"Authorization": "Token token=\"#{gon.rm_id_api_token}\""}
+      success: (data) ->
+        $('#protocol_short_title').val(data.short_title)
+        $('#protocol_title').val(data.long_title)
+        if data.eirb_validated
+          $('#protocol_human_subjects_info_attributes_pro_number').val(data.eirb_pro_number)
+          $('#protocol_human_subjects_info_attributes_initial_irb_approval_date').val(data.date_initially_approved)
+          $('#protocol_human_subjects_info_attributes_irb_approval_date').val(data.date_approved)
+          $('#protocol_human_subjects_info_attributes_irb_expiration_date').val(data.date_expiration)
+          toggleFields('.rm-locked-fields', true)
+        else
+          toggleFields('.rm-locked-fields:not(.hr-field)', true)
+      error: ->
+        swal("Error", "Research Master Record not found", "error")
+        resetRmIdFields('.rm-id-dependent', '')
+        toggleFields('.rm-locked-fields', false)
+
 toggleFields = (fields, state) ->
   $(fields).prop('disabled', state)
 
@@ -58,28 +81,10 @@ $(document).ready ->
     else
       $('.rm-id').addClass('required')
 
+  updateRmidFields()
+
   $(document).on 'blur', '.research-master-field', ->
-    rmId = $('.research-master-field').val()
-    unless $(this).val() == ''
-      $.ajax
-        url: "#{gon.rm_id_api_url}research_masters/#{rmId}.json"
-        type: 'GET'
-        headers: {"Authorization": "Token token=\"#{gon.rm_id_api_token}\""}
-        success: (data) ->
-          $('#protocol_short_title').val(data.short_title)
-          $('#protocol_title').val(data.long_title)
-          if data.eirb_validated
-            $('#protocol_human_subjects_info_attributes_pro_number').val(data.eirb_pro_number)
-            $('#protocol_human_subjects_info_attributes_initial_irb_approval_date').val(data.date_initially_approved)
-            $('#protocol_human_subjects_info_attributes_irb_approval_date').val(data.date_approved)
-            $('#protocol_human_subjects_info_attributes_irb_expiration_date').val(data.date_expiration)
-            toggleFields('.rm-locked-fields', true)
-          else
-            toggleFields('.rm-locked-fields:not(.hr-field)', true)
-        error: ->
-          swal("Error", "Research Master Record not found", "error")
-          resetRmIdFields('.rm-id-dependent', '')
-          toggleFields('.rm-locked-fields', false)
+    updateRmidFields()
 
   $(document).on 'change', '.research-master-field', ->
     if $(this).val() == ''

--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -20,7 +20,7 @@
 
 (exports ? this).updateRmidFields = () ->
   rmId = $('.research-master-field').val()
-  unless rmId == ''
+  if rmId
     $.ajax
       url: "#{gon.rm_id_api_url}research_masters/#{rmId}.json"
       type: 'GET'

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -128,17 +128,6 @@ class Protocol < ApplicationRecord
     self.bypass_rmid_validation ? false : Setting.get_value('research_master_enabled') && has_human_subject_info?
   end
 
-  def eirb_validated?
-    @validated ||= Setting.get_value("research_master_enabled") &&
-      begin
-        research_master = HTTParty.get(Setting.get_value("research_master_api") + "research_masters/#{self.research_master_id}.json", headers: {'Content-Type' => 'application/json', 'Authorization' => "Token token=\"#{Setting.get_value("rmid_api_token")}\""})
-
-        research_master['eirb_validated']
-      rescue
-        return false
-      end
-  end
-
   def has_human_subject_info?
     self.research_types_info.try(:human_subjects) || false
   end

--- a/app/views/dashboard/protocols/form/study_form_sections/_research_involving.html.haml
+++ b/app/views/dashboard/protocols/form/study_form_sections/_research_involving.html.haml
@@ -51,7 +51,7 @@
           .form-group.row
             = hs_form.label :pro_number, t(:protocols)[:studies][:research_involving][:humans][:pro_number], class: 'col-lg-2 control-label', data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' }, title: t(:protocols)[:tooltips][:pro_number]
             .col-lg-10
-              = hs_form.text_field :pro_number, class: ['form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?
+              = hs_form.text_field :pro_number, class: ['form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : '']
 
           .form-group.row
             = hs_form.label :irb_of_record, t(:protocols)[:studies][:research_involving][:humans][:record_irb], class: 'col-lg-2 control-label'
@@ -71,17 +71,17 @@
           .form-group.row.initial_irb_approval_date
             = hs_form.label :initial_irb_approval_date, t(:protocols)[:studies][:research_involving][:humans][:initial_irb_approval_date], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :initial_irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?, value: (protocol.human_subjects_info.initial_irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
+              = hs_form.text_field :initial_irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], value: (protocol.human_subjects_info.initial_irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
 
           .form-group.row.irb_approval_date
             = hs_form.label :irb_approval_date, t(:protocols)[:studies][:research_involving][:humans][:irb_approval_date], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?, value: (protocol.human_subjects_info.irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
+              = hs_form.text_field :irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], value: (protocol.human_subjects_info.irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
 
           .form-group.row.irb_expiration_date
             = hs_form.label :irb_expiration_date, t(:protocols)[:studies][:research_involving][:humans][:irb_expiration_date], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :irb_expiration_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?, value: (protocol.human_subjects_info.irb_expiration_date.strftime('%_m/%d/%Y') rescue nil)
+              = hs_form.text_field :irb_expiration_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], value: (protocol.human_subjects_info.irb_expiration_date.strftime('%_m/%d/%Y') rescue nil)
 
           .form-group.row
             = form.label :study_phase, t(:protocols)[:studies][:information][:phase], class: 'col-lg-2 control-label'

--- a/app/views/protocols/form/study_form_sections/_research_involving.html.haml
+++ b/app/views/protocols/form/study_form_sections/_research_involving.html.haml
@@ -51,7 +51,7 @@
           .form-group.row
             = hs_form.label :pro_number, t(:protocols)[:studies][:research_involving][:humans][:pro_number], class: 'col-lg-2 control-label', data: { toggle: 'tooltip', placement: 'right', delay: '{"show":"500"}' }, title: t(:protocols)[:tooltips][:pro_number]
             .col-lg-10
-              = hs_form.text_field :pro_number, class: ['form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?
+              = hs_form.text_field :pro_number, class: ['form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : '']
 
           .form-group.row
             = hs_form.label :irb_of_record, t(:protocols)[:studies][:research_involving][:humans][:record_irb], class: 'col-lg-2 control-label'
@@ -71,17 +71,17 @@
           .form-group.row.initial_irb_approval_date
             = hs_form.label :initial_irb_approval_date, t(:protocols)[:studies][:research_involving][:humans][:initial_irb_approval_date], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :initial_irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?, value: (protocol.human_subjects_info.initial_irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
+              = hs_form.text_field :initial_irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], value: (protocol.human_subjects_info.initial_irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
 
           .form-group.row.irb_approval_date
             = hs_form.label :irb_approval_date, t(:protocols)[:studies][:research_involving][:humans][:irb_approval_date], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?, value: (protocol.human_subjects_info.irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
+              = hs_form.text_field :irb_approval_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], value: (protocol.human_subjects_info.irb_approval_date.strftime('%_m/%d/%Y') rescue nil)
 
           .form-group.row.irb_expiration_date
             = hs_form.label :irb_expiration_date, t(:protocols)[:studies][:research_involving][:humans][:irb_expiration_date], class: 'col-lg-2 control-label'
             .col-lg-10
-              = hs_form.text_field :irb_expiration_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], disabled: protocol.eirb_validated?, value: (protocol.human_subjects_info.irb_expiration_date.strftime('%_m/%d/%Y') rescue nil)
+              = hs_form.text_field :irb_expiration_date, class: ['datetimepicker form-control', Setting.get_value("research_master_enabled") ? 'rm-id-dependent rm-locked-fields hr-field' : ''], value: (protocol.human_subjects_info.irb_expiration_date.strftime('%_m/%d/%Y') rescue nil)
 
           .form-group.row
             = form.label :study_phase, t(:protocols)[:studies][:information][:phase], class: 'col-lg-2 control-label'

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -671,7 +671,7 @@
   },
   {
     "key":            "remote_service_notifier_host",
-    "value":          "http://127.0.0.1:5001",
+    "value":          "127.0.0.1:5001",
     "friendly_name":  "Remote Service Notifier",
     "description":    "This is the host domain of the SPARCRequest API.",
     "group":          "",

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -371,7 +371,7 @@
   },
   {
     "key":            "host",
-    "value":          "http://127.0.0.1:5000",
+    "value":          "127.0.0.1:5000",
     "friendly_name":  "Host",
     "description":    "This is the host domain of your instance of SPARCRequest.",
     "group":          "",

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -51,7 +51,7 @@
   },
   {
     "key":            "clinical_work_fulfillment_url",
-    "value":          "127.0.0.1:6000",
+    "value":          "http://127.0.0.1:6000",
     "friendly_name":  "Clinical Work Fulfillment URL",
     "description":    "This is the URL of your institution's SPARCFulfillment application.",
     "group":          "",
@@ -311,7 +311,7 @@
   },
   {
     "key":            "header_link_2_proper",
-    "value":          "127.0.0.1:3000",
+    "value":          "http://127.0.0.1:3000",
     "friendly_name":  "Header Logo 2 URL (SPARCRequest)",
     "description":    "This is the URL for the \"SPARCRequest Logo\" in the SPARCRequest header.",
     "group":          "",
@@ -321,7 +321,7 @@
   },
   {
     "key":            "header_link_2_dashboard",
-    "value":          "127.0.0.1:3000/dashboard",
+    "value":          "http://127.0.0.1:3000/dashboard",
     "friendly_name":  "Header Logo 2 URL (SPARCDashboard)",
     "description":    "This is the URL for the \"SPARCDashboard Logo\" in the SPARCDashboard header.",
     "group":          "",
@@ -331,7 +331,7 @@
   },
   {
     "key":            "header_link_2_catalog",
-    "value":          "127.0.0.1:3000/catalog_manager",
+    "value":          "http://127.0.0.1:3000/catalog_manager",
     "friendly_name":  "Header Logo 2 URL (SPARCCatalog)",
     "description":    "This is the URL for the \"SPARCCatalog Logo\" in the SPARCCatalog header.",
     "group":          "",
@@ -371,7 +371,7 @@
   },
   {
     "key":            "host",
-    "value":          "127.0.0.1:5000",
+    "value":          "http://127.0.0.1:5000",
     "friendly_name":  "Host",
     "description":    "This is the host domain of your instance of SPARCRequest.",
     "group":          "",
@@ -521,7 +521,7 @@
   },
   {
     "key":            "navbar_links",
-    "value":          "{ \"sparc_request\": [\"SPARCRequest\", \"127.0.0.1:3000/\"], \"sparc_dashboard\": [\"SPARCDashboard\", \"127.0.0.1:3000/dashboard\"], \"sparc_fulfillment\": [\"SPARCFulfillment\", \"https://cwf-d.obis.musc.edu/identities/sign_in\"], \"sparc_catalog\": [\"SPARCCatalog\", \"127.0.0.1:3000/catalog_manager\"], \"sparc_report\": [\"SPARCReport\", \"127.0.0.1:3000/reports\"], \"sparc_forms\": [\"SPARCForms\", \"127.0.0.1:3000/surveyor/responses\"] }",
+    "value":          "{ \"sparc_request\": [\"SPARCRequest\", \"http://127.0.0.1:3000/\"], \"sparc_dashboard\": [\"SPARCDashboard\", \"http://127.0.0.1:3000/dashboard\"], \"sparc_fulfillment\": [\"SPARCFulfillment\", \"https://cwf-d.obis.musc.edu/identities/sign_in\"], \"sparc_catalog\": [\"SPARCCatalog\", \"http://127.0.0.1:3000/catalog_manager\"], \"sparc_report\": [\"SPARCReport\", \"http://127.0.0.1:3000/reports\"], \"sparc_forms\": [\"SPARCForms\", \"http://127.0.0.1:3000/surveyor/responses\"] }",
     "friendly_name":  "Navbar Links",
     "description":    "This defines the links that appear in the header navbar. New links may be added by using the following syntax: \"key\": [\"Link Text\", \"Full URL\"].",
     "group":          "",
@@ -671,7 +671,7 @@
   },
   {
     "key":            "remote_service_notifier_host",
-    "value":          "127.0.0.1:5001",
+    "value":          "http://127.0.0.1:5001",
     "friendly_name":  "Remote Service Notifier",
     "description":    "This is the host domain of the SPARCRequest API.",
     "group":          "",
@@ -721,7 +721,7 @@
   },
   {
     "key":            "research_master_api",
-    "value":          "127.0.0.1:4000/api/",
+    "value":          "http://127.0.0.1:4000/api/",
     "friendly_name":  "Research Master API URL",
     "description":    "This is the URL of your institution's RMID API.",
     "group":          "",
@@ -741,7 +741,7 @@
   },
   {
     "key":            "research_master_link",
-    "value":          "127.0.0.1:4000",
+    "value":          "http://127.0.0.1:4000",
     "friendly_name":  "Research Master ID URL",
     "description":    "This is the URL of your institution's RMID application.",
     "group":          "",
@@ -761,7 +761,7 @@
   },
   {
     "key":            "root_url",
-    "value":          "127.0.0.1:3000",
+    "value":          "http://127.0.0.1:3000",
     "friendly_name":  "Root URL",
     "description":    "This is the root URL for the application for use in emails.",
     "group":          "",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156204327

When editing a protocol with an RMID, the current data (short title, title, PRO#, dates) should be pulled from RMID and populated. Since I was able to do this using existing Javascript that disables the fields, I removed the code that I had previously added from the views and model.