### PR TITLE
SJ - Linked services bug fix

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -67,6 +67,10 @@ class LineItem < ApplicationRecord
     joins(:sub_service_request).where.not(sub_service_requests: { status: Status.complete })
   }
 
+  scope :unassigned, -> {
+    where(sub_service_request_id: nil)
+  }
+
   def friendly_notable_type
     Service.model_name.human
   end

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -95,7 +95,7 @@ class ServiceRequest < ApplicationRecord
     recursive_call        = args[:recursive_call]
 
     # If this service has already been added, then do nothing
-    return if !allow_duplicates && self.line_items.incomplete.where(service_id: service.id).any?
+    return if !allow_duplicates && (self.line_items.incomplete.where(service_id: service.id).any? or self.line_items.unassigned.where(service_id: service.id).any?)
 
     line_items = []
 


### PR DESCRIPTION
Fixing psuedo-infinite loop on adding linked services. The check for duplicate services was scoped to "incomplete" which uses ssr_id. However, new services don't HAVE an ssr ID, so it just kept going until it failed both services once and errored out.

[#170390420]

https://www.pivotaltracker.com/story/show/170390420