### PR TITLE
KG - Calendar Bugs

### DIFF
--- a/app/controllers/arms_controller.rb
+++ b/app/controllers/arms_controller.rb
@@ -24,7 +24,6 @@ class ArmsController < ApplicationController
   before_action :initialize_service_request,  unless: :in_dashboard?
   before_action :authorize_identity,          unless: :in_dashboard?
   before_action :authorize_admin,             if: :in_dashboard?, except: [:index]
-  before_action :authorize_overlord,          only: [:index]
   before_action :find_arm,                    only: [:edit, :update, :destroy]
 
   def index

--- a/app/views/service_calendars/master_calendar/pppv/billing_strategy/_billing_strategy_header.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/billing_strategy/_billing_strategy_header.html.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 %tr
-  %th.service-name.text-center{ colspan: 8, rowspan: 2 }
+  %th.service-name.text-center{ colspan: 9, rowspan: 2 }
     = LineItem.human_attribute_name(:service)
   %th.notes.text-center{ colspan: 2, rowspan: 2 }
     %span{ title: t(:calendars)[:tooltips][:line_item_notes], data: { toggle: 'tooltip' } }

--- a/app/views/service_calendars/master_calendar/pppv/billing_strategy/_billing_strategy_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/billing_strategy/_billing_strategy_line_items.html.haml
@@ -53,7 +53,7 @@
   -# Line Item Visits
   - livs.each do |liv|
     %tr{ class: ["line-item-#{liv.line_item.id}", "line-items-visit-#{liv.id}", "text-#{text_context}"] }
-      %td.service-name{ colspan: 8, title: calendar_service(liv), data: { toggle: 'tooltip', html: 'true' } }
+      %td.service-name{ colspan: 9, title: calendar_service(liv), data: { toggle: 'tooltip', html: 'true' } }
         = calendar_service(liv)
       %td.notes.editable.text-center{ colspan: 2, title: "#{Service.model_name.human} #{Note.model_name.plural.capitalize}", data: { toggle: 'tooltip' } }
         = notes_button(liv, disabled: !editable, srid: service_request.try(:id), ssrid: sub_service_request.try(:id))

--- a/app/views/service_calendars/master_calendar/pppv/calendar/_calendar_header.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/calendar/_calendar_header.html.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 %tr
-  %th.service-name.text-center{ colspan: 8, rowspan: 2 }
+  %th.service-name.text-center{ colspan: 9, rowspan: 2 }
     = LineItem.human_attribute_name(:service)
   %th.notes.text-center{ colspan: 2, rowspan: 2 }
     %span{ title: t(:calendars)[:tooltips][:line_item_notes], data: { toggle: 'tooltip' } }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170957314

* The calendar structure table is open to any users who can access the protocol, not just overlords. I think this was accidentally done because the lock/unlock button _is_ overlord-specific
* The service calendar was misaligned on the consolidated request tab because some colspans needed to be adjusted