### PR TITLE
KG - SSR Resubmission-related Request Submission Bug

### DIFF
--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -215,7 +215,7 @@ class ServiceRequest < ApplicationRecord
 
   def created_ssrs_since_previous_submission(ssrids)
     start_time = submitted_at.nil? ? Time.now.utc : submitted_at.utc
-    AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%'#{ssrids.any? ? "AND auditable_id IN (#{ssrids.join(', ')})" : ""} AND auditable_type = 'SubServiceRequest' AND action = 'create' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'")
+    AuditRecovery.where("audited_changes LIKE '%service_request_id: #{id}%'#{ssrids.blank? ? "" : "AND auditable_id IN (#{ssrids.join(', ')})"} AND auditable_type = 'SubServiceRequest' AND action = 'create' AND created_at BETWEEN '#{start_time}' AND '#{Time.now.utc}'")
   end
 
   def previously_submitted_ssrs


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169156333

The issue was the method didn't consider the case the `ssrids` was nil. Changing `.any?` to `.blank?` and reversing the ternary fixes that.

```
undefined method `any?' for nil:NilClass
/var/www/rails/sparc-request/releases/20200402151727/app/models/service_request.rb:218:in `created_ssrs_since_previous_submission’
/var/www/rails/sparc-request/releases/20200402151727/app/lib/notifier_logic.rb:34:in `initialize’
/var/www/rails/sparc-request/releases/20200402151727/app/lib/notifier_logic.rb:23:in `new’
/var/www/rails/sparc-request/releases/20200402151727/app/lib/notifier_logic.rb:23:in `confirmation_logic’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/performable_method.rb:26:in `perform’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/backend/base.rb:81:in `block in invoke_job’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:61:in `block in initialize’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:66:in `execute’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:40:in `run_callbacks’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/backend/base.rb:78:in `invoke_job’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/newrelic_rpm-6.9.0.363/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb:129:in `block in invoke_job’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/newrelic_rpm-6.9.0.363/lib/new_relic/agent/instrumentation/controller_instrumentation.rb:376:in `perform_action_with_newrelic_trace’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/newrelic_rpm-6.9.0.363/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb:128:in `invoke_job’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:230:in `block (2 levels) in run’
/usr/local/rvm/rubies/ruby-2.5.5/lib/ruby/2.5.0/timeout.rb:93:in `block in timeout’
/usr/local/rvm/rubies/ruby-2.5.5/lib/ruby/2.5.0/timeout.rb:103:in `timeout’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:230:in `block in run’
/usr/local/rvm/rubies/ruby-2.5.5/lib/ruby/2.5.0/benchmark.rb:308:in `realtime’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:229:in `run’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:312:in `block in reserve_and_run_one_job’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:61:in `block in initialize’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:66:in `execute’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:40:in `run_callbacks’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:312:in `reserve_and_run_one_job’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:213:in `block in work_off’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:212:in `times’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:212:in `work_off’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:175:in `block (4 levels) in start’
/usr/local/rvm/rubies/ruby-2.5.5/lib/ruby/2.5.0/benchmark.rb:308:in `realtime’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:174:in `block (3 levels) in start’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:61:in `block in initialize’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:66:in `execute’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:40:in `run_callbacks’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:173:in `block (2 levels) in start’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:172:in `loop’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:172:in `block in start’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/plugins/clear_locks.rb:7:in `block (2 levels) in <class:ClearLocks>'
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:79:in `block (2 levels) in add’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:61:in `block in initialize’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:79:in `block in add’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:66:in `execute’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/lifecycle.rb:40:in `run_callbacks’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/worker.rb:171:in `start’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/command.rb:137:in `run’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/command.rb:125:in `block in run_process’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application.rb:275:in `block in start_proc’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/daemonize.rb:84:in `call_as_daemon’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application.rb:279:in `start_proc’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application.rb:305:in `start’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application_group.rb:164:in `block (2 levels) in start_all’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application_group.rb:163:in `fork’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application_group.rb:163:in `block in start_all’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application_group.rb:162:in `each’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/application_group.rb:162:in `start_all’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/controller.rb:66:in `run’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons.rb:199:in `block in run_proc’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons/cmdline.rb:121:in `catch_exceptions’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/daemons-1.3.1/lib/daemons.rb:198:in `run_proc’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/command.rb:123:in `run_process’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/command.rb:104:in `block in daemonize’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/command.rb:102:in `times’
/var/www/rails/sparc-request/shared/bundle/ruby/2.5.0/gems/delayed_job-4.1.8/lib/delayed/command.rb:102:in `daemonize’
bin/delayed_job:5:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `load’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `kernel_load’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:28:in `run’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/cli.rb:465:in `exec’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/cli.rb:27:in `dispatch’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/cli.rb:18:in `start’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/exe/bundle:30:in `block in <top (required)>'
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/gems/bundler-2.0.2/exe/bundle:22:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/bin/bundle:23:in `load’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/bin/bundle:23:in `<main>'
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/bin/ruby_executable_hooks:24:in `eval’
/usr/local/rvm/gems/ruby-2.5.5@sparc-request/bin/ruby_executable_hooks:24:in `<main>'
```