### PR TITLE
SAW - SPARCForms Filter Bug

### DIFF
--- a/app/views/surveyor/responses/_filter_responses_form.html.haml
+++ b/app/views/surveyor/responses/_filter_responses_form.html.haml
@@ -28,11 +28,11 @@
         .form-group.row
           = form.label :of_type, t(:surveyor)[:response_filters][:fields][:type], class: 'col-4 control-label'
           .col-8
-            = form.select :of_type, filterrific.select_options[:of_type], {}, class: 'form-control selectpicker'
+            = form.select :of_type, filterrific.select_options[:of_type], {}, autocomplete: 'off', class: 'form-control selectpicker'
         .form-group.row
           = form.label :with_state, t(:surveyor)[:response_filters][:fields][:state], class: 'col-4 control-label'
           .col-8
-            = form.select :with_state, options_for_select(Response::STATE_FILTERS, filterrific.with_state), {}, class: 'form-control selectpicker', multiple: true
+            = form.select :with_state, options_for_select(Response::STATE_FILTERS, filterrific.with_state), {}, autocomplete: 'off', class: 'form-control selectpicker', multiple: true
         .form-group.row{ id: "for-#{Form.name}", class: filterrific.of_type == Form.name ? "" : "d-none" }
           = form.label :with_survey, Form.name, class: 'col-4 control-label'
           .col-8

--- a/app/views/surveyor/responses/_surveys_dropdown.html.haml
+++ b/app/views/surveyor/responses/_surveys_dropdown.html.haml
@@ -23,4 +23,4 @@
   - surveys.order(:title).group_by(&:title).each do |title, surveys|
     %optgroup{ label: title }
       - surveys.each do |survey|
-        %option{ value: survey.id, disabled: filterrific.with_state && filterrific.with_state.length > 0 && !filterrific.with_state.include?(survey.active ? 1 : 0), selected: filterrific.with_survey && filterrific.with_survey.include?(survey.id), data: { active: survey.active ? '1' : '0', content: "<span>#{t(:surveyor)[:response_filters][:fields][:form_filter][:version]} #{survey.version} (#{I18n.t(:surveyor)[:response_filters][:fields][:state_filters][survey.active ? :active : :inactive]})</span>" } }
+        %option{ value: survey.id, disabled: filterrific.with_state && filterrific.with_state.reject(&:blank?).length > 0 && !filterrific.with_state.include?(survey.active ? 1 : 0), selected: filterrific.with_survey && filterrific.with_survey.include?(survey.id), data: { active: survey.active ? '1' : '0', content: "<span>#{t(:surveyor)[:response_filters][:fields][:form_filter][:version]} #{survey.version} (#{I18n.t(:surveyor)[:response_filters][:fields][:state_filters][survey.active ? :active : :inactive]})</span>" } }

--- a/app/views/surveyor/responses/_surveys_dropdown.html.haml
+++ b/app/views/surveyor/responses/_surveys_dropdown.html.haml
@@ -19,7 +19,7 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 = hidden_field_tag "filterrific[with_survey][]"
-%select.form-control.selectpicker.survey-select{ id: 'filterrific_with_survey', name: 'filterrific[with_survey][]', multiple: true, data: { hide_disabled: 'true', live_search: 'true' } }
+%select.form-control.selectpicker.survey-select{ id: 'filterrific_with_survey', name: 'filterrific[with_survey][]', multiple: true, autocomplete: 'off', data: { hide_disabled: 'true', live_search: 'true' } }
   - surveys.order(:title).group_by(&:title).each do |title, surveys|
     %optgroup{ label: title }
       - surveys.each do |survey|


### PR DESCRIPTION
[#170904455](https://www.pivotaltracker.com/story/show/170904455)

After pressing "Filter" on the responses filter, empty strings are added to the `with_state` and `with_survey` arrays. This doesn't affect `with_survey`, however if no state is selected after pressing "Filter", the array of states is `[""]`. This makes it so `filterrific.with_state.length > 0` evaluate to `true` for all options in determining which options should be disabled. Since the survey dropdown is set to hide disabled options, there appeared to be no surveys to filter. This was fixed by rejecting blank elements in the `with_state` array.

Additionally, sometimes browsers will cache the select tag states and ignore which options are meant to be selected. This was confusing because it would appear as though no survey state was selected, even though `filterrific.with_state` included a state, and the following survey dropdown would only show surveys with that state (see second screenshot in the story). This was fixed by adding `autocomplete: "off"` to all of the filter dropdowns so that the dropdown states would not be cached by the browser.