### PR TITLE
Only show cost analysis report when has clinical services

### DIFF
--- a/app/views/dashboard/service_requests/_service_requests.html.haml
+++ b/app/views/dashboard/service_requests/_service_requests.html.haml
@@ -49,7 +49,7 @@
             .dropdown-menu.dropdown-menu-right{ aria: { labelledby: "coverageAnalysis#{sr.id}" } }
               = link_to t(:calendars)[:show_chosen_services], service_request_path(srid: sr.id, display_all_services: false, format: :xlsx, report_type: 'coverage_analysis', show_signature_section: true), class: 'dropdown-item'
               = link_to t(:calendars)[:show_all_services], service_request_path(srid: sr.id, display_all_services: true, format: :xlsx, report_type: 'coverage_analysis', show_signature_section: true), class: 'dropdown-item'
-        - if protocol.is_a?(Study)
+        - if protocol.is_study? && protocol.has_clinical_services?
           = link_to dashboard_protocol_path(protocol, format: :pdf), target: :blank, class: 'btn btn-success cost-analysis' do
             = succeed t('dashboard.protocols.service_requests.cost_analysis_report') do
               = icon('fas', 'file-pdf mr-2')

--- a/app/views/service_calendars/_view_full_calendar.html.haml
+++ b/app/views/service_calendars/_view_full_calendar.html.haml
@@ -28,7 +28,7 @@
     .modal-body#serviceCalendar
       = hidden_field_tag :srid, service_request.id, disabled: true
       .d-flex.justify-content-between.mb-1
-        - if service_request.protocol.is_study?
+        - if service_request.protocol.is_study? && service_request.protocol.has_clinical_services?
           = link_to dashboard_protocol_path(service_request.protocol, format: :pdf), target: :blank, class: 'btn btn-lg btn-success' do
             = succeed t('dashboard.protocols.service_requests.cost_analysis_report') do
               = icon('fas', 'file-pdf mr-2')


### PR DESCRIPTION
Because the current version of the report only shows clinical
services, the report is not very useful otherwise.

This hides the button so that users who wouldn't get any value
from the report don't see and and click through and be
disappointed.