### PR TITLE
KG - Add Funding Lock

### DIFF
--- a/app/views/protocols/form/_financial_information.html.haml
+++ b/app/views/protocols/form/_financial_information.html.haml
@@ -29,13 +29,16 @@
       .form-row
         .form-group.col-3
           = f.label :funding_status, class: 'required', title: t('protocols.tooltips.funding_status'), data: { toggle: 'tooltip', placement: 'right' }
-          = f.select :funding_status,options_for_select(PermissibleValue.get_inverted_hash('funding_status'), protocol.funding_status), { include_blank: true }, class: 'selectpicker'
+          .tooltip-wrapper{ title: protocol.locked? ? t('calendar_structure.funding_locked', protocol_type: protocol.model_name.human) : "", data: { toggle: 'tooltip' } }
+            = f.select :funding_status,options_for_select(PermissibleValue.get_inverted_hash('funding_status'), protocol.funding_status), { include_blank: true }, class: 'selectpicker', disabled: protocol.locked?
         .form-group.col-3#fundingSourceContainer{ class: protocol.new_record? || protocol.funded? ? '' : 'd-none' }
           = f.label :funding_source, class: 'required', title: t('protocols.tooltips.funding_source'), data: { toggle: 'tooltip', placement: 'right' }
-          = f.select :funding_source,options_for_select(PermissibleValue.get_inverted_hash('funding_source'), protocol.funding_source), { include_blank: true }, class: 'selectpicker', disabled: protocol.new_record?
+          .tooltip-wrapper{ title: protocol.locked? ? t('calendar_structure.funding_locked', protocol_type: protocol.model_name.human) : "", data: { toggle: 'tooltip' } }
+            = f.select :funding_source, options_for_select(PermissibleValue.get_inverted_hash('funding_source'), protocol.funding_source), { include_blank: true }, class: 'selectpicker', disabled: protocol.new_record? || protocol.locked?
         .form-group.col-3#potentialFundingSourceContainer{ class: protocol.pending_funding? ? '' : 'd-none' }
           = f.label :potential_funding_source, class: 'required', title: t('protocols.tooltips.potential_funding_source'), data: { toggle: 'tooltip', placement: 'right' }
-          = f.select :potential_funding_source, options_for_select(PermissibleValue.get_inverted_hash('potential_funding_source'), protocol.potential_funding_source), { include_blank: true }, class: 'selectpicker', disabled: protocol.new_record?
+          .tooltip-wrapper{ title: protocol.locked? ? t('calendar_structure.funding_locked', protocol_type: protocol.model_name.human) : "", data: { toggle: 'tooltip' } }
+            = f.select :potential_funding_source, options_for_select(PermissibleValue.get_inverted_hash('potential_funding_source'), protocol.potential_funding_source), { include_blank: true }, class: 'selectpicker', disabled: protocol.new_record? || protocol.locked?
         .form-group.col-3#fundingSourceOtherContainer{ class: protocol.internally_funded? ? '' : 'd-none' }
           = f.label :funding_source_other, t('constants.prompts.please_specify'), class: 'required'
           = f.text_field :funding_source_other, class: 'form-control'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,14 +483,15 @@ en:
 
   calendar_structure:
     header: "Calendar Structure"
-    lock_calendar: "Lock Calendar"
-    unlock_calendar: "Unlock Calendar"
+    lock_calendar: "Lock Calendar & Funding"
+    unlock_calendar: "Unlock Calendar & Funding"
+    funding_locked: "Funding for this %{protocol_type} has been locked by an administrator. No funding changes may be made at this time."
     table_fields:
       arm_name: "Arm Name"
       subject_count: "Subject Count"
       visit_count: "Visit Count"
     tooltips:
-      lock_calendar: 'Locking the calendar will prevent users from making changes to arm, subject, and visit information.'
+      lock_calendar: 'Prevent users from making changes to arm, subject, visit, and funding information.'
       arm_info: 'The calendar has been locked by an administrator. No changes to the stucture may be made at this time.'
 
   ##############################


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167900874

### Story Background
Currently, study team and admin users can go into a protocol to update the funding source and funding status at any point of time on Study Information page. This is undesired if a study has been approved and pushed to SPARCFulfillment, with possible fulfillment items going on.

### Changes
1. when an overlord uses the "Lock Calendar" button on the SPARCDashboard, the funding related fields (Proposal Funding Status, Potential Funding/Funding Source) becomes un-editable;
2. On the SPARCDashboard protocol page, please update the label to be "Lock Calendar and Funding"; and update the tooltip as well;
3. On the Protocols Information page, when the 2 funding fields are locked, please add visual indication and corresponding tooltip.