### PR TITLE
KG - Revert use_<oauth_provider>_only Routes Changes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,15 +28,13 @@ SparcRails::Application.routes.draw do
       devise_for :identities,
                  controllers: {
                    omniauth_callbacks: 'identities/omniauth_callbacks',
-                   registrations: 'identities/registrations',
-                 }, path_names: { sign_in: 'auth/shibboleth', sign_up: 'auth/shibboleth' }
+                 }, path_names: { sign_in: 'auth/shibboleth' }
 
     elsif Setting.get_value("use_cas_only")
       devise_for :identities,
                  controllers: {
                    omniauth_callbacks: 'identities/omniauth_callbacks',
-                   registrations: 'identities/registrations',
-                 }, path_names: { sign_in: 'auth/cas', sign_up: 'auth/cas' }
+                 }, path_names: { sign_in: 'auth/cas' }
     else
       devise_for :identities,
                  controllers: {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170457504

Revert the `routes.rb` config for the `user<ouath_provider>_only` blocks to what it was in `v3.5.0`. The registrations controller option and sign_up options aren't needed in this case and cause the application to show the login page rather than redirect to the oauth provider login.