### PR TITLE
SAW - RMID Label Bugs

### DIFF
--- a/app/helpers/dashboard/protocols_helper.rb
+++ b/app/helpers/dashboard/protocols_helper.rb
@@ -35,7 +35,10 @@ module Dashboard::ProtocolsHelper
   end
 
   def protocol_short_title_link(protocol)
-    link_to protocol.short_title, dashboard_protocol_path(protocol)
+    [
+      link_to(protocol.short_title, dashboard_protocol_path(protocol)),
+      display_rmid_validated_protocol(protocol, Protocol.human_attribute_name(:short_title))
+    ].join('')
   end
 
   def pis_display(protocol)

--- a/app/views/protocols/view_details/_protocol_information.html.haml
+++ b/app/views/protocols/view_details/_protocol_information.html.haml
@@ -41,7 +41,7 @@
             = label :protocol, :short_title, class: 'mb-0', title: t(:protocols)[:tooltips][:short_title], data: { toggle: 'tooltip', placement: 'right' }
           %td.d-inline-block.col-9
             = protocol.short_title
-            = display_rmid_validated_protocol(protocol, t('protocols.summary.rmid_short_title'))
+            = display_rmid_validated_protocol(protocol, Protocol.human_attribute_name(:short_title))
         - if protocol.is_a?(Project)
           %tr.d-flex
             %td.d-inline-block.col-3


### PR DESCRIPTION
[#170383881](https://www.pivotaltracker.com/story/show/170383881)

RMID verification labels are now present on the Dashboard protocols table, and missing YML text was replaced with the proper attribute text so that an error isn't in the RMID label.