### PR TITLE
SAW - Overrided SOAP Response Template

### DIFF
--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -99,7 +99,7 @@ class OncoreEndpointController < ApplicationController
   #   SOAP Endpoint for OnCore RPE messages   #
   #############################################
 
-  soap_service namespace: 'urn:ihe:qrph:rpe:2009', camelize_wsdl: :lower
+  soap_service namespace: 'urn:ihe:qrph:rpe:2009', camelize_wsdl: :lower, parser: :nokogiri
                # might need to camelize wsdl for OnCore since I'm pretty sure they use Java and camelcase
 
   soap_action "RetrieveProtocolDefResponse",
@@ -139,7 +139,8 @@ class OncoreEndpointController < ApplicationController
       }
     },
 
-    :return => { 'responseCode' => :string },
+    :return => { 'tns:responseCode' => :string },
+    :header_return => :string,
     :to     => :retrieve_protocol_def
   def retrieve_protocol_def
     # === Logging and testing info =============================
@@ -151,7 +152,8 @@ class OncoreEndpointController < ApplicationController
 
     # return proper SOAP response
     # PROTOCOL_RECEIVED might be different if an error occurs
-    render :soap => { 'responseCode' => 'PROTOCOL_RECEIVED' }
+    render :soap => { 'tns:responseCode' => 'PROTOCOL_RECEIVED' },
+           :header => SecureRandom.uuid
   end
 
   private

--- a/app/views/wash_out/rpc/response.builder
+++ b/app/views/wash_out/rpc/response.builder
@@ -1,0 +1,40 @@
+# Copyright © 2011-2019 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This view was taken from WashOut directly (https://github.com/inossidabile/wash_out/blob/master/app/views/wash_out/rpc/response.builder)
+# then modified to fit the specific RPC SOAP response OnCore requires to work with SPARC.
+# There was no way to include a MessageId element with an xmlns element and a value within the element,
+# so the proper format was forced in this view.
+xml.instruct!
+xml.tag! "soap:Envelope", "xmlns:soap" => 'http://schemas.xmlsoap.org/soap/envelope/',
+                          "xmlns:xsd" => 'http://www.w3.org/2001/XMLSchema',
+                          "xmlns:xsi" => 'http://www.w3.org/2001/XMLSchema-instance',
+                          "xmlns:tns" => @namespace do
+  if !header.nil?
+    xml.tag! "soap:Header" do
+      xml.tag! "MessageID", header.first.value, { "xmlns" => "http://www.w3.org/2005/08/addressing" }
+    end
+  end
+  xml.tag! "soap:Body" do
+    xml.tag! "tns:#{@action_spec[:response_tag]}" do
+      wsdl_data xml, result
+    end
+  end
+end


### PR DESCRIPTION
[#170872411](https://www.pivotaltracker.com/story/show/170872411)

OnCore required that there be a MessageID element in the SOAP response header from SPARC with an xmlns attribute and a UUID as the value. This was not possible with WashOut alone. I created a custom view to replace their response.builder view that would create the correct format for OnCore.

This is the format OnCore requires:
```<?xml version="1.0"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="urn:ihe:qrph:rpe:2009" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <soap:Header>
      <MessageID xmlns="http://www.w3.org/2005/08/addressing">urn:uuid:50d58575-8056-4a2c-9cf4-662b4de52000</MessageID>
   </soap:Header>
  <soap:Body>
    <tns:RetrieveProtocolDefResponseResponse>
      <tns:responseCode xsi:type="xsd:string">PROTOCOL_RECEIVED</tns:responseCode>
    </tns:RetrieveProtocolDefResponseResponse>
  </soap:Body>
</soap:Envelope>```
