### PR TITLE
SJ - Email root url setting

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,11 @@ SparcRails::Application.configure do
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
 
+  config.after_initialize do
+    # Need to do this after initialization so that obis_setup has run and our config is loaded
+    config.action_mailer.default_url_options = { :host => Setting.get_value("root_url") }
+  end
+
   config.log_level = :debug
 
   # Stuff to do on each request

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,6 +118,7 @@ SparcRails::Application.configure do
 
       end
     end
+    config.action_mailer.default_url_options = { :host => Setting.get_value("root_url") }
   end
 
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -108,4 +108,9 @@ SparcRails::Application.configure do
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   config.action_mailer.default_url_options = { :host => 'sparc-s.obis.musc.edu' }
+
+  config.after_initialize do
+    # Need to do this after initialization so that obis_setup has run and our config is loaded
+    config.action_mailer.default_url_options = { :host => Setting.get_value("root_url") }
+  end
 end

--- a/config/environments/testing.rb
+++ b/config/environments/testing.rb
@@ -53,4 +53,9 @@ SparcRails::Application.configure do
   config.assets.debug = true
 
   config.action_mailer.default_url_options = { :host => 'sparc-d.obis.musc.edu' }
+
+  config.after_initialize do
+    # Need to do this after initialization so that obis_setup has run and our config is loaded
+    config.action_mailer.default_url_options = { :host => Setting.get_value("root_url") }
+  end
 end


### PR DESCRIPTION
Emails were using a hard-coded root url, instead of pulling from settings. Solution was to have the default mail options re-set after initialization, and pull from settings.

[#162137007]

https://www.pivotaltracker.com/story/show/162137007