### PR TITLE
KG - Improved Epic Interface Push Error Handling

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -485,11 +485,12 @@ class Protocol < ApplicationRecord
   # thread-safe.
   def push_to_epic(epic_interface, origin, identity_id=nil, withhold_calendar=false)
     begin
+      binding.pry
       self.last_epic_push_time = Time.now
       self.last_epic_push_status = 'started'
       save(validate: false)
 
-      Rails.logger.info("Sending study message to Epic")
+      Rails.logger.info("Sending study message to Epic - Study #{self.id}")
       withhold_calendar ? epic_interface.send_study_creation(self) : epic_interface.send_study(self)
 
       self.last_epic_push_status = 'complete'
@@ -497,7 +498,8 @@ class Protocol < ApplicationRecord
 
       EpicQueueRecord.create(protocol_id: self.id, status: self.last_epic_push_status, origin: origin, identity_id: identity_id)
     rescue Exception => e
-      Rails.logger.info("Push to Epic failed.")
+      Rails.logger.error("Push to Epic failed - Study #{self.id}")
+      Rails.logger.error([e.message, *e.backtrace].join($/))
 
       self.last_epic_push_status = 'failed'
       save(validate: false)

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -485,7 +485,6 @@ class Protocol < ApplicationRecord
   # thread-safe.
   def push_to_epic(epic_interface, origin, identity_id=nil, withhold_calendar=false)
     begin
-      binding.pry
       self.last_epic_push_time = Time.now
       self.last_epic_push_status = 'started'
       save(validate: false)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164840135

### Background:
With the Protocol Update functionality of our SPARC/Epic interface, for protocols that have already been pushed to Epic before, when there's an user change/update in SPARC, the protocol (and protocol information only piece) is being queued and batch updated to Epic daily. However, we found out that if one of the protocol is missing a validation (such as missing study type answers), the rest of the queue is skipped.

### Acceptance Criteria:
Please look into ways to handle this type of errors more gracefully, so that if it happens again in the future, 1 failed protocol update is skipped, but the rest of the queue will still be pushed to Epic.

### Notes from Kayla
1. The `Protocol#push_to_epic method already had a begin/rescue to log failed pushes. I expanded on this by including the error message and backtrace for improved tracking. In the future this could be expanded to an email notification or slack message.
2. Because `Protocol#push_to_epic` raises the exception after rescuing it, we have to add another begin/rescue in the `send_to_epic` task. We have error handling like this elsewhere in the app to handle these exceptions.