### PR TITLE
KG - Add News Feed API Token For Atlassian API

### DIFF
--- a/app/lib/news_feed/api_adapter.rb
+++ b/app/lib/news_feed/api_adapter.rb
@@ -20,10 +20,12 @@
 
 module NewsFeed
   class ApiAdapter < NewsFeed::Base
-    def initialize(api_string="", content_type='application/json', parameters={limit: NewsFeed::Base::POST_LIMIT})
-      @content_type = content_type
-      @parameters   = parameters
+    def initialize(api_string, opts={})
+      @content_type = opts[:content_type] || 'application/json'
+      @headers      = opts[:headers] || { 'Content-Type' => @content_type }
+      @parameters   = opts[:parameters] || {limit: NewsFeed::Base::POST_LIMIT}
       @url          = NewsFeed::Base::BASE_URL + api_string + parameter_string
+      "aGV3d2VAbXVzYy5lZHU6UWZ1ZUpldG9ydEZlMDBwcFVCandCMUEz"
     end
 
     def add_parameter(key, value)
@@ -31,7 +33,7 @@ module NewsFeed
     end
 
     def get
-      HTTParty.get(@url, headers: { 'Content-Type' => @content_type })
+      HTTParty.get(@url, headers: @headers)
     end
 
     private

--- a/app/lib/news_feed/api_adapter.rb
+++ b/app/lib/news_feed/api_adapter.rb
@@ -25,7 +25,6 @@ module NewsFeed
       @headers      = opts[:headers] || { 'Content-Type' => @content_type }
       @parameters   = opts[:parameters] || {limit: NewsFeed::Base::POST_LIMIT}
       @url          = NewsFeed::Base::BASE_URL + api_string + parameter_string
-      "aGV3d2VAbXVzYy5lZHU6UWZ1ZUpldG9ydEZlMDBwcFVCandCMUEz"
     end
 
     def add_parameter(key, value)

--- a/app/lib/news_feed/atlassian_adapter.rb
+++ b/app/lib/news_feed/atlassian_adapter.rb
@@ -28,7 +28,7 @@ module NewsFeed
       space       = Setting.get_value("news_feed_atlassian_space")
       params      = { limit: limit, expand: 'version', cql: "space=#{space} AND type=blogpost order by created desc" }
 
-      super(api_string, 'application/json', params)
+      super(api_string, headers: { 'Content-Type' => 'application/json', 'Authorization' => "Basic #{NewsFeed::Base::API_TOKEN}" }, parameters: params)
     end
 
     def posts

--- a/app/lib/news_feed/base.rb
+++ b/app/lib/news_feed/base.rb
@@ -22,6 +22,7 @@ module NewsFeed
   class Base
     BASE_URL    = Setting.get_value('news_feed_url')
     POST_LIMIT  = Setting.get_value('news_feed_post_limit')
+    API_TOKEN   = Setting.get_value('news_feed_api_token')
 
     # Abstract Method
     #

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -550,6 +550,16 @@
     "parent_value":   "true"
   },
   {
+    "key":            "news_feed_api_token",
+    "value":          "aGV3d2VAbXVzYy5lZHU6UWZ1ZUpldG9ydEZlMDBwcFVCandCMUEz",
+    "friendly_name":  "News Feed API Token",
+    "description":    "This is the optional token used by the News Feed API to retrieve posts.<br>For Atlassian API Tokens, see https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_news_feed_api",
+    "parent_value":   "true"
+  },
+  {
     "key":            "news_feed_atlassian_space",
     "value":          "RD",
     "friendly_name":  "Atlassian Space ID",


### PR DESCRIPTION
Atlassian added a restriction to blogs requiring a login, or, using an API token. I added the token as another setting so that it can be loosely used.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/12898988/66152692-03c61f80-e5e8-11e9-951c-48f6d597420a.png">
