### PR TITLE
KG - SSR Resubmission Review Modal

### DIFF
--- a/app/assets/javascripts/review.js.coffee
+++ b/app/assets/javascripts/review.js.coffee
@@ -20,7 +20,7 @@
 
 $ ->
   if $('#use_system_satisfaction').val() == 'true'
-    $(document).one 'click', '#getCostEstimate, #submitRequest', (event) ->
+    $(document).one 'click ajax:beforeSend', '#getCostEstimate, #submitRequest', (event) ->
       event.preventDefault()
       $this = $(this)
       $this.addClass('disabled')
@@ -32,3 +32,9 @@ $ ->
         data:
           srid: getSRId()
           forward: $this.prop('href')
+
+  $(document).on 'submit', '#submitSSRsForm', ->
+    event.preventDefault()
+    data = $('#ssrsSubmissionTable').bootstrapTable('getSelections').map (e, index) -> e[0]
+
+    window.location = "#{$(this).prop('action')}&#{$.param({ ssrids: data })}"

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -116,24 +116,28 @@ class ServiceRequestsController < ApplicationController
   end
 
   def confirmation
-    @protocol = @service_request.protocol
-    @service_request.previous_submitted_at = @service_request.submitted_at
+    respond_to do |format|
+      format.js # Nothing needed but rendering a modal
+      format.html {
+        @protocol = @service_request.protocol
+        @service_request.previous_submitted_at = @service_request.submitted_at
 
-    if Setting.get_value("use_epic") && @service_request.should_push_to_epic? && @protocol.selected_for_epic?
-      # Send a notification to Lane et al to create users in Epic.  Once
-      # that has been done, one of them will click a link which calls
-      # approve_epic_rights.
-      @protocol.ensure_epic_user
-      if Setting.get_value("queue_epic")
-        EpicQueue.create(protocol_id: @protocol.id, identity_id: current_user.id) if should_queue_epic?(@protocol)
-      else
-        @protocol.awaiting_approval_for_epic_push
-        send_epic_notification_for_user_approval(@protocol)
-      end
+        if Setting.get_value("use_epic") && @service_request.should_push_to_epic? && @protocol.selected_for_epic?
+          # Send a notification to Lane et al to create users in Epic.  Once
+          # that has been done, one of them will click a link which calls
+          # approve_epic_rights.
+          @protocol.ensure_epic_user
+          if Setting.get_value("queue_epic")
+            EpicQueue.create(protocol_id: @protocol.id, identity_id: current_user.id) if should_queue_epic?(@protocol)
+          else
+            @protocol.awaiting_approval_for_epic_push
+            send_epic_notification_for_user_approval(@protocol)
+          end
+        end
+
+        NotifierLogic.delay.confirmation_logic(@service_request, current_user, params[:ssrids])
+      }
     end
-
-    NotifierLogic.delay.confirmation_logic(@service_request, current_user)
-    render formats: [:html]
   end
 
   def save_and_exit

--- a/app/lib/notifier_logic.rb
+++ b/app/lib/notifier_logic.rb
@@ -27,7 +27,7 @@ class NotifierLogic
     NotifierLogic.new(service_request, current_user).update_status_and_send_get_a_cost_estimate_email
   end
 
-  def initialize(service_request, current_user, ssrids=nil)
+  def initialize(service_request, current_user, ssrids=[])
     @service_request = service_request
     @current_user = current_user
     @destroyed_ssrs_needing_notification = destroyed_ssr_that_needs_a_request_amendment_email
@@ -244,6 +244,6 @@ class NotifierLogic
   end
 
   def find_draft_ssrs(ssrids)
-    @service_request.sub_service_requests.select{ |ssr| ssrids.present? && ssrids.include?(ssr.id.to_s) && ssr.status == "draft" }
+    @service_request.sub_service_requests.select{ |ssr| (ssrids.blank? || ssrids.include?(ssr.id.to_s)) && ssr.status == "draft" }
   end
 end

--- a/app/lib/notifier_logic.rb
+++ b/app/lib/notifier_logic.rb
@@ -17,23 +17,22 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 class NotifierLogic
-
-
-  def self.confirmation_logic(service_request, current_user)
-    NotifierLogic.new(service_request, current_user).update_ssrs_and_send_emails
+  def self.confirmation_logic(service_request, current_user, ssrids)
+    NotifierLogic.new(service_request, current_user, ssrids).update_ssrs_and_send_emails
   end
 
   def self.obtain_research_pricing_logic(service_request, current_user)
     NotifierLogic.new(service_request, current_user).update_status_and_send_get_a_cost_estimate_email
   end
 
-  def initialize(service_request, current_user)
+  def initialize(service_request, current_user, ssrids=nil)
     @service_request = service_request
     @current_user = current_user
     @destroyed_ssrs_needing_notification = destroyed_ssr_that_needs_a_request_amendment_email
-    @created_ssrs_needing_notification = @service_request.created_ssrs_since_previous_submission
-    @ssrs_updated_from_un_updatable_status = ssrs_that_have_been_updated_from_a_un_updatable_status
+    @created_ssrs_needing_notification = @service_request.created_ssrs_since_previous_submission(ssrids)
+    @ssrs_updated_from_un_updatable_status = ssrs_that_have_been_updated_from_a_un_updatable_status(ssrids)
   end
 
   def ssr_deletion_emails(deleted_ssr: nil, ssr_destroyed: true, request_amendment: false, admin_delete_ssr: false)
@@ -91,8 +90,8 @@ class NotifierLogic
 
   private
 
-  def ssrs_that_have_been_updated_from_a_un_updatable_status
-    draft_ssrs = find_draft_ssrs
+  def ssrs_that_have_been_updated_from_a_un_updatable_status(ssrids)
+    draft_ssrs = find_draft_ssrs(ssrids)
     # Filtering out the newly created draft ssrs
     ssrs_that_have_been_updated_from_a_un_updatable_status = []
     draft_ssrs.each do |ssr|
@@ -244,7 +243,7 @@ class NotifierLogic
     deleted_ssr_audits_that_need_request_amendment_email
   end
 
-  def find_draft_ssrs
-    @service_request.sub_service_requests.select{ |ssr| (ssr.status == "draft") }
+  def find_draft_ssrs(ssrids)
+    @service_request.sub_service_requests.select{ |ssr| ssrids.present? && ssrids.include?(ssr.id.to_s) && ssr.status == "draft" }
   end
 end

--- a/app/models/permissible_value.rb
+++ b/app/models/permissible_value.rb
@@ -19,6 +19,8 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 class PermissibleValue < ApplicationRecord
+  audited
+
   belongs_to :parent, class_name: 'PermissibleValue'
 
   acts_as_list column: :sort_order, scope: [:category]

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -213,9 +213,9 @@ class ServiceRequest < ApplicationRecord
     AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%' AND auditable_type = 'SubServiceRequest' AND action = 'destroy' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'")
   end
 
-  def created_ssrs_since_previous_submission
+  def created_ssrs_since_previous_submission(ssrids)
     start_time = submitted_at.nil? ? Time.now.utc : submitted_at.utc
-    AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%' AND auditable_type = 'SubServiceRequest' AND action = 'create' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'")
+    AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%' AND auditable_id IN (?) AND auditable_type = 'SubServiceRequest' AND action = 'create' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'", ssrids || self.sub_service_requests.map(&:id))
   end
 
   def previously_submitted_ssrs

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -215,7 +215,7 @@ class ServiceRequest < ApplicationRecord
 
   def created_ssrs_since_previous_submission(ssrids)
     start_time = submitted_at.nil? ? Time.now.utc : submitted_at.utc
-    AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%' AND auditable_id IN (?) AND auditable_type = 'SubServiceRequest' AND action = 'create' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'", ssrids || self.sub_service_requests.map(&:id))
+    AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%'#{ssrids.any? ? "AND auditable_id IN (#{ssrids.join(', ')})" : ""} AND auditable_type = 'SubServiceRequest' AND action = 'create' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'")
   end
 
   def previously_submitted_ssrs

--- a/app/views/service_requests/_ssr_resubmission_form.html.haml
+++ b/app/views/service_requests/_ssr_resubmission_form.html.haml
@@ -18,40 +18,44 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-.modal-dialog.modal-lg#newResponseModal{ role: 'document' }
+.modal-dialog.modal-lg{ role: 'document' }
   .modal-content
-    = form_for response, url: surveyor_responses_path(response), method: 'post', remote: true do |f|
+    = form_for service_request, url: confirmation_service_request_path(srid: service_request.id), method: :get, html: { id: 'submitSSRsForm' } do |f|
       .modal-header
         %h3.modal-title
-          = survey.title
+          = "Select Requests to Resubmit"
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
-      .modal-body#survey-response
-        = f.hidden_field :identity_id, value: current_user.id
-        = f.hidden_field :survey_id, value: survey.id
-        = f.hidden_field :respondable_id, value: respondable.id
-        = f.hidden_field :respondable_type, value: respondable.class.name
-        - unless survey.description.blank?
-          .form-group
-            %p.survey-description
-              = raw(survey.description)
-        .row
-          .list-group.list-group-flush.survey-sections.w-100
-            - survey.sections.eager_load(questions: :options).each do |section|
-              %section.list-group-item
-                %h4.mb-2
-                  = section.title
-                - unless section.description.blank?
-                  .form-group
-                    %p.section-description
-                      = raw(section.description)
-                - unless section.questions.none?
-                  = render 'layouts/required_fields'
-
-                - section.questions.each_with_index do |question, index|
-                  = f.fields_for :question_responses do |qr|
-                    = render 'surveyor/responses/form/response_question', qr: qr, question_response: qr.object, section: section, question: question, index: index
+      .modal-body
+        - ssrs = service_request.sub_service_requests.select{ |ssr| ['draft', 'awaiting_pi_approval'].include?(ssr.status) }
+        %table#ssrsSubmissionTable{ data: { toggle: 'table', click_to_select: 'true' } }
+          %thead.bg-light
+            %th.d-none
+            %th{ data: { checkbox: 'true', checked: 'true' } }
+            %th
+              = ServiceRequest.human_attribute_name(:id)
+            %th
+              = ServiceRequest.human_attribute_name(:organization)
+            %th
+              = ServiceRequest.human_attribute_name(:status)
+            %th.text-center
+              = ServiceRequest.human_attribute_name(:previously_submitted)
+          %body
+            - ssrs.each do |ssr|
+              %tr
+                %td.d-none
+                  = ssr.id
+                %td
+                %td
+                  = ssr.display_id
+                %td
+                  = ssr.org_tree_display
+                %td
+                  = PermissibleValue.get_value('status', ssr.status)
+                %td.text-center
+                  - klass = ssr.previously_submitted? ? 'check fa-lg text-success' : 'times fa-lg text-danger'
+                  = icon('fas', klass)
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
-          = t(:actions)[:close]
-        = f.submit t(:actions)[:submit], class: 'btn btn-primary'
+          = t('actions.close')
+        = f.submit t('actions.submit'), class: 'btn btn-primary'

--- a/app/views/service_requests/confirmation.js.coffee
+++ b/app/views/service_requests/confirmation.js.coffee
@@ -18,44 +18,9 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-<% if @errors %>
-$("[name^='response[question_responses_attributes]']:not([type='hidden'])").parents('.form-group').removeClass('is-invalid').addClass('is-valid')
-$('.form-error').remove()
-
-<% @response.question_responses.each_with_index do |qr, index| %>
-<% qr.errors.messages.each do |attr, messages| %>
-<% messages.each do |message| %>
-$("[name^='response[question_responses_attributes][<%= index %>][<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
-<% end %>
-<% end %>
-<% end %>
-
-<% else %>
-
-<% if @response.survey.is_a?(Form) %>
-$('#forms').removeClass('d-none')
-$('#formsTable').bootstrapTable('refresh')
-$('#modalContainer').modal('hide')
-
-if window.location.pathname.startsWith('/dashboard')
-  $('.service-request-card:not(:eq(0))').remove()
-  $(".service-request-card:eq(0)").replaceWith("<%= j render 'dashboard/service_requests/service_requests', protocol: @protocol, permission_to_edit: @permission_to_edit %>")
-  $(".service-requests-table").bootstrapTable()
+$('#modalContainer').html("<%= j render 'service_requests/ssr_resubmission_form', service_request: @service_request %>")
+$("#modalContainer").modal('show')
 
 $(document).trigger('ajax:complete') # rails-ujs element replacement bug fix
 
-<% elsif @response.survey.is_a?(SystemSurvey) && @response.survey.system_satisfaction? %>
-<% if @response.respondable.previously_submitted? %>
-$.ajax
-  method: 'GET'
-  dataType: 'script'
-  url: '/service_request/confirmation'
-  data:
-    srid: getSRId()
-<% else %>
-$('#modalContainer').modal('hide')
-<% end %>
-<% else %>
-window.location = "/surveyor/responses/<%=@response.id%>/complete"
-<% end %>
-<% end %>
+$('[name=btSelectAll]').trigger('click')

--- a/app/views/service_requests/navigation/_footer.html.haml
+++ b/app/views/service_requests/navigation/_footer.html.haml
@@ -47,7 +47,7 @@
             = link_to t("proper.navigation.bottom.get_cost_estimate"),obtain_research_pricing_service_request_path(srid: @service_request.id), class: 'btn btn-lg btn-outline-secondary', id: 'getCostEstimate'
         .col.text-right
           - if action_name == 'review'
-            = link_to confirmation_service_request_path(srid: @service_request.id), class: 'btn btn-lg btn-outline-success', id: 'submitRequest' do
+            = link_to confirmation_service_request_path(srid: @service_request.id), remote: @service_request.previously_submitted?, class: 'btn btn-lg btn-outline-success', id: 'submitRequest' do
               - succeed icon('fas', 'arrow-right ml-2') do
                 = t('proper.navigation.bottom.submit')
           - else

--- a/app/views/service_requests/system_satisfaction_survey.js.coffee
+++ b/app/views/service_requests/system_satisfaction_survey.js.coffee
@@ -25,6 +25,7 @@ ConfirmSwal.fire(
   confirmButtonText: I18n.t('constants.yes_select')
   cancelButtonText: I18n.t('constants.no_select')
 ).then (result) ->
+  $('#getCostEstimate, #submitRequest').removeClass('disabled')
   if result.value
     $.ajax
       method: 'get'
@@ -36,7 +37,23 @@ ConfirmSwal.fire(
         survey_id:        "<%= @survey.id %>"
         type:             "<%= SystemSurvey.name %>"
       success: ->
-        $(document).one 'hide.bs.modal', ->
+        $(document).one 'hidden.bs.modal', ->
+          # When previously subbmited show the SSRs resubmission modal
+          <% if @service_request.previously_submitted? && @forward.include?('confirmation') %>
+          $.ajax
+            method: 'get'
+            dataType: 'script'
+            url: "<%= confirmation_service_request_path(srid: @service_request.id) %>"
+          <% else %>
           window.location = "<%= @forward %>"
+          <% end %>
   else
+    # When previously subbmited show the SSRs resubmission modal
+    <% if @service_request.previously_submitted? && @forward.include?('confirmation') %>
+    $.ajax
+      method: 'get'
+      dataType: 'script'
+      url: "<%= confirmation_service_request_path(srid: @service_request.id) %>"
+    <% else %>
     window.location = "<%= @forward %>"
+    <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,24 +43,9 @@ SparcRails::Application.configure do
   config.assets.compile = true
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: ENV.fetch('ROOT_URL') }
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-
-  config.after_initialize do
-    # Need to do this after initialization so that the database is loaded
-    begin
-      new_options = { host: Setting.get_value("root_url") }
-      config.action_mailer.default_url_options = new_options
-
-      # By the time we run ActionMailer has already copied the options
-      # from config so we need to override here to really make the change
-      # We only set the default_url_options to keep the settings consistent
-      ActionMailer::Base.default_url_options = new_options
-    rescue
-      puts "WARNING: Database does not exist, restart server after database has been created and populated, to set mailer default url options from database."
-    end
-  end
 
   config.log_level = :debug
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,20 +104,5 @@ SparcRails::Application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.default_url_options = { host: "sparc.musc.edu" }
-  config.after_initialize do
-    # Need to do this after initialization so that the database is loaded
-    begin
-      new_options = { host: Setting.get_value("root_url") }
-      config.action_mailer.default_url_options = new_options
-
-      # By the time we run ActionMailer has already copied the options
-      # from config so we need to override here to really make the change
-      # We only set the default_url_options to keep the settings consistent
-      ActionMailer::Base.default_url_options = new_options
-    rescue
-      puts "WARNING: Database does not exist, restart server after database has been created and populated, to set mailer default url options from database."
-    end
-  end
-
+  config.action_mailer.default_url_options = { host: ENV.fetch('ROOT_URL') }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -107,14 +107,5 @@ SparcRails::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
-  config.action_mailer.default_url_options = { :host => 'sparc-s.obis.musc.edu' }
-
-  config.after_initialize do
-    # Need to do this after initialization so that obis_setup has run and our config is loaded
-    begin
-      config.action_mailer.default_url_options = { :host => Setting.get_value("root_url") }
-    rescue
-      puts "WARNING: Database does not exist, restart server after database has been created and populated, to set mailer default url options from database."
-    end
-  end
+  config.action_mailer.default_url_options = { host: ENV.fetch('ROOT_URL') }
 end

--- a/config/environments/testing.rb
+++ b/config/environments/testing.rb
@@ -52,20 +52,5 @@ SparcRails::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'sparc-d.obis.musc.edu' }
-
-  config.after_initialize do
-    # Need to do this after initialization so that the database is loaded
-    begin
-      new_options = { host: Setting.get_value("root_url") }
-      config.action_mailer.default_url_options = new_options
-
-      # By the time we run ActionMailer has already copied the options
-      # from config so we need to override here to really make the change
-      # We only set the default_url_options to keep the settings consistent
-      ActionMailer::Base.default_url_options = new_options
-    rescue
-      puts "WARNING: Database does not exist, restart server after database has been created and populated, to set mailer default url options from database."
-    end
-  end
+  config.action_mailer.default_url_options = { host: ENV.fetch('ROOT_URL') }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,7 @@ en:
         owner: "Owner"
         status: "Status"
         forms: "Forms"
+        previously_submitted: "Previously Submitted"
       sub_service_request:
         srid: "SRID"
       short_interaction:

--- a/config/locales/proper.en.yml
+++ b/config/locales/proper.en.yml
@@ -118,6 +118,8 @@ en:
     # CONFIRMATION #
     ################
     confirmation:
+      ssr_resubmission:
+        header: "Select Requests to Resubmit"
       confirmation_warning: "An email has been sent to each of your Service Providers and they should be contacting you soon.<br>If you have any questions or concerns, please don't hesitate to contact the %{department_name} at %{phone} or <a href='mailto:%{email}'>%{email}</a>"
       cost_estimate_warning: " Emails have been submitted on your behalf and we will respond to your request shortly. Should you have any questions regarding your request, please contact the Service Providers listed below."
       service_requests_notice: "My Service Requests"

--- a/spec/controllers/service_requests/get_confirmation_spec.rb
+++ b/spec/controllers/service_requests/get_confirmation_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
     it 'should call the Notifier Logic to update the request' do
       expect(NotifierLogic).to receive_message_chain(:delay, :confirmation_logic)
 
-      get :confirmation, params: { srid: sr.id }, xhr: true
+      get :confirmation, params: { srid: sr.id }, xhr: true, format: :html
 
       expect(assigns(:service_request).previous_submitted_at).to eq(sr.submitted_at)
     end
@@ -62,7 +62,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
           it 'should update the existing record' do
             expect {
-              get :confirmation, params: { srid: sr.id }, xhr: true
+              get :confirmation, params: { srid: sr.id }, xhr: true, format: :html
             }.to change{ EpicQueue.count }.by(0)
 
             expect(@eq.reload.user_change).to eq(false)
@@ -76,7 +76,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
 
           it 'should create a queue record' do
             expect {
-              get :confirmation, params: { srid: sr.id }, xhr: true
+              get :confirmation, params: { srid: sr.id }, xhr: true, format: :html
             }.to change{ EpicQueue.count }.by(1)
           end
         end
@@ -88,7 +88,7 @@ RSpec.describe ServiceRequestsController, type: :controller do
         it 'should send an epic approval notification' do
           expect(Notifier).to receive_message_chain(:notify_for_epic_user_approval, :deliver)
 
-          get :confirmation, params: { srid: sr.id }, xhr: true
+          get :confirmation, params: { srid: sr.id }, xhr: true, format: :html
         end
       end
     end

--- a/spec/features/proper/review/user_submits_previously_submitted_request.rb
+++ b/spec/features/proper/review/user_submits_previously_submitted_request.rb
@@ -1,0 +1,107 @@
+# Copyright © 2011-2019 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rails_helper'
+
+RSpec.describe 'User submits a previously submitted request', js: true do
+  let_there_be_lane
+  fake_login_for_each_test
+
+  before :each do
+    Delayed::Worker.delay_jobs = false
+  end
+
+  after :each do
+    Delayed::Worker.delay_jobs = true
+  end
+
+  before :each do
+    org       = create(:organization, name: "Program", process_ssrs: true, pricing_setup_count: 1)
+    service   = create(:service, name: "Service", abbreviation: "Service", organization: org, pricing_map_count: 1, one_time_fee: true)
+    @protocol = create(:study_federally_funded, primary_pi: jug2)
+    @sr       = create(:service_request_without_validations, status: 'draft', protocol: @protocol, submitted_at: Date.today - 1.month)
+    @ssr      = create(:sub_service_request_without_validations, service_request: @sr, organization: org, status: 'draft', submitted_at: Date.today - 1.month)
+                create(:line_item, service_request: @sr, sub_service_request: @ssr, service: service)
+  end
+
+  context 'and selects SSRs to submit' do
+    scenario 'and sees the submitted SSRs' do
+      visit review_service_request_path(srid: @sr.id)
+      wait_for_javascript_to_finish
+
+      click_link I18n.t('proper.navigation.bottom.submit')
+      wait_for_javascript_to_finish
+
+      click_button I18n.t('actions.submit')
+      wait_for_javascript_to_finish
+
+      expect(@ssr.reload.status).to eq('submitted')
+    end
+  end
+
+  context 'system satisfaction survey enabled' do
+    stub_config('system_satisfaction_survey', true)
+
+    before :each do
+      create(:system_survey, :with_question, access_code: 'system-satisfaction-survey', title: 'System Satisfaction Survey', active: true)
+
+      visit review_service_request_path(srid: @sr.id)
+      wait_for_javascript_to_finish
+
+      click_link I18n.t('proper.navigation.bottom.submit')
+      wait_for_javascript_to_finish
+    end
+
+    context 'user takes the survey' do
+      scenario 'should show the SSR submission modal' do
+        confirm_swal
+        wait_for_javascript_to_finish
+
+        fill_in 'response_question_responses_attributes_0_content', with: 'My answer is no'
+        click_button I18n.t('actions.submit')
+        wait_for_javascript_to_finish
+
+        expect(page).to have_selector('#submitSSRsForm')
+      end
+
+      context 'user closes the modal without finishing' do
+        scenario 'should show the SSR submission modal' do
+          confirm_swal
+          wait_for_javascript_to_finish
+
+          fill_in 'response_question_responses_attributes_0_content', with: 'My answer is no'
+          click_button I18n.t('actions.close')
+          wait_for_javascript_to_finish
+
+          expect(page).to have_selector('#submitSSRsForm')
+        end
+      end
+    end
+
+    context 'use closes the survey alert' do
+      scenario 'should show the SSR submission modal' do
+        cancel_swal
+        wait_for_javascript_to_finish
+
+        expect(page).to have_selector('#submitSSRsForm')
+      end
+    end
+  end
+end

--- a/spec/features/proper/review/user_takes_system_satisfaction_survey_spec.rb
+++ b/spec/features/proper/review/user_takes_system_satisfaction_survey_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe 'User takes system satisfaction survey after reviewing their requ
 
       it 'should offer a survey' do
         confirm_swal
+        wait_for_javascript_to_finish
+
         fill_in 'response_question_responses_attributes_0_content', with: 'My answer is no'
         click_button I18n.t('actions.submit')
         wait_for_javascript_to_finish
@@ -102,6 +104,8 @@ RSpec.describe 'User takes system satisfaction survey after reviewing their requ
 
       it 'should offer a survey' do
         confirm_swal
+        wait_for_javascript_to_finish
+
         fill_in 'response_question_responses_attributes_0_content', with: 'My answer is no'
         click_button I18n.t('actions.submit')
         wait_for_javascript_to_finish

--- a/spec/support/permissible_values.rb
+++ b/spec/support/permissible_values.rb
@@ -19,6 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 def populate_permissible_values_before_suite
+  PermissibleValue.auditing_enabled = false
   ActiveRecord::Base.transaction do
     build_impact_areas
     build_statuses

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -19,6 +19,7 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 def populate_settings_before_suite
+  Setting.auditing_enabled = false
   SettingsPopulator.new().populate
 
   Setting.find_by_key("use_epic").update_attribute(:value, true)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169156333

### Background
When  overlord users are working on a protocol using "Modify Request" button and re-submit, it is currently re-submitting all sub-service-requests that are not finished (complete, invoiced, withdrawn), locked (defined by the organizational\ status lock) or under an admin status (submitted and beyond), which causes issue in certain scenarios. Especially when this overlord is not intended to change the status of "Awaiting Requester Response" and "Draft" status to be submitted, since those are still waiting for response from study team members.

### Acceptance Criteria
1). When "Modify Request" button is used on a protocol, and users are re-submitting a protocol on SPARCRequest Step 4 page, please trigger a multiple selection modal (or additional section on the page, whichever layout is more user-friendly) asking users to select/confirm which sub-service-requests they desire to re-submit;
2). This modal should only list the sub-service-requests (SSRs) that are in "Draft" and "Awaiting Requester Response" statuses, with the split/notify organization and the current statuses displayed;
3). This modal should default selection of all the sub-service-requests that meets the category (to save time), and users could un-select the ones they don't want to resubmit.
4). The SSRs that are un-selected to the resubmission should hold current status afterwards, with no emails triggered. Only the effective re-submitted SSRs should trigger status change and emails.

### Screenshots
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12898988/77574714-d0829000-6ea8-11ea-829f-d53543d7662a.png">

### Additional Comments
The modal appears when clicking the Submit Request button and the request has been previously submitted. If the system satisfaction survey is turned on, the modal appears after the user 1. declines the survey, 2. completes the survey, or 3. closes the survey modal. The user can check which SSRs to submit (by default all are checked) and the NotifierLogic mailers will now use those IDs when determining where to send emails.