### PR TITLE
SAW - Guarantor Fields Bug

### DIFF
--- a/app/views/protocols/form/_financial_information.html.haml
+++ b/app/views/protocols/form/_financial_information.html.haml
@@ -83,8 +83,9 @@
                 = f.text_field :indirect_cost_rate, class: 'form-control'
 
         .form-row
-          %h4.pb-2.mb-2.border-bottom.w-100
-            = t('protocols.form.financial_information.guarantor_header')
+          .form-group.col-12.mb-2
+            %h4.pb-2.border-bottom.w-100
+              = t('protocols.form.financial_information.guarantor_header')
           .form-group.col-12
             = f.label :guarantor_contact
             .input-group


### PR DESCRIPTION
[https://www.pivotaltracker.com/story/show/170156418](https://www.pivotaltracker.com/story/show/170156418)

The guarantor header was wrapped in a form group so that the width of the line matches the rest of the form. Before these changes, it was wider than the form by a few pixels.