### PR TITLE
KG - Max Subject Count Buttons

### DIFF
--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -70,3 +70,7 @@ $text-map: (
 .rotate {
   animation: rotate 3s linear infinite;
 }
+
+.pointer-none {
+  pointer-events: none;
+}

--- a/app/controllers/arms_controller.rb
+++ b/app/controllers/arms_controller.rb
@@ -73,6 +73,10 @@ class ArmsController < ApplicationController
     setup_calendar_pages
 
     if @arm.update_attributes(arm_params)
+      if params[:apply_max_subject_count] == 'true'
+        @arm.line_items_visits.update_all(subject_count: @arm.subject_count)
+      end
+
       flash[:success] = t('arms.updated')
     else
       @errors = @arm.errors

--- a/app/views/arms/_form.html.haml
+++ b/app/views/arms/_form.html.haml
@@ -41,7 +41,13 @@
           = f.text_field :name, class: 'form-control'
         .form-group
           = f.label :subject_count, class: 'required', title: t('arms.tooltips.subject_count'), data: { toggle: 'tooltip' }
-          = f.number_field :subject_count, class: 'form-control', min: 0
+          .input-group
+            = f.number_field :subject_count, class: 'form-control', min: 0
+            .input-group-append
+              %button.btn.btn-secondary#applyMaxSubjectCount{ type: 'button', onclick: "$('#apply_max_subject_count').prop('checked', !$('#apply_max_subject_count').prop('checked'))" }
+                %span.mr-2
+                  = t('actions.apply_all')
+                = check_box_tag :apply_max_subject_count, 'true', false, class: 'pointer-none'
         .form-group
           = f.label :visit_count, class: 'required', title: t('arms.tooltips.subject_count'), data: { toggle: 'tooltip' }
           = f.number_field :visit_count, class: 'form-control', min: 0

--- a/app/views/line_items_visits/_form.html.haml
+++ b/app/views/line_items_visits/_form.html.haml
@@ -34,7 +34,11 @@
       .modal-body
         .form-group
           = f.label params[:field], class: 'required'
-          = f.number_field params[:field], class: 'form-control', min: 0, max: line_items_visit.arm.subject_count
+          .input-group
+            .input-group-prepend
+              %button.btn.btn-secondary#subjectCountMax{ type: 'button', onclick: "$('#line_items_visit_subject_count').val(#{line_items_visit.arm.subject_count})" }
+                = t('actions.max')
+            = f.number_field params[:field], class: 'form-control', min: 0, max: line_items_visit.arm.subject_count
           %small.form-text.text-muted
             = t('constants.min', min: 0)
             = t('constants.max', max: line_items_visit.arm.subject_count)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
     activate: "Activate"
     add: "Add"
     adding: "Adding..."
+    apply_all: "Apply to all"
     back: "Back"
     approve: "Approve"
     cancel: "Cancel"
@@ -45,6 +46,7 @@ en:
     edit: "Edit"
     export: "Export"
     filter: "Filter"
+    max: "Max"
     preview: "Preview"
     print: "Print"
     remove: "Remove"
@@ -74,7 +76,7 @@ en:
     attributes:
       arm:
         name: "Arm Name"
-        subject_count: "Subject Count"
+        subject_count: "Max Subject Count"
         visit_count: "Visit Count"
       document:
         doc_type: "Document Type"

--- a/spec/models/arm/validations_spec.rb
+++ b/spec/models/arm/validations_spec.rb
@@ -67,14 +67,12 @@ RSpec.describe Arm, type: :model do
       arm = build(:arm, protocol: @protocol, visit_count: 0)
 
       expect(arm.valid?).to eq(false)
-      expect(arm.errors.full_messages[0]).to eq("Visit Count must be greater than 0")
     end
 
     it 'must not have a visit count of less than 0' do
       arm = build(:arm, protocol: @protocol, visit_count: -1)
 
       expect(arm.valid?).to eq(false)
-      expect(arm.errors.full_messages[0]).to eq("Visit Count must be greater than 0")
     end
   end
 
@@ -89,14 +87,12 @@ RSpec.describe Arm, type: :model do
       arm = build(:arm, protocol: @protocol, subject_count: 0)
 
       expect(arm.valid?).to eq(false)
-      expect(arm.errors.full_messages[0]).to eq("Subject Count must be greater than 0")
     end
 
     it 'must not have a subject count of less than 0' do
       arm = build(:arm, protocol: @protocol, subject_count: -1)
 
       expect(arm.valid?).to eq(false)
-      expect(arm.errors.full_messages[0]).to eq("Subject Count must be greater than 0")
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170752951

1. Add a button to apply the maximum when editing a single LIV's subject count
<img width="291" alt="image" src="https://user-images.githubusercontent.com/12898988/77477310-850daa80-6df2-11ea-809d-42625ba946e8.png">

2. Add a checkbox when editing an arm to apply the max subject count to all LIVs
<img width="294" alt="image" src="https://user-images.githubusercontent.com/12898988/77477385-a2427900-6df2-11ea-9ade-bc42ea0aee13.png">
