### PR TITLE
HH - (SPARCRequest) Errors With lazy_load_ldap Enabled [#171888331]

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -132,6 +132,7 @@ $(document).ready ->
     }
   ).on 'typeahead:select', (event, suggestion) ->
     $('#protocol_primary_pi_role_attributes_identity_id').val(suggestion.value)
+    $('#lazy_identity_id').val(suggestion.lazy_id)
     $('#primary_pi').prop('placeholder', suggestion.label)
     $('#primary_pi').parents('.form-group').addClass('is-valid')
 

--- a/app/controllers/concerns/protocols_controller_shared.rb
+++ b/app/controllers/concerns/protocols_controller_shared.rb
@@ -39,9 +39,9 @@ module ProtocolsControllerShared
 
   def protocol_params
     # Fix identity_id nil problem when lazy loading is enabled
-    # when lazy loadin is enabled, identity_id is merely ldap_uid, the identity may not exist in database yet, so we create it if necessary here
-    if Setting.get_value("use_ldap") && Setting.get_value("lazy_load_ldap") && params[:primary_pi_role_attributes][:identity_id].present?
-      params[:protocol][:primary_pi_role_attributes][:identity_id] = Identity.find_or_create(params[:protocol][:primary_pi_role_attributes][:identity_id]).id
+    # when lazy loading is enabled, the identity may not exist in database yet, so we create it using lazy_identity_id if necessary here
+    if Setting.get_value("use_ldap") && Setting.get_value("lazy_load_ldap") && params[:lazy_identity_id].present?
+      params[:protocol][:primary_pi_role_attributes][:identity_id] = Identity.find_or_create(params[:lazy_identity_id]).id
     end
 
     # Sanitize date formats

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -113,7 +113,8 @@ class SearchController < ApplicationController
     results = Identity.search(term).map{ |i|
       {
         label: i.display_name,
-        value: i.suggestion_value
+        value: i.suggestion_value,
+        lazy_id: i.ldap_uid
       }
     }
     render json: results.to_json

--- a/app/views/protocols/form/_protocol_information.html.haml
+++ b/app/views/protocols/form/_protocol_information.html.haml
@@ -47,6 +47,7 @@
               = f.label :primary_pi, icon('fas', 'search'), class: 'input-group-text'
             = text_field_tag :primary_pi, ff_ppi.object.identity.try(&:display_name), class: 'form-control typeahead', placeholder: t('constants.prompts.search_for_user'), readonly: !protocol.new_record?
           = ff_ppi.hidden_field :identity_id
+          = hidden_field_tag :lazy_identity_id, ff_ppi.object.identity.try(&:ldap_uid)
           %span.form-text.text-muted
             = t('protocols.form.information.primary_pi.note')
 


### PR DESCRIPTION
Simplifies processing a protocol's `[:primary_pi_role_attributes][:identity_id]` parameter when the `lazy_load_ldap` setting is enabled. With the changes included in this PR, this parameter never contains an ldap_uid value, which simplifies logic and prevents errors when ProtocolsControllerShared#protocol_params is called more than once. See Pivotal Tracker #171888331.

Note that lazy_load_ldap is critical to deploying 3.6.x at OCTRI, so once a solution is implemented, we would appreciate it if the fix were cherry-picked in to a 3.6.2 release as well.

# Details

The `protocol_params` method in the ProtocolsControllerShared concern throws errors when `lazy_load_ldap` is enabled, because of how the `[:protocol][:primary_pi_role_attributes][:identity_id]` parameter is mutated.

## RMID Validation

When the `research_master_enabled` setting is true, `protocol_params` is called from [`ProtocolsController#validate_rmid`](https://github.com/sparc-request/sparc-request/blob/7cdc10a269f554e1d56f10d70ad264e6d6452185/app/controllers/protocols_controller.rb#L93). In this case, `params[:protocol]` is nil, triggering a NoMethodError.

## Protocol Creation

The `protocol_params` method throws an error if called more than once, such as in [`Dashboard::ProtocolsController#create`](https://github.com/sparc-request/sparc-request/blob/7cdc10a269f554e1d56f10d70ad264e6d6452185/app/controllers/dashboard/protocols_controller.rb#L115). The first time through, the value of `params[:protocol][:primary_pi_role_attributes][:identity_id]` is converted from an `ldap_uid` to an identity ID as expected. Subsequent calls fail due to a TypeError in [`Directory#find_or_create`](https://github.com/sparc-request/sparc-request/blob/7cdc10a269f554e1d56f10d70ad264e6d6452185/app/lib/directory.rb#L119), because the assumption that `identity_id` is an `ldap_uid` is no longer valid (it's now a number).

```
A TypeError occurred in protocols#create:
 
  no implicit conversion of Integer into String
 
  app/lib/directory.rb:119:in `match'
```

## Protocol Update

When updating a protocol, the primary PI identity is already set. The payload sent to the controller looks something like this:

```
{
    "utf8"=>"✓",
    "_method"=>"patch",
    "srid"=>"",
    "protocol"=>{
        "type"=>"Study",
        "requester_id"=>"9",
        "research_master_id"=>"17769",
        # ...
        "primary_pi_role_attributes"=>{
            "identity_id"=>"9",
            "id"=>"221"
    },
    # ...
}
```

This causes a NoMethodError in [`Directory#find_or_create`](https://github.com/sparc-request/sparc-request/blob/7cdc10a269f554e1d56f10d70ad264e6d6452185/app/lib/directory.rb#L120). In this example, no email in LDAP matches "9@ohsu.edu", so the regex match at line 120 is nil.

Changes in this PR ensure that `identity_id` is always set from `ldap_uid`, preventing these errors. However, I'm not very familiar with the source code, so I'm happy to implement an alternative solution instead.