### PR TITLE
KG - Fix Survey Distribution

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -43,6 +43,7 @@ class Organization < ApplicationRecord
   has_many :org_children, class_name: "Organization", foreign_key: :parent_id
 
   has_many :protocols, through: :sub_service_requests
+  has_many :surveys, through: :associated_surveys
 
   validates :abbreviation,
             :order,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165355454

> When testing the survey function, I came across a bug where a Core (Additional PRA Services) is not sending out Surveys upon completion of services under that core. The split/notify resides at the Program Level (Billing Compliance - Prospective Reimbursement Analysis) and surveys are being send for completion of the two services (PRA & PRA Exception) that are directly underneath the program. Please look into this bug.