### PR TITLE
KG - Single Service Landing Page Redirect if Service Inactive

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -32,6 +32,7 @@ class ServiceRequestsController < ApplicationController
   before_action :authorize_identity,              except: [:approve_changes, :get_help, :feedback, :show]
   before_action :authenticate_identity!,          except: [:catalog, :add_service, :remove_service, :get_help, :feedback]
   before_action :find_locked_org_ids,             only:   [:catalog]
+  before_action :find_service,                    only:   [:catalog]
 
   def show
     @protocol = @service_request.protocol
@@ -58,13 +59,6 @@ class ServiceRequestsController < ApplicationController
 
   def catalog
     @institutions = Institution.all
-
-    if params[:service_id]
-      @service  = Service.find(params[:service_id])
-      @provider = @service.provider
-      @program  = @service.program
-      @core     = @service.core
-    end
 
     setup_catalog_calendar
     setup_catalog_news_feed
@@ -411,6 +405,17 @@ class ServiceRequestsController < ApplicationController
       return false
     else
       return true
+    end
+  end
+
+  def find_service
+    if params[:service_id]
+      @service  = Service.find(params[:service_id])
+      @provider = @service.provider
+      @program  = @service.program
+      @core     = @service.core
+
+      redirect_to catalog_service_request_path unless @service.is_available?
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163063556

> Per our convo this morning, several direct service links are displaying a blank Program/Core when they are inactive. We discussed a redirect to the SPARC homepage when services are inactive so it doesn't just go into a Program/Core and not display anything. A few examples below.
