### PR TITLE
ML - add padding below steps

### DIFF
--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -100,8 +100,11 @@ $core-blue: #003366
     @media (min-width: 1300px)
       width: 1300px
 
-    .steps, .step-header, .body-container
+    .steps, .body-container
       margin-bottom: 20px
+
+    .step-header
+      margin-bottom: 60px
 
 .footer
   margin-left: auto


### PR DESCRIPTION
Re: the 'About SPARCRequest' button removal

"the logo is removed on -d,but our home page seems a little busier. Could you add some blank space between the Step1 header and the search bar to make it more appealing?"