### PR TITLE
KG - Admin Edit Remove Service (Line Item) Bug

### DIFF
--- a/app/assets/javascripts/dashboard/study_schedule_management.js.coffee
+++ b/app/assets/javascripts/dashboard/study_schedule_management.js.coffee
@@ -211,29 +211,14 @@ $ ->
     $("#add_line_items_form_button").attr('disabled','disabled')
 
   $(document).on 'click', '#remove_service_button', ->
-    line_item_count = $('#study_schedule_buttons').data('line-item-count')
-    data =
-      'protocol_id'             : $('#study_schedule_buttons').data('protocol-id')
-      'sub_service_request_id'  : $('#study_schedule_buttons').data('sub-service-request-id')
-      'service_request_id'      : $('#study_schedule_buttons').data('service-request-id')
-    if line_item_count == 1
+    if $('#study_schedule_buttons').data('line-item-count') == 1
       sweetAlert("Warning", "Please add a new service(s) prior to removing the last service; To remove all services use the 'Delete Request' button.")
     else
       $.ajax
         type: 'GET'
         url: '/dashboard/multiple_line_items/edit_line_items'
-        data: data
-
-  $(document).on 'change', "#remove_service_id", ->
-    data =
-      'protocol_id' : $('#study_schedule_buttons').data('protocol-id')
-      'service_id'  : $(this).find('option:selected').val()
-      'sub_service_request_id'  : $('#study_schedule_buttons').data('sub-service-request-id')
-      'service_request_id'      : $('#study_schedule_buttons').data('service-request-id')
-    $.ajax
-      type: 'GET'
-      url: '/dashboard/multiple_line_items/edit_line_items'
-      data: data
+        data:
+          sub_service_request_id: $('#study_schedule_buttons').data('sub-service-request-id')
 
   $(document).on 'submit', '#destroy_service', ->
     $("#remove_line_items_form_button").attr('disabled','disabled')

--- a/app/controllers/dashboard/multiple_line_items_controller.rb
+++ b/app/controllers/dashboard/multiple_line_items_controller.rb
@@ -18,10 +18,11 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# this controller exists in order to separate the mass creation of line items
+# from single line item creation and deletion which will happen on the study schedule
 class Dashboard::MultipleLineItemsController < Dashboard::BaseController
-  respond_to :json, :html
-  #this controller exists in order to separate the mass creation of line items
-  #from single line item creation and deletion which will happen on the study schedule
+
+  repsond_to :js
 
   def new_line_items
     # called to render modal to mass create line items
@@ -66,23 +67,16 @@ class Dashboard::MultipleLineItemsController < Dashboard::BaseController
   end
 
   def edit_line_items
-    # called to render modal to mass remove line items
-    @service_request = ServiceRequest.find(params[:service_request_id])
-    @sub_service_request = SubServiceRequest.find(params[:sub_service_request_id])
-    @protocol = Protocol.find(params[:protocol_id])
-    @all_services = @sub_service_request.line_items.map(&:service).uniq
-    @service = params[:service_id].present? ? Service.find(params[:service_id]) : @all_services.first
-    @arms = @protocol.arms.joins(:line_items).where(line_items: { service_id: @service.id })
+    @sub_service_request  = SubServiceRequest.find(params[:sub_service_request_id])
   end
 
   def destroy_line_items
-    # handles submission of the remove line items form
-    @service_request = ServiceRequest.find(params[:service_request_id])
-    @sub_service_request = SubServiceRequest.find(params[:sub_service_request_id])
-    @service = Service.find(params[:remove_service_id])
+    @line_item            = LineItem.find(params[:line_item_id])
+    @sub_service_request  = @line_item.sub_service_request
+    @service_request      = @sub_service_request.service_request
 
-    @line_items = @sub_service_request.line_items.where(service_id: @service.id)
-    @line_items.each(&:destroy)
+    @line_item.destroy
+
     flash.now[:alert] = t(:dashboard)[:multiple_line_items][:destroyed]
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -27,6 +27,7 @@ class LineItem < ApplicationRecord
   belongs_to :service_request
   belongs_to :service, counter_cache: true
   belongs_to :sub_service_request
+
   has_many :fulfillments, dependent: :destroy
   has_many :line_items_visits, dependent: :destroy
   has_many :procedures
@@ -47,6 +48,7 @@ class LineItem < ApplicationRecord
   accepts_nested_attributes_for :fulfillments, allow_destroy: true
 
   delegate :one_time_fee, to: :service
+  delegate :name, to: :service
   delegate :status, to: :sub_service_request
 
   validates :service_id, numericality: true, presence: true

--- a/app/views/dashboard/multiple_line_items/_remove_line_items_form.html.haml
+++ b/app/views/dashboard/multiple_line_items/_remove_line_items_form.html.haml
@@ -20,7 +20,7 @@
 
 .modal-dialog
   .modal-content
-    = form_tag(destroy_line_items_dashboard_multiple_line_items_path, method: "put", class: "form-horizontal", id: "destroy_service", remote: true) do
+    = form_tag destroy_line_items_dashboard_multiple_line_items_path, method: :put, class: "form-horizontal", id: "destroy_service", remote: true do
       .modal-header
         %button.close{type: 'button', data: {dismiss: 'modal'}}
           %span{aria: {hidden:'true'}} &times;
@@ -31,12 +31,10 @@
         #modal_errors
         .row
           .col-md-12
-            = hidden_field_tag :service_request_id, service_request.id
-            = hidden_field_tag :sub_service_request_id, sub_service_request.id
             .form-group
-              = label_tag "remove_service_id", t(:dashboard)[:multiple_line_items][:service], class: "col-sm-4 control-label"
+              = label_tag :line_item_id, t(:dashboard)[:multiple_line_items][:service], class: "col-sm-4 control-label"
               .col-sm-7
-                = select_tag "remove_service_id", options_from_collection_for_select(all_services, 'id' , 'display_service_name', service.id), class: "form-control selectpicker"
+                = select_tag :line_item_id, options_from_collection_for_select(sub_service_request.per_patient_per_visit_line_items, :id , :name), class: "form-control selectpicker"
       .modal-footer
         .center-block
           %button.btn.btn-default{type: 'button', data: {dismiss: 'modal'}}

--- a/app/views/dashboard/multiple_line_items/destroy_line_items.js.coffee
+++ b/app/views/dashboard/multiple_line_items/destroy_line_items.js.coffee
@@ -18,16 +18,11 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#modal_errors").html("<%= escape_javascript(render(partial: 'shared/modal_errors', locals: {errors: @errors})) %>")
-<% unless @errors %>
-$("#per_patient_services").html("<%= escape_javascript(render(:partial =>'dashboard/sub_service_requests/per_patient_per_visit', locals: {sub_service_request: @sub_service_request, service_request: @service_request})) %>");
-
-$("#sub_service_request_header").html("<%= escape_javascript(render(partial: 'dashboard/sub_service_requests/header', locals: { sub_service_request: @sub_service_request })) %>");
-$("#subsidy_information").html("<%= escape_javascript(render(partial: 'dashboard/subsidies/subsidy', locals: { sub_service_request: @sub_service_request, admin: true })) %>");
+$("#per_patient_services").html("<%= j render 'dashboard/sub_service_requests/per_patient_per_visit', sub_service_request: @sub_service_request, service_request: @service_request %>")
+$("#sub_service_request_header").html("<%= j render 'dashboard/sub_service_requests/header', sub_service_request: @sub_service_request %>")
+$("#subsidy_information").html("<%= j render 'dashboard/subsidies/subsidy', sub_service_request: @sub_service_request, admin: true %>")
 $(".selectpicker").selectpicker()
+$("#modal_place").modal('hide')
+$("#flashes_container").html("<%= j render 'shared/flash' %>")
 
 refresh_study_schedule()
-
-$("#modal_place").modal 'hide'
-$("#flashes_container").html("<%= escape_javascript(render('shared/flash')) %>")
-<% end %>

--- a/app/views/dashboard/multiple_line_items/edit_line_items.js.coffee
+++ b/app/views/dashboard/multiple_line_items/edit_line_items.js.coffee
@@ -18,6 +18,6 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-$("#modal_place").html("<%= escape_javascript(render(:partial =>'dashboard/multiple_line_items/remove_line_items_form', locals: { arms: @arms, all_services: @all_services, service: @service, protocol: @protocol, sub_service_request: @sub_service_request, service_request: @service_request })) %>");
-$("#modal_place").modal 'show'
+$("#modal_place").html("<%= j render 'dashboard/multiple_line_items/remove_line_items_form', sub_service_request: @sub_service_request %>");
+$("#modal_place").modal('show')
 $(".selectpicker").selectpicker()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164802564

**Background:**
In SPARCDashboard Admin Edit, an admin user is currently able to add duplicative clinical services. However, when realizing there are duplicatives, users go to "Manage Services" -> "Delete Service", both of the duplicatives are gone. 

**Acceptance Criteria:**
We need to fix this issue, and turn the "Delete Service" to refer to each line item , which follows the sequence of the line items in the calendar.

This work is linked with fulfillment synchronization work, so that users can clean up historical duplicative services on calendars, before we link SR and SF pppv line items. 