### PR TITLE
KG - Request Details Datepicker Bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,18 +19,26 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module ApplicationHelper
-  def format_date(date)
+  def format_date(date, opts={})
     if date.present?
-      content_tag :span do
-        raw date.strftime('%m/%d/%Y')
+      if opts[:html]
+        content_tag :span do
+          raw date.strftime('%m/%d/%Y')
+        end
+      else
+        date.strftime('%m/%d/%Y')
       end
     end
   end
 
-  def format_datetime(datetime)
+  def format_datetime(datetime, opts={})
     if datetime.present?
-      content_tag :span do
-        raw datetime.strftime('%m/%d/%Y %l:%M') + content_tag(:span, datetime.strftime(':%S'), class: 'd-none') + datetime.strftime(' %p')
+      if opts[:html]
+        content_tag :span do
+          raw datetime.strftime('%m/%d/%Y %l:%M') + content_tag(:span, datetime.strftime(':%S'), class: 'd-none') + datetime.strftime(' %p')
+        end
+      else
+        datetime.strftime('%m/%d/%Y %l:%M')
       end
     end
   end

--- a/app/helpers/dashboard/notifications_helper.rb
+++ b/app/helpers/dashboard/notifications_helper.rb
@@ -36,9 +36,9 @@ module Dashboard::NotificationsHelper
 
   def notification_time_display(notification)
     unless notification.messages.empty?
-      format_datetime(notification.messages.last.created_at)
+      format_datetime(notification.messages.last.created_at, html: true)
     else
-      format_datetime(notification.updated_at)
+      format_datetime(notification.updated_at, html: true)
     end
   end
 

--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -79,7 +79,7 @@ module Dashboard::SubServiceRequestsHelper
     if sub_service_request.surveys_completed?
       content_tag :div, t('dashboard.sub_service_requests.header.surveys.completed'), class: 'alert alert-sm alert-success mb-0'
     else
-      link_to resend_surveys_dashboard_sub_service_request_path(sub_service_request), remote: true, method: :put, class: 'btn btn-warning', id: "resendSurveys", onclick: "$(this).addClass('disabled')", title: t('dashboard.sub_service_requests.header.surveys.last_sent', date: format_date(sub_service_request.survey_latest_sent_date)), data: { toggle: 'tooltip', html: 'true' } do
+      link_to resend_surveys_dashboard_sub_service_request_path(sub_service_request), remote: true, method: :put, class: 'btn btn-warning', id: "resendSurveys", onclick: "$(this).addClass('disabled')", title: t('dashboard.sub_service_requests.header.surveys.last_sent', date: format_date(sub_service_request.survey_latest_sent_date, html: true)), data: { toggle: 'tooltip', html: 'true' } do
         icon('fas', 'clipboard-list mr-2') + t('dashboard.sub_service_requests.header.surveys.resend')
       end
     end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -69,9 +69,9 @@ module NotesHelper
   def note_date(note)
     content_tag :small, class: 'text-muted mb-0' do
       if note.created_at == note.updated_at
-        format_datetime(note.created_at)
+        format_datetime(note.created_at, html: true)
       else
-        raw(format_datetime(note.updated_at) + content_tag(:i, t('notes.edited'), class: 'ml-1'))
+        raw(format_datetime(note.updated_at, html: true) + content_tag(:i, t('notes.edited'), class: 'ml-1'))
       end
     end
   end

--- a/app/views/dashboard/documents/index.json.jbuilder
+++ b/app/views/dashboard/documents/index.json.jbuilder
@@ -2,8 +2,8 @@ json.(@documents) do |doc|
   permission = current_user.catalog_overlord? || @permission_to_edit || (@admin_orgs & doc.all_organizations).any?
 
   json.document    display_document_title(doc, permission: permission)
-	json.type        doc.display_document_type
-	json.uploaded    format_datetime(doc.document_updated_at)
+  json.type        doc.display_document_type
+  json.uploaded    format_datetime(doc.document_updated_at, html: true)
   json.shared_with display_document_providers(doc)
   json.actions     document_actions(doc, permission: permission)
 end

--- a/app/views/dashboard/fulfillments/index.json.jbuilder
+++ b/app/views/dashboard/fulfillments/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.(@fulfillments) do |fulfillment|
-  json.fulfillment_date format_date(fulfillment.date)
+  json.fulfillment_date format_date(fulfillment.date, html: true)
   json.quantity         fulfillment.time
   json.quantity_type    fulfillment.timeframe
   json.notes            notes_button(fulfillment, ssrid: @sub_service_request.id)

--- a/app/views/dashboard/study_level_activities/index.json.jbuilder
+++ b/app/views/dashboard/study_level_activities/index.json.jbuilder
@@ -9,7 +9,7 @@ json.(@line_items) do |line_item|
   json.service_rate       sla_service_rate_display(line_item)
   json.cost               sla_your_cost_field(line_item)
   json.total              display_one_time_fee_direct_cost(line_item)
-  json.date_started       format_date(line_item.in_process_date)
-  json.date_completed     format_date(line_item.complete_date)
+  json.date_started       format_date(line_item.in_process_date, html: true)
+  json.date_completed     format_date(line_item.complete_date, html: true)
   json.actions            sla_actions(line_item)
 end

--- a/app/views/dashboard/sub_service_requests/approval_history.json.jbuilder
+++ b/app/views/dashboard/sub_service_requests/approval_history.json.jbuilder
@@ -1,5 +1,5 @@
 json.(@approvals) do |approval|
-  json.date format_datetime(approval.approval_date)
+  json.date format_datetime(approval.approval_date, html: true)
   json.type approval.approval_type
   json.name approval.identity.full_name
 end

--- a/app/views/dashboard/sub_service_requests/refresh_tab.js.coffee
+++ b/app/views/dashboard/sub_service_requests/refresh_tab.js.coffee
@@ -18,8 +18,6 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-initialLoad = $('#requestLoading').hasClass('show')
-
 $('#adminTabs').replaceWith("<%= j render 'dashboard/sub_service_requests/tabs', sub_service_request: @sub_service_request %>")
 $('#requestLoading').removeClass('active show')
 $("#<%= @tab.camelize(:lower) %>Tab").html('<%= j render "dashboard/sub_service_requests/#{@tab}", service_request: @service_request, sub_service_request: @sub_service_request, tab: @tab, page: @page, pages: @pages %>').addClass('active show')
@@ -28,5 +26,4 @@ $("#<%= @tab.camelize(:lower) %>Tab").html('<%= j render "dashboard/sub_service_
 loadServiceCalendar()
 <% end %>
 
-if !initialLoad || "<%= @tab %>" != 'details'
-  $(document).trigger('ajax:complete') # rails-ujs element replacement bug fix
+$(document).trigger('ajax:complete') # rails-ujs element replacement bug fix

--- a/app/views/dashboard/sub_service_requests/status_history.json.jbuilder
+++ b/app/views/dashboard/sub_service_requests/status_history.json.jbuilder
@@ -1,5 +1,5 @@
 json.(@past_statuses) do |status|
-  json.created_at format_datetime(status.date)
+  json.created_at format_datetime(status.date, html: true)
   json.changed_from PermissibleValue.get_value('status', status.status)
   json.changed_to PermissibleValue.get_value('status', status.changed_to)
   json.changed_by status.changer.try(:full_name)

--- a/app/views/dashboard/sub_service_requests/subsidy_history.json.jbuilder
+++ b/app/views/dashboard/sub_service_requests/subsidy_history.json.jbuilder
@@ -1,5 +1,5 @@
 json.(@subsidies) do |subsidy|
-  json.date             format_datetime(subsidy.approved_at)
+  json.date             format_datetime(subsidy.approved_at, html: true)
   json.request_cost     number_to_currency(subsidy.total_at_approval/100.0)
   json.percent          (subsidy.percent_subsidy * 100.0).round(2)
   json.pi_contribution  number_to_currency(subsidy.pi_contribution/100.0)

--- a/app/views/documents/index.json.jbuilder
+++ b/app/views/documents/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.(@documents) do |doc|
   json.document     display_document_title(doc)
   json.type         doc.display_document_type
-  json.uploaded     format_date(doc.document_updated_at)
+  json.uploaded     format_date(doc.document_updated_at, html: true)
   json.shared_with  display_document_providers(doc)
   json.actions      document_actions(doc, srid: @service_request.id)
 end

--- a/app/views/funding/services/documents.json.jbuilder
+++ b/app/views/funding/services/documents.json.jbuilder
@@ -6,7 +6,7 @@ json.(@funding_documents) do |document|
   json.srid ssr.display_id
   json.short_title ssr.protocol.short_title
   json.doc_title display_funding_document_title(document)
-  json.uploaded format_datetime(document.document_updated_at)
+  json.uploaded format_datetime(document.document_updated_at, html: true)
   json.status PermissibleValue.get_value('status', ssr.status)
   json.actions display_actions(ssr)
 end

--- a/app/views/funding/services/index.json.jbuilder
+++ b/app/views/funding/services/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.(@services) do |service|
   json.title         service.abbreviation
   json.program       service.organization.name
-  json.created       format_date(service.created_at)
+  json.created       format_date(service.created_at, html: true)
   json.action        display_download_button(service, current_user.is_funding_admin?)
 end

--- a/app/views/surveyor/responses/index.json.jbuilder
+++ b/app/views/surveyor/responses/index.json.jbuilder
@@ -13,7 +13,7 @@ json.(@responses) do |response|
   json.title            response.survey.full_title
   json.by               response.identity.try(:full_name) || 'N/A'
   json.complete         complete_display(response)
-  json.completion_date  response.completed? ? format_date(response.created_at) : ""
-  json.survey_sent_date format_date(response.updated_at)
+  json.completion_date  response.completed? ? format_date(response.created_at, html: true) : ""
+  json.survey_sent_date format_date(response.updated_at, html: true)
   json.actions          response_options(response, accessible_surveys)
 end

--- a/spec/support/emails/tables.rb
+++ b/spec/support/emails/tables.rb
@@ -181,7 +181,7 @@ module EmailHelpers
 
       @protocol.notes.each do |note|
         expect(mail).to have_xpath "//td[text()=\"#{note.identity.full_name}\"]"
-        expect(mail).to have_xpath "//td/span[text()='#{ActionController::Base.helpers.strip_tags(format_date(note.created_at))}']"
+        expect(mail).to have_xpath "//td[text()='#{format_date(note.created_at)}']"
         expect(mail).to have_xpath "//td[text()='#{note.body}']"
       end
     else


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170490034

Because HTML text inputs don't support HTML strings we need to have a way to format dates/datetimes without HTML. The purpose of the HTML is exclusively for sorting in Bootstrap tables.