### PR TITLE
KG - Fix Protocols Reporting Investigational Devices

### DIFF
--- a/app/lib/reports/protocols.rb
+++ b/app/lib/reports/protocols.rb
@@ -82,7 +82,7 @@ class ProtocolsReport < ReportingModule
 
     if params[:show_device_cols]
       attrs["IND #"]            = "service_request.try(:protocol).try(:investigational_products_info).try(:ind_number)"
-      attrs["IDE/HDE/HUD Type"] = "InvestigationalProductsInfo::EXEMPTION_TYPES[service_request.try(:protocol).try(:investigational_products_info).try(:exemption_type)]"
+      attrs["IDE/HDE/HUD Type"] = "InvestigationalProductsInfo::EXEMPTION_TYPES.detect{ |et| et == service_request.try(:protocol).try(:investigational_products_info).try(:exemption_type) }"
       attrs["IDE/HDE/HUD #"]    = "service_request.try(:protocol).try(:investigational_products_info).try(:inv_device_number)"
     end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160636468

I had originally changed `EXEMPTION_TYPES` to a hash but after spec failures decided to change it back but forgot to change it back in the report.