### PR TITLE
Support env vars in fulfillment_db.yml

### DIFF
--- a/config/initializers/shard.rb
+++ b/config/initializers/shard.rb
@@ -18,9 +18,11 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
+path = File.join(Rails.root, "config", "fulfillment_db.yml")
 FULFILLMENT_DB =
-  if File.exists?(File.join(Rails.root, 'config', 'fulfillment_db.yml'))
-   YAML.load_file(File.join(Rails.root, 'config', 'fulfillment_db.yml'))[Rails.env]
- else
-  nil
+  if path
+    yaml = Pathname.new(path)
+    YAML.load(ERB.new(yaml.read).result)[Rails.env.to_s]
+  else
+    nil
   end


### PR DESCRIPTION
Support environment variables in `fulfillment_db.yml`. For example,

```
  username: <%= ENV['FULFILLMENT_DB_USER'] %>
  password: <%= ENV['FULFILLMENT_DB_PASS'] %>
  database: <%= ENV['FULFILLMENT_DB_NAME'] %>
  host: <%= ENV['FULFILLMENT_DB_HOST'] %>
```