### PR TITLE
Adjust link buttons in funding Actions column

### DIFF
--- a/app/helpers/funding/documents_helper.rb
+++ b/app/helpers/funding/documents_helper.rb
@@ -45,13 +45,13 @@ module Funding::DocumentsHelper
 
   def protocol_button(ssr)
     content_tag :div, class: 'p-1' do
-      link_to t(:funding)[:download][:table][:actions][:protocol], "/dashboard/protocols/#{ssr.protocol.id}", title: t('funding.download.table.tooltips.protocol'), class: "btn btn-success btn-md protocol-btn", data: { toggle: 'tooltip', boundary: 'window' }, target: :_blank
+      link_to icon('fas', 'eye'), "/dashboard/protocols/#{ssr.protocol.id}", title: t('funding.download.table.tooltips.protocol'), class: 'btn btn-info mx-1 view-protocol', data: { toggle: 'tooltip', boundary: 'window' }, target: :_blank
     end
   end
 
   def admin_edit_button(ssr)
     content_tag :div, class: 'p-1' do
-      link_to t(:funding)[:download][:table][:actions][:admin_edit], "/dashboard/sub_service_requests/#{ssr.id}", title: t('funding.download.table.tooltips.admin_edit'), class: "btn btn-warning btn-md admin-edit-btn", data: { toggle: 'tooltip', boundary: 'window' }, target: :_blank
+      link_to icon('fas', 'edit'), dashboard_sub_service_request_path(ssr), title: t('funding.download.table.tooltips.admin_edit'), class: "btn btn-warning edit-request", data: { toggle: 'tooltip', boundary: 'window' }, target: :_blank
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/166643702/comments/208988308

Replace Protocol and Admin Edit link buttons with view and edit icons, respectively, in Document Download table to fit the screen better.
![image](https://user-images.githubusercontent.com/7648699/69442686-a2cae600-0d12-11ea-84e7-76e7c633dd79.png)
