### PR TITLE
KG - SSR Submission Status Bugs

### DIFF
--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -271,25 +271,19 @@ class SubServiceRequest < ApplicationRecord
   # Returns the SSR id that need an initial submission email and updates
   # the SSR status to new status if appropriate
   def update_status_and_notify(new_status)
-    unless self.is_locked? || self.previously_submitted?
-      available   = PermissibleValue.get_key_list('status')
-      editable    = self.is_locked? || available
-      changeable  = (available & editable).include?(new_status) && Status.updatable?(self.status)
-
-      if self.status != new_status && changeable
-        if new_status == 'submitted'
-          ### For 'submitted' status ONLY:
-          # Since adding/removing services changes a SSR status to 'draft', we have to look at the past status to see if we should notify users of a status change
-          # We do NOT notify if updating from an un-updatable status or we're updating to a status that we already were previously
-          # See Pivotal Stories: #133049647 & #135639799
-          old_status  = self.status
-          past_status = PastStatus.where(sub_service_request_id: id).last.try(:status)
-          self.update_attributes(status: new_status, submitted_at: Time.now, nursing_nutrition_approved: false, lab_approved: false, imaging_approved: false, committee_approved: false)
-          return self.id if old_status != 'draft' || (old_status == 'draft' && (past_status.nil? || (past_status != new_status && Status.updatable?(past_status)))) # past_status == nil indicates a newly created SSR
-        else
-          self.update_attribute(:status, new_status)
-          return self.id
-        end
+    if self.status != new_status && self.can_be_edited? && Status.updatable?(self.status)
+      if new_status == 'submitted'
+        ### For 'submitted' status ONLY:
+        # Since adding/removing services changes a SSR status to 'draft', we have to look at the past status to see if we should notify users of a status change
+        # We do NOT notify if updating from an un-updatable status or we're updating to a status that we already were previously
+        # See Pivotal Stories: #133049647 & #135639799
+        old_status  = self.status
+        past_status = self.past_statuses.last.try(:status)
+        self.update_attributes(status: new_status, submitted_at: Time.now, nursing_nutrition_approved: false, lab_approved: false, imaging_approved: false, committee_approved: false)
+        return self.id if !self.previously_submitted? && (old_status != 'draft' || (old_status == 'draft' && (past_status.nil? || (past_status != new_status && Status.updatable?(past_status))))) # past_status == nil indicates a newly created SSR
+      else
+        self.update_attribute(:status, new_status)
+        return self.id
       end
     end
   end

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -277,10 +277,11 @@ class SubServiceRequest < ApplicationRecord
         # Since adding/removing services changes a SSR status to 'draft', we have to look at the past status to see if we should notify users of a status change
         # We do NOT notify if updating from an un-updatable status or we're updating to a status that we already were previously
         # See Pivotal Stories: #133049647 & #135639799
-        old_status  = self.status
-        past_status = self.past_statuses.last.try(:status)
+        old_status      = self.status
+        submitted_prior = self.previously_submitted?
+        past_status     = self.past_statuses.last.try(:status)
         self.update_attributes(status: new_status, submitted_at: Time.now, nursing_nutrition_approved: false, lab_approved: false, imaging_approved: false, committee_approved: false)
-        return self.id if !self.previously_submitted? && (old_status != 'draft' || (old_status == 'draft' && (past_status.nil? || (past_status != new_status && Status.updatable?(past_status))))) # past_status == nil indicates a newly created SSR
+        return self.id if !submitted_prior && (old_status != 'draft' || (old_status == 'draft' && (past_status.nil? || (past_status != new_status && Status.updatable?(past_status))))) # past_status == nil indicates a newly created SSR
       else
         self.update_attribute(:status, new_status)
         return self.id

--- a/spec/models/sub_service_request/update_status_and_notify_spec.rb
+++ b/spec/models/sub_service_request/update_status_and_notify_spec.rb
@@ -25,17 +25,8 @@ RSpec.describe SubServiceRequest, type: :model do
   let!(:sr)       { create(:service_request_without_validations, protocol: protocol) }
 
   describe "#update_status_and_notify" do
-    context 'SubServiceRequest can be edited' do
-      context 'and has been submitted prior' do
-        let!(:ssr) { create(:sub_service_request_without_validations, :submitted, service_request: sr, organization: org) }
-
-        it 'should not update the SubServiceRequest nor notify' do
-          expect(ssr.update_status_and_notify('draft')).to eq(nil)
-          expect(ssr.reload.status).to eq('submitted')
-        end
-      end
-
-      context 'and has not been submitted prior' do
+    context 'new status is different than current status' do
+      context 'and the SSR can be edited' do
         context 'and current status is updatable' do
           context 'and new_status == submitted' do
             it 'should update status and nursing_nutrition, lab, imaging, and committee approvals' do
@@ -50,41 +41,51 @@ RSpec.describe SubServiceRequest, type: :model do
               expect(ssr.committee_approved).to eq(false)
             end
 
-            context 'and current status == draft' do
-              let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'draft') }
+            context 'and ssr was not previously submitted' do
+              context 'and current status == draft' do
+                let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'draft') }
 
-              context 'and past_status is nil indicating a newly created SubServiceRequest' do
-                it 'should update the SubServiceRequest and notify' do
-                  expect(ssr.update_status_and_notify('submitted')).to eq(ssr.id)
-                  expect(ssr.reload.status).to eq('submitted')
+                context 'and past_status is nil indicating a newly created SubServiceRequest' do
+                  it 'should update the SubServiceRequest and notify' do
+                    expect(ssr.update_status_and_notify('submitted')).to eq(ssr.id)
+                    expect(ssr.reload.status).to eq('submitted')
+                  end
+                end
+
+                context 'and past_status is updatable' do
+                  let!(:past_status) { create(:past_status, sub_service_request: ssr, status: 'draft') }
+
+                  it 'should update the SubServiceRequest and notify' do
+                    expect(ssr.update_status_and_notify('submitted')).to eq(ssr.id)
+                    expect(ssr.reload.status).to eq('submitted')
+                  end
+                end
+
+                context 'and past_status is un-updatable' do
+                  let!(:past_status) { create(:past_status, sub_service_request: ssr, status: 'complete') }
+
+                  it 'should update the SubServiceRequest but not notify' do
+                    expect(ssr.update_status_and_notify('submitted')).to eq(nil)
+                    expect(ssr.reload.status).to eq('submitted')
+                  end
                 end
               end
 
-              context 'and past_status is updatable' do
-                let!(:past_status) { create(:past_status, sub_service_request: ssr, status: 'draft') }
+              context 'and current status != draft' do
+                let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'awaiting_pi_approval') }
 
                 it 'should update the SubServiceRequest and notify' do
                   expect(ssr.update_status_and_notify('submitted')).to eq(ssr.id)
-                  expect(ssr.reload.status).to eq('submitted')
-                end
-              end
-
-              context 'and past_status is un-updatable' do
-                let!(:past_status) { create(:past_status, sub_service_request: ssr, status: 'complete') }
-
-                it 'should update the SubServiceRequest but not notify' do
-                  expect(ssr.update_status_and_notify('submitted')).to eq(nil)
                   expect(ssr.reload.status).to eq('submitted')
                 end
               end
             end
 
-            context 'and current status != draft' do
-              let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'awaiting_pi_approval') }
+            context 'and ssr was previously submitted' do
+              let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'draft', submitted_at: DateTime.now) }
 
-              it 'should update the SubServiceRequest and notify' do
-                expect(ssr.update_status_and_notify('submitted')).to eq(ssr.id)
-                expect(ssr.reload.status).to eq('submitted')
+              it 'should not notify' do
+                expect(ssr.update_status_and_notify('submitted')).to eq(nil)
               end
             end
           end
@@ -92,7 +93,7 @@ RSpec.describe SubServiceRequest, type: :model do
           context 'and new_status != submitted' do
             let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, nursing_nutrition_approved: nil, lab_approved: nil, imaging_approved: nil, committee_approved: nil) }
 
-            it 'should update only status and notify' do
+            it 'should only update status and notify' do
               expect(ssr.update_status_and_notify('get_a_cost_estimate')).to eq(ssr.id)
               ssr.reload
               expect(ssr.status).to eq('get_a_cost_estimate')
@@ -105,22 +106,35 @@ RSpec.describe SubServiceRequest, type: :model do
         end
 
         context 'and current status is un-updatable' do
-          let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'complete') }
+          let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'pending') }
 
           it 'should not update the SubServiceRequest nor notify' do
             expect(ssr.update_status_and_notify('draft')).to eq(nil)
-            expect(ssr.reload.status).to eq('complete')
+            expect(ssr.reload.status).to eq('pending')
           end
+        end
+      end
+
+      context 'and the SSR can\'t be edited' do
+        let!(:ssr) {
+          ssr = create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'draft')
+          allow(ssr).to receive(:can_be_edited?).and_return(false)
+          ssr
+        }
+
+        it 'should not update the SubServiceRequest nor notify' do
+          expect(ssr.update_status_and_notify('submitted')).to eq(nil)
+          expect(ssr.reload.status).to eq('draft')
         end
       end
     end
 
-    context 'and SubServiceRequest can\'t be edited' do
-      let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'get_a_cost_estimate') }
+    context 'new status is the same as current status' do
+      let!(:ssr) { create(:sub_service_request_without_validations, service_request: sr, organization: org, status: 'draft') }
 
-      it 'should not update the SubServiceRequest nor notify' do
+      it 'should not update the SSR nor notify' do
         expect(ssr.update_status_and_notify('draft')).to eq(nil)
-        expect(ssr.reload.status).to eq('get_a_cost_estimate')
+        expect(ssr.reload.status).to eq('draft')
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158776106

> Steps to reproduce the issues: enter an existing protocol, find a previously submitted SSR, enter "Admin Edit", and change its status to "Draft" or "Awaiting Requester Response" (or another updatable status), then use "Add/Modify Request" button, do not change any of the existing SSRs, but add a new service to create a new SSR, jump to Step 6, and Resubmit the protocol.

> Issue 1).The previously submitted but now in an updatable status SSRs were not re-submitted. For example, the 13238-0007 and 13238-0008 SSRs on sparc-d should have been flipped to "submitted" status when I re-submitted, but they stayed in "Awaiting Requester Response" and "Draft".
see screenshots 1-3 attached.

> Issue 2). For the newly created SSR, an amendment email was sent out when I re-submitted it for the first time (and the status was changed to "Submitted"), which was correct behavior. However, when I changed the status from admin side back to "Draft", and re-submit again, the same amendment email was sent out again to the study team users, when the status stayed in Draft and there was no change to this SSR. This amendment email should not be sent out again.
see screenshots 4-6 attached.