### PR TITLE
KG - Related Service Search Display Bug and Optimization

### DIFF
--- a/app/assets/javascripts/catalog_manager/catalog.js.coffee
+++ b/app/assets/javascripts/catalog_manager/catalog.js.coffee
@@ -277,10 +277,19 @@ window.initialize_related_services_search = () ->
       source: services_bloodhound,
       limit: 100,
       templates: {
-        suggestion: Handlebars.compile('<button class="text-left">
-                                          <strong><span class="text-service">Service</span><span>: {{name}}</span></strong><br>
-                                          {{{breadcrumb}}}<br>
-                                          <span>{{cpt_code}}</span><br>
+        suggestion: Handlebars.compile('<button class="service text-left" data-container="body" data-placement="right" data-toggle="tooltip" data-animation="false" data-html="true" title="{{description}}">
+                                          <h5 class="service-name col-sm-12 no-padding no-margin"><span class="text-service">Service</span><span>: {{label}}</span></h5>
+                                          <span class="col-sm-12 no-padding">{{{breadcrumb}}}</span>
+                                          <span class="col-sm-12 no-padding"><strong>Abbreviation:</strong> {{abbreviation}}</span>
+                                          {{#if cpt_code_text}}
+                                            {{{cpt_code_text}}}
+                                          {{/if}}
+                                          {{#if eap_id_text}}
+                                            {{{eap_id_text}}}
+                                          {{/if}}
+                                          {{#if pricing_text}}
+                                            {{{pricing_text}}}
+                                          {{/if}}
                                         </button>')
         notFound: '<div class="tt-suggestion">No Results</div>'
       }
@@ -290,8 +299,8 @@ window.initialize_related_services_search = () ->
     existing_services = $("[id*='service-relation-id-']").map ->
       return $(this).data('related-service-id')
 
-    if suggestion['id'] in existing_services
-      $('#new_related_services_search').parent().prepend("<div class='alert alert-danger alert-dismissable'>#{suggestion['name']} #{I18n['catalog_manager']['related_services_form']['service_in_list']}</div>")
+    if suggestion.value in existing_services
+      $('#new_related_services_search').parent().prepend("<div class='alert alert-danger alert-dismissable'>#{suggestion.label} #{I18n['catalog_manager']['related_services_form']['service_in_list']}</div>")
       $('.alert-dismissable').delay(3000).fadeOut()
     else
       $.ajax
@@ -299,5 +308,5 @@ window.initialize_related_services_search = () ->
         url: '/catalog_manager/services/add_related_service'
         data:
           service_id: $(this).data('service-id')
-          related_service_id: suggestion.id
+          related_service_id: suggestion.value
 );

--- a/app/controllers/catalog_manager/app_controller.rb
+++ b/app/controllers/catalog_manager/app_controller.rb
@@ -19,14 +19,15 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # named AppController because Devise was having problems when it was named the same as the main ApplicationController
-class CatalogManager::AppController < ActionController::Base
+class CatalogManager::AppController < ApplicationController
   layout 'catalog_manager/application'
+
   protect_from_forgery
+
   helper_method :current_user
 
   before_action :authenticate_identity!
   before_action :set_user
-  before_action :set_highlighted_link
   before_action :check_access_rights
 
   def set_highlighted_link

--- a/spec/features/catalog_manager/service_forms/related_services/user_adds_related_service_spec.rb
+++ b/spec/features/catalog_manager/service_forms/related_services/user_adds_related_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'User adds new related service', js: true do
     fill_in 'new_related_services_search', with: @rel_serv.name
     page.execute_script %Q{ $('#new_related_services_search').trigger("keydown") }
     expect(page).to have_selector('.tt-suggestion')
-    binding.pry
+
     first('.tt-suggestion').click
     wait_for_javascript_to_finish
   end

--- a/spec/features/catalog_manager/service_forms/related_services/user_adds_related_service_spec.rb
+++ b/spec/features/catalog_manager/service_forms/related_services/user_adds_related_service_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe 'User adds new related service', js: true do
   fake_login_for_each_test
 
   before :each do
-    @institution  = create(:institution)
-    @provider     = create(:provider, parent: @institution)
-    @program      = create(:program, parent: @provider)
-    @service      = create(:service, organization: @program)
-    @rel_serv     = create(:service, organization: @program)
+    @institution  = create(:institution, :with_pricing_setup)
+    @provider     = create(:provider, :with_pricing_setup, parent: @institution)
+    @program      = create(:program, :with_pricing_setup, parent: @provider)
+    @service      = create(:service, :with_pricing_map, organization: @program)
+    @rel_serv     = create(:service, :with_pricing_map, organization: @program)
     create(:catalog_manager, organization: @institution, identity: jug2)
 
     visit catalog_manager_catalog_index_path
@@ -47,7 +47,7 @@ RSpec.describe 'User adds new related service', js: true do
     fill_in 'new_related_services_search', with: @rel_serv.name
     page.execute_script %Q{ $('#new_related_services_search').trigger("keydown") }
     expect(page).to have_selector('.tt-suggestion')
-
+    binding.pry
     first('.tt-suggestion').click
     wait_for_javascript_to_finish
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163828438

After changes affecting the other two service searches (Catalog Manager and Service Catalog) the related service search appeared incorrectly.

I fixed the results to be consistent with the other searches, added eager_loading in the controller to remove n+1 queries, and also noticed settings were not being cached in catalog manager as `CatalogManager::AppController` did not inherit from `ApplicationController` as it should.