### PR TITLE
KG - Fix RMID Search & Study Type Note Authorization

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -21,9 +21,9 @@
 class ProtocolsController < ApplicationController
   respond_to :html, :js, :json
 
-  before_action :initialize_service_request,  except: [:approve_epic_rights, :push_to_epic, :push_to_epic_status]
-  before_action :authorize_identity,          except: [:approve_epic_rights, :push_to_epic, :push_to_epic_status]
-  before_action :find_protocol,               only:   [:edit, :update, :show]
+  before_action :initialize_service_request,  only: [:show, :new, :create, :edit, :update, :update_protocol_type]
+  before_action :authorize_identity,          only: [:show, :new, :create, :edit, :update, :update_protocol_type]
+  before_action :find_protocol,               only: [:show, :edit, :update]
 
   def show
     respond_to :js


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170853298

Fixes permissions for general users when:
1. Searching for an RMID record on the Protocol form
2. Changing the study type answers and displaying a study type note on the Protocol form