### PR TITLE
KG - Service Request Revamp Bugs

### DIFF
--- a/app/helpers/service_requests_helper.rb
+++ b/app/helpers/service_requests_helper.rb
@@ -71,9 +71,9 @@ module ServiceRequestsHelper
     end
   end
 
-  def save_as_draft_button
+  def save_as_draft_button(service_request)
     link_to t(:proper)[:navigation][:bottom][:save_as_draft],
-      save_and_exit_service_request_path,
+      save_and_exit_service_request_path(srid: service_request.id),
       remote: true, class: 'btn btn-default'
   end
 

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -425,7 +425,7 @@ class ServiceRequest < ApplicationRecord
   def update_status(new_status)
     # Do not change the Service Request if it has been submitted
     update_attribute(:status, new_status) unless self.previously_submitted?
-    update_attribute(:submitted_at, Time.now) if new_status == 'submitted' && !self.previously_submitted?
+    update_attribute(:submitted_at, Time.now) if new_status == 'submitted'
 
     self.sub_service_requests.map do |ssr|
       ssr.update_status_and_notify(new_status)

--- a/app/views/service_requests/navigation/_footer.html.haml
+++ b/app/views/service_requests/navigation/_footer.html.haml
@@ -22,13 +22,13 @@
     = link_to t(:proper)[:navigation][:bottom][:back], back, class: 'btn btn-default'
   - if controller.action_name == 'review'
     .col-sm-3.text-center
-      = save_as_draft_button
+      = save_as_draft_button(service_request)
     .col-sm-3.text-center
       = link_to t(:proper)[:navigation][:bottom][:get_cost_estimate],obtain_research_pricing_service_request_path(srid: service_request.id), class: 'btn btn-default get-a-cost-estimate', data: { disable_with: t(:proper)[:navigation][:bottom][:getting_cost] }
   - else
     .col-sm-6.text-center
       - if service_request.submitted_at.blank? && service_request.protocol.present?
-        = save_as_draft_button
+        = save_as_draft_button(service_request)
   -# This was extracted because the surveyor gem requires an href location to redirect to post-submit and it was being cranky
   - if Setting.get_value("system_satisfaction_survey") && action_name == 'review'
     .col-sm-3.text-right


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158776106

See the latest comment from Kyle Hutson on the pivotal story for details

- The Service Request's `previous_submitted_at` was being incorrectly assigned _after_ updating the `submitted_at` rather than before
- Amendment emails were broken because the `submitted_at` SHOULD in-fact be assigned every time a service request is submitted
- The Save as Draft button was broken because the link was missing the `srid` param