### PR TITLE
SAW - Never Submitted Confirmation Bug Fixes

### DIFF
--- a/app/lib/remove_service.rb
+++ b/app/lib/remove_service.rb
@@ -29,7 +29,8 @@ class RemoveService
   end
 
   def confirm_previously_submitted?
-    !@confirmed && @ssr.previously_submitted?
+    # If the SSR is in draft status, treat it as if it hasn't been submitted before.
+    !@confirmed && @ssr.previously_submitted? && !@ssr.is_in_draft?
   end
 
   def confirm_last_service?

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -325,6 +325,10 @@ class SubServiceRequest < ApplicationRecord
     Status.complete?(self.status) && process_ssrs_organization.has_editable_status?(self.status)
   end
 
+  def is_in_draft?
+    self.status == 'draft'
+  end
+
   def set_to_draft
     self.update_attributes(status: 'draft') unless status == 'draft'
   end

--- a/app/views/service_requests/remove_service.js.coffee
+++ b/app/views/service_requests/remove_service.js.coffee
@@ -24,7 +24,7 @@ unless window.confirmedSSRs?
 if !window.confirmedSSRs.includes(<%= @remove_service.sub_service_request.id %>)
   ConfirmSwal.fire(
     title: I18n.t('proper.cart.request_submitted.header')
-    text: I18n.t('proper.cart.request_submitted.warning', protocol_type: "<%= 'Study' %>")
+    html: I18n.t('proper.cart.request_submitted.warning', protocol_type: "<%= 'Study' %>")
   ).then (result) ->
     if result.value
       window.confirmedSSRs.push(<%= @remove_service.sub_service_request.id %>)


### PR DESCRIPTION
[#170348115](https://www.pivotaltracker.com/story/show/170348115)

The confirmation for deleting a service no longer appears if the given sub service request is in "draft" status. Also, the `<br>` tags render in the confirmation message.