### PR TITLE
KG - RMID Fixes

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -220,6 +220,7 @@ updateRmidFields = () ->
       dataType: 'script'
       url: '/protocols/validate_rmid'
       data:
+        protocol_id: $('#protocol_id').val()
         protocol:
           research_master_id: rmid
     )

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -104,7 +104,9 @@ class ProtocolsController < ApplicationController
       @protocol = Protocol.new(protocol_params)
       @protocol.valid?
 
-      unless (@errors = @protocol.errors.messages[:base]).any?
+      @errors = @protocol.errors.messages[:base] + @protocol.errors.messages[:research_master_id]
+
+      unless @errors.any?
         @rmid_record = Protocol.get_rmid(protocol_params[:research_master_id])
       end
     end

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -101,9 +101,13 @@ class ProtocolsController < ApplicationController
     respond_to :js
 
     if protocol_params[:research_master_id]
-      @protocol = Protocol.new(protocol_params)
+      if params[:protocol_id].present?
+        @protocol = Protocol.find(params[:protocol_id])
+        @protocol.assign_attributes(protocol_params)
+      else
+        @protocol = Protocol.new(protocol_params)
+      end
       @protocol.valid?
-
       @errors = @protocol.errors.messages[:base] + @protocol.errors.messages[:research_master_id]
 
       unless @errors.any?

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -124,6 +124,7 @@ class Protocol < ApplicationRecord
   end
 
   def self.rmid_status
+    @@rmid_server_down = false
     begin
       HTTParty.get(Setting.get_value("research_master_api") + 'research_masters.json', headers: {'Content-Type' => 'application/json', 'Authorization' => "Token token=\"#{Setting.get_value("rmid_api_token")}\""})
       return true
@@ -134,6 +135,7 @@ class Protocol < ApplicationRecord
   end
 
   def self.get_rmid(rmid)
+    @@rmid_server_down = false
     begin
       HTTParty.get("#{Setting.get_value('research_master_api')}research_masters/#{rmid}.json", headers: { "Content-Type" => "application/json", "Authorization" => "Token token=\"#{Setting.get_value('rmid_api_token')}\"" })
     rescue

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -638,7 +638,7 @@ class Protocol < ApplicationRecord
   def validate_existing_rmid
     rmid = Protocol.get_rmid(self.research_master_id)
 
-    if self.research_master_id.present? && rmid['status'] == 404 && self.errors[:research_master_id].empty?
+    if self.research_master_id.present? && rmid['status'] == 404 && self.errors[:research_master_id].empty? 
       self.errors.add(:base, I18n.t('protocols.rmid.errors.not_found', rmid: self.research_master_id, rmid_link: Setting.get_value('research_master_link')))
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,8 @@ en:
               invalid: "Recruitment Start Date must come before Recruitment End Date"
             recruitment_start_date:
               invalid: "Recruitment Start Date must come before Recruitment End Date"
+            research_master_id:
+              not_a_number: "The Research Master ID entered is invalid."
             selected_for_epic:
               inclusion: "can't be blank"
             start_date:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170586100

# Issues Fixed
* Correctly display RMID not found popup
* Default `@@rmid_server_down` to `false` to prevent it from never being reassigned
* Fix unique RMID validation not considering the current Protocol
* When loading the protocol form for a protocol that already has an RMID, the `protocol_id` must be passed to ensure the unique RMID validation passes correctly