### PR TITLE
SAW - Protocol Information Form NCT# Validation Silent Failure

### DIFF
--- a/app/models/human_subjects_info.rb
+++ b/app/models/human_subjects_info.rb
@@ -27,6 +27,6 @@ class HumanSubjectsInfo < ApplicationRecord
   self.table_name = 'human_subjects_info'
 
   belongs_to :protocol
-  validates :nct_number, :numericality => {:allow_blank => true, :only_integer => true, :message => "must contain 8 numerical digits"}
-  validates :nct_number, :length => {:allow_blank => true, :is => 8, :message => "must contain 8 numerical digits"}
+  validates :nct_number, numericality: {allow_blank: true, only_integer: true, message: "must contain 8 numerical digits"}
+  validates :nct_number, length: {allow_blank: true, is: 8, message: "must contain 8 numerical digits"}
 end

--- a/app/views/dashboard/protocols/create.js.coffee
+++ b/app/views/dashboard/protocols/create.js.coffee
@@ -40,6 +40,12 @@ $("[name='protocol[primary_pi_role_attributes][<%= attr.to_s %>]']").parents('.f
 <% end %>
 <% end %>
 
+<% @protocol.human_subjects_info.errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='protocol[human_subjects_info_attributes][<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
+
 <% if @errors.messages[:study_type_answers][0] %>
 <% @errors.messages[:study_type_answers][0].each do |question_id, message| %>
 $("#study_type_answer_<%= question_id %>").children('.form-group:last-of-type').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")

--- a/app/views/dashboard/protocols/update.js.coffee
+++ b/app/views/dashboard/protocols/update.js.coffee
@@ -40,6 +40,12 @@ $("[name='protocol[primary_pi_role_attributes][<%= attr.to_s %>]']").parents('.f
 <% end %>
 <% end %>
 
+<% @protocol.human_subjects_info.errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='protocol[human_subjects_info_attributes][<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
+
 <% if @errors.messages[:study_type_answers][0] %>
 <% @errors.messages[:study_type_answers][0].each do |question_id, message| %>
 $("#study_type_answer_<%= question_id %>").children('.form-group:last-of-type').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")

--- a/app/views/protocols/create.js.coffee
+++ b/app/views/protocols/create.js.coffee
@@ -40,6 +40,12 @@ $("[name='protocol[primary_pi_role_attributes][<%= attr.to_s %>]']").parents('.f
 <% end %>
 <% end %>
 
+<% @protocol.human_subjects_info.errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='protocol[human_subjects_info_attributes][<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
+
 <% if @errors.messages[:study_type_answers][0] %>
 <% @errors.messages[:study_type_answers][0].each do |question_id, message| %>
 $("#study_type_answer_<%= question_id %>").children('.form-group:last-of-type').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")

--- a/app/views/protocols/update.js.coffee
+++ b/app/views/protocols/update.js.coffee
@@ -40,6 +40,12 @@ $("[name='protocol[primary_pi_role_attributes][<%= attr.to_s %>]']").parents('.f
 <% end %>
 <% end %>
 
+<% @protocol.human_subjects_info.errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='protocol[human_subjects_info_attributes][<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
+
 <% if @errors.messages[:study_type_answers][0] %>
 <% @errors.messages[:study_type_answers][0].each do |question_id, message| %>
 $("#study_type_answer_<%= question_id %>").children('.form-group:last-of-type').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")


### PR DESCRIPTION
[#170646883](https://www.pivotaltracker.com/story/show/170646883)

Human Subjects Info validations were functioning properly, but the error those validations produced was not being handled properly on the front end, resulting in a "silent error." The error messages are now iterated over properly in the dashboard and in SPARC, and the validations syntax in the Human Subjects Info was updated to git rid of `=>`s.