### PR TITLE
SAW - Bootstrap 4 Subsidies Bugs

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -22,7 +22,13 @@ module NotesHelper
   def notes_button(notable, opts={})
     has_notes = notable.notes.length > 0
 
-    link_to notes_path(note: { notable_id: notable.id, notable_type: notable.class.name }, protocol_id: opts[:protocol_id], srid: opts[:srid], ssrid: opts[:ssrid]), remote: true, id: "#{notable.class.name.downcase}#{notable.id}Notes", class: ['btn btn-light position-relative', opts[:class], opts[:disabled] ? 'disabled' : '', opts[:model] ? '' : 'btn-sq'], title: opts[:tooltip], data: { toggle: opts[:tooltip] ? 'tooltip' : '' } do
+    if notable.is_a?(Subsidy) || notable.is_a?(Protocol)
+      notable_type = notable.class.superclass.name
+    else
+      notable_type = notable.class.name
+    end
+
+    link_to notes_path(note: { notable_id: notable.id, notable_type: notable_type }, protocol_id: opts[:protocol_id], srid: opts[:srid], ssrid: opts[:ssrid]), remote: true, id: "#{notable.class.name.downcase}#{notable.id}Notes", class: ['btn btn-light position-relative', opts[:class], opts[:disabled] ? 'disabled' : '', opts[:model] ? '' : 'btn-sq'], title: opts[:tooltip], data: { toggle: opts[:tooltip] ? 'tooltip' : '' } do
       raw(icon('far', 'sticky-note') + content_tag(:span, format_count(notable.notes.length, 1), class: ['badge badge-pill badge-c notification-badge', has_notes ? 'badge-warning ' : 'badge-secondary'])) + (opts[:model] ? content_tag(:span, (opts[:model].is_a?(String) ? opts[:model] : opts[:model].model_name.human) + " " + Note.model_name.plural.capitalize, class: 'ml-2') : '')
     end
   end

--- a/app/views/protocols/_summary.html.haml
+++ b/app/views/protocols/_summary.html.haml
@@ -27,12 +27,12 @@
       = I18n.t('protocols.summary.header', protocol_type: protocol.model_name.human)
     .protocol-links-container<
       - if in_dashboard?
-        = notes_button(protocol.becomes(Protocol), protocol_id: protocol.id, model: protocol, tooltip: t(:protocols)[:summary][:tooltips][:notes], class: 'mr-1')
+        = notes_button(protocol, protocol_id: protocol.id, model: protocol, tooltip: t(:protocols)[:summary][:tooltips][:notes], class: 'mr-1')
         = protocol_details_button(protocol)
         = edit_protocol_button(protocol, permission: permission_to_edit || admin)
         = archive_protocol_button(protocol, permission: permission_to_edit || Protocol.for_super_user(current_user.id).include?(protocol))
       - else
-        = notes_button(protocol.becomes(Protocol), srid: service_request.id, model: protocol, tooltip: t(:protocols)[:summary][:tooltips][:notes], class: 'mr-1')
+        = notes_button(protocol, srid: service_request.id, model: protocol, tooltip: t(:protocols)[:summary][:tooltips][:notes], class: 'mr-1')
         = protocol_details_button(protocol, srid: service_request.id)
         - unless in_review?
           = edit_protocol_button(protocol, srid: service_request.id)

--- a/app/views/subsidies/_form.html.haml
+++ b/app/views/subsidies/_form.html.haml
@@ -32,13 +32,13 @@
       .modal-body
         %table.table.table-bordered
           %tr
-            %td.col-6
+            %td.w-50
               .d-flex.justify-content-between
                 %span{ title: t(:subsidies)[:tooltips][:request_cost],  data: { toggle: 'tooltip' } }
                   = Subsidy.human_attribute_name(:request_cost)
                 %span#subsidy_form_table_request_cost{ data: { cost:  subsidy.total_request_cost } }
                   = number_to_currency(subsidy.total_request_cost / 100.0)
-            %td.col-6
+            %td.w-50
               .d-flex.justify-content-between
                 %span{ title: t(:subsidies)[:tooltips][:cost], data: {  toggle: 'tooltip' } }
                   = Subsidy.human_attribute_name(:subsidy_cost)


### PR DESCRIPTION
Fixed Subsidy bugs according to comments on [#166643302](https://www.pivotaltracker.com/story/show/166643302).

- The table inside the modal to request a subsidy was resized to be equal widths (this was originally working in Firefox but not Chrome).
- Fixed bug where notes were not properly added to a subsidy.