### PR TITLE
KG - IE Document Upload Bug Remove Remotipart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ gem 'rails', '5.2.4'
 gem 'rails-html-sanitizer' # Check usage
 gem "rails-observers", git: 'https://github.com/rails/rails-observers.git' # Needed to used audited-activerecord w/ Rails 5
 gem 'redcarpet' # Check usage
-gem 'remotipart'
 gem 'rest-client' # Consider replacing usage with httparty
 gem 'request_store'
 gem 'sanitized_data',  git: 'https://github.com/HSSC/sanitized_data.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,6 @@ GEM
     rake (13.0.1)
     redcarpet (3.5.0)
     regexp_parser (1.6.0)
-    remotipart (1.4.3)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (3.0.0)
@@ -700,7 +699,6 @@ DEPENDENCIES
   rails-html-sanitizer
   rails-observers!
   redcarpet
-  remotipart
   request_store
   rest-client
   rspec-activemodel-mocks

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -42,7 +42,6 @@
 //= require custom/sweetalert-integration
 //= require jquery/dist/jquery.min
 //= require rails-ujs
-//= require jquery.remotipart
 
 //////////////////////////////////
 /// Require Remaining Packages ///

--- a/app/assets/javascripts/catalog_manager/application.js
+++ b/app/assets/javascripts/catalog_manager/application.js
@@ -32,7 +32,6 @@
 //= require catalog_manager/catalog
 //= require catalog_manager/form
 //= require jquery_ujs
-//= require jquery.remotipart
 //= require nprogress
 //= require nprogress-ajax
 //= require twitter/typeahead.min

--- a/app/views/documents/_form.html.haml
+++ b/app/views/documents/_form.html.haml
@@ -20,7 +20,7 @@
 
 .modal-dialog{ role: 'document' }
   .modal-content
-    = form_for in_dashboard? ? [:dashboard, document] : document, remote: true, multipart: true, authenticity_token: form_authenticity_token do |f|
+    = form_for in_dashboard? ? [:dashboard, document] : document, remote: true do |f|
       = f.hidden_field :protocol_id
       - unless in_dashboard?
         = hidden_field_tag :srid, service_request.id


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170648500

Yet again another attempt. This time trying to remove Remotipart altogether. Rails 5 introduced native file handling and file uploads seem to work without Remotipart. Let's see if this fixes IE?