### PR TITLE
SAW - Dependent Questions Bug Fixes

### DIFF
--- a/app/assets/javascripts/surveyor/responses.js.coffee
+++ b/app/assets/javascripts/surveyor/responses.js.coffee
@@ -31,11 +31,12 @@ $(document).ready ->
     $(this).find('input').prop('checked', true)
 
   $(document).on 'change', '.option input', ->
-    if ($(this).prop('type') == 'checkbox' && $(this).prop('id').endsWith('for_dependent')) || $(this).prop('type') == 'radio'
+    if $(this).prop('type') == 'checkbox' || $(this).prop('type') == 'radio'
       question_id = $(this).parents('.option').data('question-id')
       option_id = $(this).parents('.option').data('option-id')
 
-      $(".dependent-for-question-#{question_id}").addClass('d-none')
+      if $(this).prop('type') == 'radio'
+        $(".dependent-for-question-#{question_id}").addClass('d-none')
 
       if $(this).is(":checked")
         $(".dependent-for-option-#{option_id}").removeClass('d-none')

--- a/app/models/question_response.rb
+++ b/app/models/question_response.rb
@@ -86,10 +86,14 @@ class QuestionResponse < ActiveRecord::Base
   end
 
   def depender_selected?
-    self.depender && self.response.question_responses.detect{ |qr| qr.question_id == self.depender.question_id }.try(:content).try(:downcase) == self.depender.content.downcase
+    self.depender && split_options(self.response.question_responses.detect{ |qr| qr.question_id == self.depender.question_id }.try(:content).try(:downcase)).include?(self.depender.content.downcase)
   end
 
   private
+
+  def split_options(content)
+    !content.nil? && content.start_with?("[\"") && content.end_with?("\"]") ? content.tr("[]\"", "").split(',').map(&:strip) : content
+  end
 
   def remove_unanswered
     return false if self.required? && self.content.blank?

--- a/app/views/surveyor/responses/form/form_partials/_checkbox_form_partial.html.haml
+++ b/app/views/surveyor/responses/form/form_partials/_checkbox_form_partial.html.haml
@@ -21,7 +21,7 @@
   - question.options.each do |option|
     .form-check.option.mb-1{ data: { question_id: question.id, option_id: option.id } }
       - if ['new', 'edit', 'preview'].include?(action_name)
-        = qr.check_box :content, { multiple: true, class: 'form-check-input mt-1' }, option.content, nil
+        = qr.check_box :content, { multiple: true, checked: question_response.content.nil? ? false : multiple_select_formatter(question_response.content.try(:downcase)).include?(option.content.downcase), class: 'form-check-input mt-1' }, option.content, nil
         .form-check-label
           = option.content
       - else


### PR DESCRIPTION
[(SPARCForms) Multiple Choice with Dependent Question Error - #168031795](https://www.pivotaltracker.com/story/show/168031795)

- Questions that are dependent on Survey/Form checkboxes now properly show and hide when previewing or responding to a Survey/Form.
- Questions that are dependent on Survey/Form checkboxes now properly show dependent question response when viewing a response.
- I found and fixed an issue where the response to a checkbox question is not showing up as a checked option when editing a response. Checkboxes now have the response already checked when editing a response (like every other type of question).