### PR TITLE
HH - Cache Available Permissible Values [#171868635]

### DIFF
--- a/app/models/permissible_value.rb
+++ b/app/models/permissible_value.rb
@@ -36,7 +36,7 @@ class PermissibleValue < ApplicationRecord
   }
 
   def self.preload_values
-    RequestStore.store[:permissible_values] ||= PermissibleValue.all.group_by(&:category).map{ |category, values| [category, values.map{ |p| [p.key, { value: p.value, default: p.default }] }.to_h] }.to_h
+    RequestStore.store[:permissible_values] ||= PermissibleValue.available.group_by(&:category).map{ |category, values| [category, values.map{ |p| [p.key, { value: p.value, default: p.default }] }.to_h] }.to_h
   end
 
   # Get the first PermissibleValue value using a category and key


### PR DESCRIPTION
Only add permissible values where `is_available` is true to the `RequestStore` cache. Fixes a regression from SPARCRequest 3.5 where disabled values appear in the protocol form.

Pivotal Tracker: https://www.pivotaltracker.com/story/show/171868635

## Context

At OHSU, we have customized SPARCRequest by creating new permissible values and setting others unavailable. For example, in the `study_type` category, the values "Clinical Trials," "Basic Science," and "Translational Science" are unavailable. The result in 3.5.0 is this (note that we also customized the title through the locale file):

![image](https://user-images.githubusercontent.com/2746306/78055660-b62d3400-7338-11ea-9343-e99288fab095.png)

In SPARCRequest 3.6, all of the unavailable permissible values are present in the protocol form.

![Screen Shot 2020-03-30 at 13 45 15](https://user-images.githubusercontent.com/2746306/78055760-e1178800-7338-11ea-9b26-9276afb70059.png)


This seems to be related to the introduction of caching in the `PermissibleValue` model. The change in this pull request caches only the available permissible values, and with this change only the available permissible values are present in the protocol form.

![Screenshot_2020-03-30 SPARCRequest](https://user-images.githubusercontent.com/2746306/78055795-eb398680-7338-11ea-82d6-fbadffe03f6b.png)
