### PR TITLE
KG - Fix Document Management "Back" button

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -98,7 +98,7 @@ class ServiceRequestsController < ApplicationController
     @eligible_for_subsidy = @service_request.sub_service_requests.map(&:eligible_for_subsidy?).any?
 
     unless @has_subsidy || @eligible_for_subsidy
-      @back = 'service_calendar'
+      @back = service_calendar_service_request_path(srid: @service_request.id)
     end
   end
 

--- a/spec/controllers/service_requests/get_document_management_spec.rb
+++ b/spec/controllers/service_requests/get_document_management_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     end
 
     context '!@has_subsidy && !@eligible_for_subidy' do
-      it 'should assign @back to \'service_calendar\'' do
+      it 'should assign @back to \'service_calendar\' path' do
         org      = create(:organization)
         service  = create(:service, organization: org, one_time_fee: true)
         protocol = create(:protocol_federally_funded, primary_pi: logged_in_user)
@@ -120,7 +120,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
         get :document_management, params: { srid: sr.id }, xhr: true
 
-        expect(assigns(:back)).to eq('service_calendar')
+        expect(assigns(:back)).to eq(service_calendar_service_request_path(srid: sr.id))
       end
     end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165088240

When a service request is not eligible for a subsidy, we manually reassign the `@back` instance variable in the `document_management` route. This scenario was missed previously. All other "Back" buttons appear to work as intended.