### PR TITLE
hide extra fields in study general information view when configuratio…

### DIFF
--- a/app/views/protocols/view_details/_protocol_information.html.haml
+++ b/app/views/protocols/view_details/_protocol_information.html.haml
@@ -25,7 +25,7 @@
         = t('protocols.form.information.header')
     %table.table.mb-0
       %tbody
-        - if protocol.is_a?(Study)
+        - if protocol.is_a?(Study) && Setting.get_value("research_master_enabled")
           %tr.d-flex
             %td.d-inline-block.col-3
               = label :protocol, :research_master_id, class: 'mb-0'
@@ -54,11 +54,12 @@
           %td.d-inline-block.col-9
             = protocol.primary_pi.display_name
         - if protocol.is_a?(Study)
-          %tr.d-flex
-            %td.d-inline-block.col-3
-              = label :protocol, :selected_for_epic, class: 'mb-0'
-            %td.d-inline-block.col-9
-              = protocol.selected_for_epic ? t('constants.yes_select') : t('constants.no_select')
+          - if Setting.get_value("use_epic")
+            %tr.d-flex
+              %td.d-inline-block.col-3
+                = label :protocol, :selected_for_epic, class: 'mb-0'
+              %td.d-inline-block.col-9
+                = protocol.selected_for_epic ? t('constants.yes_select') : t('constants.no_select')
 
           - if display_readonly_study_type_questions?(protocol) && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
             %tr.bg-light

--- a/spec/views/protocols/view_details/_protocol_information.html.haml_spec.rb
+++ b/spec/views/protocols/view_details/_protocol_information.html.haml_spec.rb
@@ -34,10 +34,25 @@ RSpec.describe 'protocols/view_details/_protocol_information', type: :view do
   context 'viewing study' do
     let!(:protocol) { create(:study_without_validations, primary_pi: create(:identity), research_master_id: 1234) }
 
-    it 'should show the RMID column' do
-      render 'protocols/view_details/protocol_information', protocol: protocol
+    context  'RMID is enabled' do
+      stub_config('research_master_enabled', true)
 
-      expect(response).to have_content(1234)
+      it 'should show the RMID column' do
+        render 'protocols/view_details/protocol_information', protocol: protocol
+
+        expect(response).to have_content(1234)
+      end
     end
+    
+    context  'RMID is not enabled' do
+      stub_config('research_master_enabled', false)
+
+      it 'should not show the RMID column' do
+        render 'protocols/view_details/protocol_information', protocol: protocol
+
+        expect(response).to have_no_content(1234)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
…ns turned off

https://www.pivotaltracker.com/n/projects/1918597/stories/170963115/comments/210936624

1. Research Master ID shouldn't show if research_master_enabled = false
2. 'Do you want to have your Study Published in Epic?' shoudn't show up when use_epic = false