### PR TITLE
KG - RMID Validated Flag When RMID Removed

### DIFF
--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -45,7 +45,7 @@ module ProtocolsHelper
   end
 
   def display_rmid_validated_protocol(protocol, option)
-    if Setting.get_value("research_master_enabled") && protocol.rmid_validated?
+    if Setting.get_value("research_master_enabled") && protocol.research_master_id.present? && protocol.rmid_validated?
       content_tag(:h6, t("protocols.rmid.validated", title: option), class: "text-success")
     end
   end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -305,6 +305,12 @@ class Protocol < ApplicationRecord
       where.not(sub_service_requests: {status: 'first_draft'})
   }
 
+  def research_master_id=(rmid)
+    self.rmid_validated = false if rmid.blank?
+
+    super(rmid)
+  end
+
   def validate_dates
     is_valid = true
     if self.start_date.blank?


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169095503

### Background
When a Research Master ID (RMID) is removed from a SPARC protocol, and that protocol already had a "rmid_validated" flag on it, currently it is keeping that validation flag, although RMID is not associated with the SPARC record any more. (i.e., currently on -d when I query amount protocols.rmid = NULL and protocols.rmid_valdiated = 1, protocols 13781 and 12343 shows up).

### Acceptance Criteria
1). When a RMID number is removed from SPARC protocol on SPARCRequest Step 2 or SPARCDashboard, please also remove the rmid_validated flag on the record.

2). The front UI should be consistent (no green "verified" labels showing). 