### PR TITLE
KG - Add "All Protocols" Protocol Filter for General Users

### DIFF
--- a/app/assets/javascripts/custom/bootstrap-custom.es6
+++ b/app/assets/javascripts/custom/bootstrap-custom.es6
@@ -43,9 +43,9 @@
     $(document).on('click', 'table.table-interactive tbody tr', event => {
       el = event.target
 
-      if (el.tagName == 'tr') {
+      if (el.tagName == 'tr' && $(el).find('a').length) {
         window.location = $(el).find('a').first().attr('href');
-      } else if (el.tagName != 'a') {
+      } else if (el.tagName != 'a' && $(el).parents('tr').find('a').length) {
         window.location = $(el).parents('tr').find('a').first().attr('href');
       }
     })

--- a/app/helpers/dashboard/protocols_helper.rb
+++ b/app/helpers/dashboard/protocols_helper.rb
@@ -30,29 +30,39 @@ module Dashboard::ProtocolsHelper
     end
   end
 
-  def protocol_id_link(protocol)
-    link_to protocol.id, dashboard_protocol_path(protocol)
+  def protocol_id_link(protocol, access)
+    if access
+      link_to protocol.id, dashboard_protocol_path(protocol)
+    else
+      protocol.id
+    end
   end
 
-  def protocol_short_title_link(protocol)
-    content_tag(:div, (link_to protocol.short_title, dashboard_protocol_path(protocol)) ) + content_tag(:div, (display_rmid_validated_protocol(protocol, Protocol.human_attribute_name(:short_title))) )
+  def protocol_short_title_link(protocol, access)
+    short_title = if access
+      (link_to protocol.short_title, dashboard_protocol_path(protocol))
+    else
+      protocol.short_title
+    end
+
+    content_tag(:div, short_title) + content_tag(:div, (display_rmid_validated_protocol(protocol, Protocol.human_attribute_name(:short_title))) )
   end
 
   def pis_display(protocol)
-    if protocol.primary_pi
-      content_tag(:div, title: Protocol.human_attribute_name(:primary_pi), data: { toggle: 'tooltip', boundary: 'window' }) do
-        content_tag(:span) do
+    content_tag(:div, class: 'd-flex flex-column align-items-start') do
+      if protocol.primary_pi
+        content_tag(:div, title: Protocol.human_attribute_name(:primary_pi), data: { toggle: 'tooltip', boundary: 'window' }) do
           icon('fas', 'user-circle mr-2') + protocol.primary_pi.display_name
-        end + '<br>'.html_safe
-      end
-    else
-      ""
-    end + raw(
-    protocol.principal_investigators.select{ |pi| pi != protocol.primary_pi }.map do |pi|
-      content_tag(:span) do
-        icon('fas', 'user mr-2') + pi.display_name
-      end
-    end.join('<br>'.html_safe))
+        end
+      else
+        ""
+      end + raw(
+      protocol.principal_investigators.select{ |pi| pi != protocol.primary_pi }.map do |pi|
+        content_tag(:span) do
+          icon('fas', 'user mr-2') + pi.display_name
+        end
+      end.join())
+    end
   end
 
   def display_requests_button(protocol, access)

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -230,10 +230,13 @@ class Protocol < ApplicationRecord
 
   scope :admin_filter, -> (params) {
     filter, id  = params.split(" ")
+
     if filter == 'for_admin'
       for_admin(id)
     elsif filter == 'for_identity'
       for_identity(id)
+    elsif filter == 'for_all'
+      return
     end
   }
 

--- a/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
+++ b/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
@@ -52,18 +52,21 @@
           = f.label :show_archived, t('dashboard.protocol_filters.archived'), class: 'col-5 col-form-label pr-0'
           .col-7
             = f.check_box :show_archived, data: { toggle: 'toggle', on: t('dashboard.protocol_filters.archived'), off: t('dashboard.protocol_filters.unarchived'), style: 'btn-block' }
+        %hr
+        .form-group.row.mb-0
+          = f.label "admin_filter_for_identity_#{current_user.id}", t('dashboard.protocol_filters.my_protocols'), class: 'col-6 col-form-label pr-0'
+          .col-5.d-flex.align-items-center.justify-content-center
+            = f.radio_button :admin_filter, "for_identity #{current_user.id}"
         - if admin
-          %hr
-          .form-group.row.mb-0
-            = f.label "admin_filter_for_identity_#{current_user.id}", t('dashboard.protocol_filters.my_protocols'), class: 'col-6 col-form-label pr-0'
-            .col-5.d-flex.align-items-center.justify-content-center
-              = f.radio_button :admin_filter, "for_identity #{current_user.id}"
           .form-group.row.mb-0
             = f.label "admin_filter_for_admin_#{current_user.id}", t('dashboard.protocol_filters.my_admin_protocols'), class: 'col-6 col-form-label pr-0'
             .col-5.d-flex.align-items-center.justify-content-center
               = f.radio_button :admin_filter, "for_admin #{current_user.id}"
         - else
-          = f.hidden_field :admin_filter, value: "for_identity #{current_user.id}"
+          .form-group.row.mb-0
+            = f.label "admin_filter_for_all", t('dashboard.protocol_filters.all_protocols'), class: 'col-6 col-form-label pr-0'
+            .col-5.d-flex.align-items-center.justify-content-center
+              = f.radio_button :admin_filter, "for_all"
       .card-footer.flex-wrap
         = f.submit t('actions.filter'), class: 'btn btn-block btn-primary mb-2'
         .col-lg-6.col-12.pl-0.pr-1

--- a/app/views/dashboard/protocols/index.json.jbuilder
+++ b/app/views/dashboard/protocols/index.json.jbuilder
@@ -5,9 +5,9 @@ json.total @protocol_count
 json.rows (@protocols) do |protocol|
   access = authorized_user_protocols.include?(protocol.id) || admin_protocols.include?(protocol.id)
 
-  json.id               protocol_id_link(protocol)
+  json.id               protocol_id_link(protocol, access)
   json.protocol_merges  display_merges(protocol)
-  json.short_title      protocol_short_title_link(protocol)
+  json.short_title      protocol_short_title_link(protocol, access)
   json.pis              pis_display(protocol)
   json.requests         display_requests_button(protocol, access)
 end

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -113,6 +113,7 @@ en:
       status: "Status"
       organization: "Organization"
       owner: "Owner"
+      all_protocols: "All Protocols"
       my_protocols: "My Protocols"
       my_admin_protocols: "My Admin Protocols"
       modal:

--- a/spec/features/dashboard/protocols/index/filters/user_filters_with_all_protocols_radio_spec.rb
+++ b/spec/features/dashboard/protocols/index/filters/user_filters_with_all_protocols_radio_spec.rb
@@ -1,0 +1,48 @@
+# Copyright © 2011-2019 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+require "rails_helper"
+
+RSpec.describe "User filters using \"All Protocols\"", js: :true do
+
+  let_there_be_lane
+  fake_login_for_each_test
+
+  context "as a general user (AKA the default search)" do
+    before :each do
+      organization  = create(:organization)
+      @protocol     = create(:study_without_validations, primary_pi: jug2)
+      @protocol2    = create(:study_without_validations, primary_pi: create(:identity))
+
+      visit dashboard_protocols_path
+      wait_for_javascript_to_finish
+
+      find("#filterrific_admin_filter_for_all").click
+      click_button I18n.t('actions.filter')
+      wait_for_javascript_to_finish
+    end
+
+    scenario "and sees all protocols" do
+      expect(page).to have_selector("#protocolsTable tbody tr", count: 2)
+      expect(page).to have_content(@protocol.short_title)
+      expect(page).to have_content(@protocol2.short_title)
+    end
+  end
+end

--- a/spec/views/dashboard/protocol_filters/_filter_protocols_form.html.haml_spec.rb
+++ b/spec/views/dashboard/protocol_filters/_filter_protocols_form.html.haml_spec.rb
@@ -46,16 +46,12 @@ RSpec.describe 'dashboard/protocol_filters/_filter_protocols_form', type: :view 
       render 'dashboard/protocol_filters/filter_protocols_form', filterrific: @filterrific, current_user: jug2, protocol_filters: [], reset_filterrific_url: '', admin: false
     end
 
-    it 'should not show "My Protocols" radio' do
-      expect(response).not_to have_content('My Protocols')
+    it 'should show "All Protocols" radio' do
+      expect(response).to have_selector(:label, text: I18n.t('dashboard.protocol_filters.all_protocols'))
     end
 
     it 'should not show "My Admin Protocols" radio' do
-      expect(response).not_to have_content('My Admin Protocols')
-    end
-
-    it 'should show "Organization" select' do
-      expect(response).to have_content('Organization')
+      expect(response).to_not have_selector(:label, text: I18n.t('dashboard.protocol_filters.my_admin_protocols'))
     end
   end
 
@@ -64,12 +60,12 @@ RSpec.describe 'dashboard/protocol_filters/_filter_protocols_form', type: :view 
       render 'dashboard/protocol_filters/filter_protocols_form', filterrific: @filterrific, current_user: jug2, protocol_filters: [], reset_filterrific_url: '', admin: true
     end
 
-    it 'should show "My Protocols" radio' do
-      expect(response).to have_selector('label', text: 'My Protocols')
+    it 'should show "My Admin Protocols" radio' do
+      expect(response).to have_selector(:label, text: 'My Admin Protocols')
     end
 
-    it 'should show "My Admin Protocols" radio' do
-      expect(response).to have_selector('label', text: 'My Admin Protocols')
+    it 'should not show "All Protocols" radio' do
+      expect(response).to_not have_selector(:label, text: I18n.t('dashboard.protocol_filters.all_protocols'))
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168226099

### Background:
When there are multiple users managing the same set of protocols, or staff turn-over period happens, there has been cases where people can't search or see the protocols that they should have access to.  

### Acceptance Criteria
Add a new filter to enable general users to be able to search through all protocols in SPARCDashboard and return results, instead of just the ones they have access to.