### PR TITLE
KG - Original Submitted Date Backfill Edge Case

### DIFF
--- a/lib/tasks/backfill_original_submission_dates.rake
+++ b/lib/tasks/backfill_original_submission_dates.rake
@@ -23,10 +23,15 @@ namespace :data do
   task backfill_original_submissions: :environment do
     ServiceRequest.joins(:sub_service_requests).where(original_submitted_date: nil).each do |sr|
       if first_submitted_ssr = sr.sub_service_requests.where.not(submitted_at: nil).order(submitted_at: :asc).first
-        puts "Updating Request ##{sr.id}"
         sr.original_submitted_date = first_submitted_ssr.submitted_at
+      elsif sr.submitted_at
+        sr.original_submitted_date = sr.submitted_at
+      end
+
+      if sr.original_submitted_date
+        puts "Updating Request ##{sr.id}"
         puts "- New Original Submitted Date: #{sr.original_submitted_date}"
-        sr.save(validate: false) 
+        sr.save(validate: false)
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/162964012

> However, I did notice that there are still 62 leftover Service Requests on -d after the script was run, that had 'submitted' status and 'submitted_at' date, but null "original_submitted_date". When I looked into the related protocols, I found out that the protocols were all empty. That's the edge case when users went back to a previously submitted protocol and deleted all requests.

> In this case (and only in this case), we should probably just use the SR 'submitted_at' date to fill in the SR 'original_submitted_date', because that's our best bet. Please look into that.