### PR TITLE
SAW - Mailer specs fixed

### DIFF
--- a/spec/support/emails/tables.rb
+++ b/spec/support/emails/tables.rb
@@ -20,6 +20,8 @@
 
 module EmailHelpers
   include ApplicationHelper
+  include ActionView::Helpers::TagHelper
+  include ActionView::Context
 
   def assert_email_project_information(mail_response)
     #assert correct protocol information is included in notification email
@@ -178,7 +180,9 @@ module EmailHelpers
       expect(mail).to have_xpath "//th[text()='#{I18n.t(:notifier)[:note_user]}']/following-sibling::th[text()='#{I18n.t(:notifier)[:note_date]}']/following-sibling::th[text()='#{I18n.t(:notifier)[:note]}']"
 
       @protocol.notes.each do |note|
-        expect(mail).to have_xpath "//td[text()=\"#{note.identity.full_name}\"]/following-sibling::td[text()='#{format_date(note.created_at)}']/following-sibling::td[text()='#{note.body}']"
+        expect(mail).to have_xpath "//td[text()=\"#{note.identity.full_name}\"]"
+        expect(mail).to have_xpath "//td/span[text()='#{ActionController::Base.helpers.strip_tags(format_date(note.created_at))}']"
+        expect(mail).to have_xpath "//td[text()='#{note.body}']"
       end
     else
       expect(mail).to_not have_xpath "//table//th[text()='#{I18n.t('notifier.protocol_notes', type: @protocol.type)}']"


### PR DESCRIPTION
After changing `format_date` for [#169160786](https://www.pivotaltracker.com/story/show/169160786), several mailer specs were failing because `content_tag` was not available in mailer specs, or an xpath format was failing due to introducing a new span element. 

Specs that were fixed:
- /spec/mailers/notifier/deleted_all_services_spec.rb
- /spec/mailers/notifier/get_a_cost_estimate_spec.rb
- /spec/mailers/notifier/request_amendment_spec.rb
- /spec/mailers/notifier/submitted_spec.rb
