### PR TITLE
KG - Milestones Not Saving Values Bug

### DIFF
--- a/app/assets/javascripts/protocols.js.coffee
+++ b/app/assets/javascripts/protocols.js.coffee
@@ -92,8 +92,11 @@ $(document).ready ->
 
   $('#protocolInitialBudgetSponsorReceivedDatePicker').on('hide.datetimepicker', ->
     if $('#protocol_initial_budget_sponsor_received_date').val()
-      $('#protocol_initial_amount_clinical_services').val(initialAmountClinical).parents('.form-group').removeClass('d-none')
-      $('#protocol_initial_amount').val(initialAmountNonClinical).parents('.form-group').removeClass('d-none')
+      $('#protocol_initial_amount_clinical_services').parents('.form-group').removeClass('d-none')
+      $('#protocol_initial_amount').parents('.form-group').removeClass('d-none')
+    if initialAmountClinical
+      $('#protocol_initial_amount_clinical_services').val(initialAmountClinical)
+      $('#protocol_initial_amount').val(initialAmountNonClinical)
   ).on('change.datetimepicker', ->
     if !$('#protocol_initial_budget_sponsor_received_date').val()
       initialAmountClinical    = $('#protocol_initial_amount_clinical_services').val()
@@ -115,8 +118,11 @@ $(document).ready ->
 
   $('#protocolBudgetAgreedUponDatePicker').on('hide.datetimepicker', ->
     if $('#protocol_budget_agreed_upon_date').val()
-      $('#protocol_negotiated_amount_clinical_services').val(negotiatedAmountClinical).parents('.form-group').removeClass('d-none')
-      $('#protocol_negotiated_amount').val(negotiatedAmountNonClinical).parents('.form-group').removeClass('d-none')
+      $('#protocol_negotiated_amount_clinical_services').parents('.form-group').removeClass('d-none')
+      $('#protocol_negotiated_amount').parents('.form-group').removeClass('d-none')
+    if negotiatedAmountNonClinical
+      $('#protocol_negotiated_amount_clinical_services').val(negotiatedAmountClinical)
+      $('#protocol_negotiated_amount').val(negotiatedAmountNonClinical)
   ).on('change.datetimepicker', ->
     if !$('#protocol_budget_agreed_upon_date').val()
       negotiatedAmountClinical    = $('#protocol_negotiated_amount_clinical_services').val()

--- a/app/controllers/concerns/protocols_controller_shared.rb
+++ b/app/controllers/concerns/protocols_controller_shared.rb
@@ -45,9 +45,17 @@ module ProtocolsControllerShared
     end
 
     # Sanitize date formats
-    params[:protocol][:funding_start_date]           = sanitize_date params[:protocol][:funding_start_date]
-    params[:protocol][:potential_funding_start_date] = sanitize_date params[:protocol][:potential_funding_start_date]
-    params[:protocol][:guarantor_phone]              = sanitize_phone params[:protocol][:guarantor_phone]
+    params[:protocol][:start_date]                            = sanitize_date params[:protocol][:start_date]                            if params[:protocol][:start_date]
+    params[:protocol][:end_date]                              = sanitize_date params[:protocol][:end_date]                              if params[:protocol][:end_date]
+    params[:protocol][:initial_budget_sponsor_received_date]  = sanitize_date params[:protocol][:initial_budget_sponsor_received_date]  if params[:protocol][:initial_budget_sponsor_received_date]
+    params[:protocol][:budget_agreed_upon_date]               = sanitize_date params[:protocol][:budget_agreed_upon_date]               if params[:protocol][:budget_agreed_upon_date]
+    params[:protocol][:recruitment_start_date]                = sanitize_date params[:protocol][:recruitment_start_date]                if params[:protocol][:recruitment_start_date]
+    params[:protocol][:recruitment_end_date]                  = sanitize_date params[:protocol][:recruitment_end_date]                  if params[:protocol][:recruitment_end_date]
+    params[:protocol][:funding_start_date]                    = sanitize_date params[:protocol][:funding_start_date]                    if params[:protocol][:funding_start_date]
+    params[:protocol][:potential_funding_start_date]          = sanitize_date params[:protocol][:potential_funding_start_date]          if params[:protocol][:potential_funding_start_date]
+
+    # Sanitize phone formats
+    params[:protocol][:guarantor_phone] = sanitize_phone params[:protocol][:guarantor_phone] if params[:protocol][:guarantor_phone]
 
     if params[:protocol][:human_subjects_info_attributes]
       params[:protocol][:human_subjects_info_attributes][:initial_irb_approval_date] = sanitize_date params[:protocol][:human_subjects_info_attributes][:initial_irb_approval_date]
@@ -66,6 +74,7 @@ module ProtocolsControllerShared
       :billing_business_manager_static_email,
       :brief_description,
       :budget_agreed_upon_date,
+      :end_date,
       :federal_grant_code_id,
       :federal_grant_serial_number,
       :federal_grant_title,
@@ -97,6 +106,7 @@ module ProtocolsControllerShared
       :selected_for_epic,
       :short_title,
       :sponsor_name,
+      :start_date,
       :study_type_question_group_id,
       :title,
       :type,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170849787

Milestone dates were not being saved properly because their parameters had to be sanitized to the correct format to be saved. This wasn't apparent at first because TempusDominus datetimepickers seem to cache values so that they appeared to save unless doing a hard refresh (cmd+shift+r).

I also noticed that changing the budget agreed upon date initial budget sponsor received date would always reset the values of the amount fields, so I added a separate check to make sure the value cached in the JS variables weren't null before assigning them