### PR TITLE
KG - Fix Original Submitted Date Script

### DIFF
--- a/lib/tasks/backfill_original_submission_dates.rake
+++ b/lib/tasks/backfill_original_submission_dates.rake
@@ -21,7 +21,7 @@
 namespace :data do
   desc "Backfill missing `original_submitted_date`s for Service Requests"
   task backfill_original_submissions: :environment do
-    ServiceRequest.joins(:sub_service_requests).where(original_submitted_date: nil).each do |sr|
+    ServiceRequest.where.not(submitted_at: nil).where(original_submitted_date: nil).each do |sr|
       if first_submitted_ssr = sr.sub_service_requests.where.not(submitted_at: nil).order(submitted_at: :asc).first
         sr.original_submitted_date = first_submitted_ssr.submitted_at
       elsif sr.submitted_at


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/162964012

When joining on `sub_service_requests`, the script skipped a number of service requests that had their sub service requests removed and was therefore not updating them.