### PR TITLE
SAW - Guarantor Fields Bug

### DIFF
--- a/app/views/protocols/form/_financial_information.html.haml
+++ b/app/views/protocols/form/_financial_information.html.haml
@@ -82,5 +82,29 @@
                   = f.label :indirect_cost_rate, t('constants.currency'), class: 'input-group-text'
                 = f.text_field :indirect_cost_rate, class: 'form-control'
 
+        .form-row
+          %h4.pb-2.mb-2.border-bottom.w-100
+            = t('protocols.form.financial_information.guarantor_header')
+          .form-group.col-12
+            = f.label :guarantor_contact
+            .input-group
+              .input-group-prepend
+                = f.label :guarantor_contact, icon('fas', 'user'), class: 'input-group-text'
+              = f.text_field :guarantor_contact, class: 'form-control'
+          .form-group.col-6.persist-validation
+            = f.label :guarantor_phone
+            .input-group
+              .input-group-prepend
+                = f.label :guarantor_phone, icon('fas', 'phone'), class: 'input-group-text'
+              = f.phone_field :guarantor_phone, value: format_phone(f.object.guarantor_phone), class: 'form-control', placeholder: t('constants.phone.placeholder')
+            %span.form-text.text-muted
+              = t('constants.phone.note')
+          .form-group.col-6
+            = f.label :guarantor_email
+            .input-group
+              .input-group-prepend
+                = f.label :guarantor_email, icon('far', 'envelope'), class: 'input-group-text'
+              = f.text_field :guarantor_email, class: 'form-control'
+
       - if protocol.is_a?(Study)
         = render 'protocols/form/federal_grant_information', f: f, protocol: protocol

--- a/app/views/protocols/form/_protocol_information.html.haml
+++ b/app/views/protocols/form/_protocol_information.html.haml
@@ -50,29 +50,6 @@
           %span.form-text.text-muted
             = t('protocols.form.information.primary_pi.note')
 
-      - if protocol.is_a?(Study)
-        .form-row
-          .form-group.col-12
-            = f.label :guarantor_contact
-            .input-group
-              .input-group-prepend
-                = f.label :guarantor_contact, icon('fas', 'user'), class: 'input-group-text'
-              = f.text_field :guarantor_contact, class: 'form-control'
-          .form-group.col-6.persist-validation
-            = f.label :guarantor_phone
-            .input-group
-              .input-group-prepend
-                = f.label :guarantor_phone, icon('fas', 'phone'), class: 'input-group-text'
-              = f.phone_field :guarantor_phone, value: format_phone(f.object.guarantor_phone), class: 'form-control', placeholder: t('constants.phone.placeholder')
-            %span.form-text.text-muted
-              = t('constants.phone.note')
-          .form-group.col-6
-            = f.label :guarantor_email
-            .input-group
-              .input-group-prepend
-                = f.label :guarantor_email, icon('far', 'envelope'), class: 'input-group-text'
-              = f.text_field :guarantor_email, class: 'form-control'
-
       - if protocol.is_a?(Study) && Setting.get_value("use_epic")
         .form-group
           = f.label :selected_for_epic, class: [protocol.bypass_stq_validation ? '' : 'required'], title: t('protocols.tooltips.epic'), data: { toggle: 'tooltip', placement: 'right' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -753,6 +753,7 @@ en:
         study_type_note: "Note: %{note}"
       financial_information:
         header: "Financial Information"
+        guarantor_header: "Guarantor Information"
       grant_information:
         header: "Federal Grant Information"
         sponsor_separator: "- OR -"


### PR DESCRIPTION
[#170156418](https://www.pivotaltracker.com/story/show/170156418)

Moved guarantor contact information from the General Information section to the Financial Information section in Step 2 and on the Dashboard.

<img width="797" alt="image" src="https://user-images.githubusercontent.com/19152930/70563828-ef108580-1b5c-11ea-8365-cf429c92c027.png">