### PR TITLE
KG - Admin Edit Visit Group Insert into Position Bug

### DIFF
--- a/app/helpers/visit_groups_helper.rb
+++ b/app/helpers/visit_groups_helper.rb
@@ -21,28 +21,11 @@
 module VisitGroupsHelper
   def visit_position_options(arm, visit_group=nil)
     if visit_group
-      options_from_collection_for_select(
-        arm.visit_groups.where.not(id: visit_group.id),
-        'position',
-        'insertion_name',
-        visit_group.position
-      ) +
-      content_tag(
-        :option,
-        t(:constants)[:add_as_last],
-        value: "#{arm.visit_groups.count+1}"
-      )
+      options_from_collection_for_select(arm.visit_groups.where.not(id: visit_group.id), :position, :insertion_name, visit_group.position + 1) +
+      content_tag(:option, t(:constants)[:add_as_last], value: (last_position = arm.visit_groups.maximum(:position)) + 1, selected: visit_group.position == last_position)
     else
-      options_from_collection_for_select(
-        arm.visit_groups,
-        'position',
-        'insertion_name'
-      ) +
-      content_tag(
-        :option,
-        t(:constants)[:add_as_last],
-        value: "#{arm.visit_groups.count+1}"
-      )
+      options_from_collection_for_select(arm.visit_groups, :position, :insertion_name) +
+      content_tag(:option, t(:constants)[:add_as_last], value: arm.visit_groups.maximum(:position) + 1)
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164967292

When editing a visit group through the study schedule, the "Insert into Position" field does not automatically populate, forcing users to manually select the position every time.