### PR TITLE
KG - Authorized User Email Improvements

### DIFF
--- a/app/views/user_mailer/_intro.html.haml
+++ b/app/views/user_mailer/_intro.html.haml
@@ -21,7 +21,10 @@
 %p= "Dear #{@send_to.try(:full_name)},"
 %p{ style: 'display: inline;' }
   - if @action == "destroy"
-    = t(:mailer)[:delete_intro]
+    - if @modified_roles.count == 1
+      = t(:mailer)[:delete_intro]
+    - else
+      = t(:mailer)[:delete_intro_p]
   - if @action == "add"
     = t(:mailer)[:add_intro]
 %p{ style: 'display: inline;' }

--- a/app/views/user_mailer/_user_info_table.html.haml
+++ b/app/views/user_mailer/_user_info_table.html.haml
@@ -33,14 +33,19 @@
   %tbody
     - @modified_roles.each do |pr|
       %tr{:style => 'border: 1px solid black;'}
-        %td{:style => 'border: 1px solid black; text-align: center;'}<
-          = pr.identity.full_name
-        %td{:style => 'border: 1px solid black; text-align: center;'}<
-          = pr.identity.email
-        %td{:style => 'border: 1px solid black; text-align: center;'}<
-          = pr.role.upcase
-        %td{:style => 'border: 1px solid black; text-align: center;'}<
-          = pr.display_rights
+        %td{:style => 'border: 1px solid black; text-align: center;'}
+          %del<
+            = pr.identity.full_name
+        %td{:style => 'border: 1px solid black; text-align: center;'}
+          %del<
+            = pr.identity.email
+        %td{:style => 'border: 1px solid black; text-align: center;'}
+          %del<
+            = pr.role.upcase
+        %td{:style => 'border: 1px solid black; text-align: center;'}
+          %del<
+            = pr.display_rights
         - if @protocol.selected_for_epic
-          %td{:style => 'border: 1px solid black; text-align: center;'}<
-            = pr.epic_access == true ? "Yes" : "No"
+          %td{:style => 'border: 1px solid black; text-align: center;'}
+            %del<
+              = pr.epic_access == true ? "Yes" : "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1326,6 +1326,7 @@ en:
     add_intro: "An Authorized User has been added in"
     contact_information: "Contact Information"
     delete_intro: "An Authorized User has been deleted in"
+    delete_intro_p: "Authorized Users have been deleted in"
     epic_access: "Epic Access"
     issue_contact: "Please contact the %{department_name} at %{phone} or <a href='mailto:%{email}'>%{email}</a> for assistance with this process or with any questions you may have."
     name: "Name:"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe UserMailer do
       end
 
       it 'should show epic column' do
-        user_information_table_with_epic_col
+        user_information_table_with_epic_col(true)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe UserMailer do
       end
 
       it 'should not show epic col' do
-        user_information_table_without_epic_col
+        user_information_table_without_epic_col(true)
       end
     end
   end
@@ -139,7 +139,7 @@ RSpec.describe UserMailer do
       end
 
       it 'should show epic column' do
-        user_information_table_with_epic_col
+        user_information_table_with_epic_col(true)
       end
     end
 
@@ -154,7 +154,7 @@ RSpec.describe UserMailer do
       end
 
       it 'should not show epic col' do
-        user_information_table_without_epic_col
+        user_information_table_without_epic_col(true)
       end
     end
   end

--- a/spec/support/user_mailer_emails/tables.rb
+++ b/spec/support/user_mailer_emails/tables.rb
@@ -29,27 +29,34 @@ module EmailHelpers
     expect(@mail).to have_xpath "//th[text()='Funding Source']/following-sibling::td[text()='#{@protocol.funding_source.capitalize}']"
   end
 
-  def user_information_table_with_epic_col
+  def user_information_table_with_epic_col(delete=false)
     expect(@mail).to have_xpath "//table//strong[text()='User Information']"
     expect(@mail).to have_xpath "//th[text()='User Modification']/following-sibling::th[text()='Contact Information']/following-sibling::th[text()='Role']/following-sibling::th[text()='SPARC Proxy Rights']/following-sibling::th[text()='Epic Access']"
-    expect(@mail).to have_xpath "//td[text()=\"#{modified_identity.full_name}\"]/following-sibling::td[text()=\"#{modified_identity.email}\"]/following-sibling::td[text()='#{modified_identity.project_roles.first.role.upcase}']/following-sibling::td[text()='#{modified_identity.project_roles.first.display_rights}']"
-    if modified_identity.project_roles.first.epic_access == false
-      expect(@mail).to have_xpath "//td[text()='No']"
+
+    if delete
+      [modified_identity.full_name, modified_identity.email, modified_identity.project_roles.first.role.upcase, modified_identity.project_roles.first.display_rights, modified_identity.project_roles.first.epic_access ? 'Yes' : 'No'].each do |text|
+        expect(@mail).to have_selector('td del', text: text)
+      end
     else
-      expect(@mail).to have_xpath "//td[text()='Yes']"
+      expect(@mail).to have_xpath "//td[text()=\"#{modified_identity.full_name}\"]/following-sibling::td[text()=\"#{modified_identity.email}\"]/following-sibling::td[text()='#{modified_identity.project_roles.first.role.upcase}']/following-sibling::td[text()='#{modified_identity.project_roles.first.display_rights}']"
+      expect(@mail).to have_xpath "//td[text()=\"#{modified_identity.project_roles.first.epic_access ? 'Yes' : 'No'}\"]"
     end
   end
 
-  def user_information_table_without_epic_col
+  def user_information_table_without_epic_col(delete=false)
     expect(@mail).to have_xpath "//table//strong[text()='User Information']"
     expect(@mail).to have_xpath "//th[text()='User Modification']/following-sibling::th[text()='Contact Information']/following-sibling::th[text()='Role']/following-sibling::th[text()='SPARC Proxy Rights']"
     expect(@mail).not_to have_xpath "//following-sibling::th[text()='Epic Access']"
-    expect(@mail).to have_xpath "//td[text()=\"#{modified_identity.full_name}\"]/following-sibling::td[text()=\"#{modified_identity.email}\"]/following-sibling::td[text()='#{modified_identity.project_roles.first.role.upcase}']/following-sibling::td[text()='#{modified_identity.project_roles.first.display_rights}']"
 
-    if modified_identity.project_roles.first.epic_access == false
-      expect(@mail).not_to have_xpath "//td[text()='No']"
+    if delete
+      [modified_identity.full_name, modified_identity.email, modified_identity.project_roles.first.role.upcase, modified_identity.project_roles.first.display_rights].each do |text|
+        expect(@mail).to have_selector('td del', text: text)
+      end
+
+      expect(@mail).to_not have_selector('td del', text: modified_identity.project_roles.first.epic_access ? 'Yes' : 'No')
     else
-      expect(@mail).not_to have_xpath "//td[text()='Yes']"
+      expect(@mail).to have_xpath "//td[text()=\"#{modified_identity.full_name}\"]/following-sibling::td[text()=\"#{modified_identity.email}\"]/following-sibling::td[text()='#{modified_identity.project_roles.first.role.upcase}']/following-sibling::td[text()='#{modified_identity.project_roles.first.display_rights}']"
+      expect(@mail).to_not have_xpath "//td[text()=\"#{modified_identity.project_roles.first.epic_access ? 'Yes' : 'No'}\"]"
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164082119

per our discussion today, the bulk emails are now sending out appropriately. Two suggested changes:
1) when more then one user is being deleted, change the language from "an authorized user has been deleted in SPARCDashboard" to "Authorized Users have been deleted in SPARCDashboard"
2) Strike through the authorized user names that have been deleted, similarly to the request deletion strike through (screenshot below).