### PR TITLE
YW- Service Survey Complete Alerts 

### DIFF
--- a/app/controllers/catalog_manager/organizations_controller.rb
+++ b/app/controllers/catalog_manager/organizations_controller.rb
@@ -280,6 +280,7 @@ class CatalogManager::OrganizationsController < CatalogManager::AppController
       :process_ssrs,
       :is_available,
       :use_default_statuses,
+      :survey_completion_alerts,
       { tag_list:  [] },
       submission_emails_attributes: [:organization_id, :email]
       ])

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -138,8 +138,6 @@ class Surveyor::ResponsesController < Surveyor::BaseController
         SurveyNotification.service_survey_completed(@response, @response.respondable, su).deliver
       end
     end
-  end  
-    
   end
 
   def resend_survey

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -132,7 +132,14 @@ class Surveyor::ResponsesController < Surveyor::BaseController
   end
 
   def complete
-    @survey = Response.find(params[:response_id]).survey
+    @response = Response.find(params[:response_id])
+    if @response.respondable_id && @response.respondable.organization.survey_completion_alerts
+      @response.respondable.organization.super_users.each do |su|
+        SurveyNotification.service_survey_completed(@response, @response.respondable, su).deliver
+      end
+    end
+  end  
+    
   end
 
   def resend_survey

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -134,7 +134,8 @@ class Surveyor::ResponsesController < Surveyor::BaseController
   def complete
     @response = Response.find(params[:response_id])
     if @response.respondable_id && @response.respondable.organization.survey_completion_alerts
-      @response.respondable.organization.super_users.each do |su|
+      ### sent emails to all relevant super users for an organization of which survey_completion_alerts is true
+      @response.respondable.organization.all_super_users.each do |su|
         SurveyNotification.service_survey_completed(@response, @response.respondable, su).deliver
       end
     end

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -136,7 +136,7 @@ class Surveyor::ResponsesController < Surveyor::BaseController
     if @response.respondable_id && @response.respondable.organization.survey_completion_alerts
       ### sent emails to all relevant super users for an organization of which survey_completion_alerts is true
       @response.respondable.organization.all_super_users.each do |su|
-        SurveyNotification.service_survey_completed(@response, @response.respondable, su).deliver
+        SurveyNotification.service_survey_completed(@response, @response.respondable, su).deliver_later
       end
     end
   end

--- a/app/mailers/survey_notification.rb
+++ b/app/mailers/survey_notification.rb
@@ -42,4 +42,13 @@ class SurveyNotification < ActionMailer::Base
     mail(to: email, from: Setting.get_value("no_reply_from"), subject: subject)
   end
 
+  def service_survey_completed(response, ssr, super_user)
+    @response  = response
+    @identity  = Identity.find(response.identity_id)
+    email      = super_user.identity.email
+    subject    = t('surveyor.responses.emails.service_survey_completed.subject', site_name: t(:proper)[:header], ssr_id: ssr.display_id)
+
+    mail(to: email, from: @identity.email, subject: subject)
+  end
+
 end

--- a/app/mailers/survey_notification.rb
+++ b/app/mailers/survey_notification.rb
@@ -44,7 +44,7 @@ class SurveyNotification < ActionMailer::Base
 
   def service_survey_completed(response, ssr, super_user)
     @response  = response
-    @identity  = Identity.find(response.identity_id)
+    @identity  = response.identity
     email      = super_user.identity.email
     subject    = t('surveyor.responses.emails.service_survey_completed.subject', site_name: t(:proper)[:header], ssr_id: ssr.display_id)
 

--- a/app/views/catalog_manager/organizations/_general_info_form.html.haml
+++ b/app/views/catalog_manager/organizations/_general_info_form.html.haml
@@ -47,6 +47,11 @@
       .col-sm-9
         = f.check_box :process_ssrs, { checked: organization.process_ssrs, disabled: false, data: {toggle: 'toggle', on: 'Yes', off: 'No'}}
 
+    .form-group.survey_alert_container
+      = f.label :survey_completion_alerts, t(:catalog_manager)[:organization_form][:survey_completion_alerts], class: 'col-sm-3 control-label'
+      .col-sm-9
+        = f.check_box :survey_completion_alerts, { checked: organization.survey_completion_alerts, data: {toggle: 'toggle', on: 'Yes', off: 'No'}}
+
   - if ['Institution','Provider'].include?(organization.type) && current_user.catalog_overlord?
     .form-group
       = f.label :css_class, t(:catalog_manager)[:organization_form][:css_class], class: 'col-sm-3 control-label'

--- a/app/views/survey_notification/service_survey_completed.html.haml
+++ b/app/views/survey_notification/service_survey_completed.html.haml
@@ -22,4 +22,4 @@
 = t(:surveyor)[:responses][:emails][:service_survey_completed][:text1]
 
 = t(:surveyor)[:responses][:emails][:service_survey_completed][:text2]
-= link_to 'here', url_for(controller: '/surveyor/responses', action: :show, only_path: false, id: @response.id, format: :html), target: '_blank'
+= link_to t(:surveyor)[:responses][:emails][:link_to], url_for(controller: '/surveyor/responses', action: :show, only_path: false, id: @response.id, format: :html), target: '_blank'

--- a/app/views/survey_notification/service_survey_completed.html.haml
+++ b/app/views/survey_notification/service_survey_completed.html.haml
@@ -17,12 +17,9 @@
 -# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.card.w-100#surveyCard
-  .card-body.pt-2.text-center
-    %h1
-      = t(:surveyor)[:responses][:complete][:header]
-    %h4.text-muted
-      = @response.survey.title
-    .alert.alert-info.text-center
-      = t(:surveyor)[:responses][:complete][:thanks]
-    = link_to t(:surveyor)[:responses][:complete][:to_dashboard], Setting.get_value("dashboard_link"), class: 'btn btn-lg btn-success'
+
+= @identity.display_name
+= t(:surveyor)[:responses][:emails][:service_survey_completed][:text1]
+
+= t(:surveyor)[:responses][:emails][:service_survey_completed][:text2]
+= link_to 'here', url_for(controller: '/surveyor/responses', action: :show, only_path: false, id: @response.id, format: :html), target: '_blank'

--- a/app/views/survey_notification/system_satisfaction_survey.html.haml
+++ b/app/views/survey_notification/system_satisfaction_survey.html.haml
@@ -22,4 +22,4 @@
 = t(:surveyor)[:responses][:emails][:system_satisfaction][:text1]
 
 = t(:surveyor)[:responses][:emails][:system_satisfaction][:text2]
-= link_to 'here', url_for(controller: '/surveyor/responses', action: :show, only_path: false, id: @response.id, format: :html), target: '_blank'
+= link_to t(:surveyor)[:responses][:emails][:link_to], url_for(controller: '/surveyor/responses', action: :show, only_path: false, id: @response.id, format: :html), target: '_blank'

--- a/config/locales/catalog_manager.en.yml
+++ b/config/locales/catalog_manager.en.yml
@@ -180,6 +180,7 @@ en:
       status_legend: "Status Options (Use default statuses below or click to create custom service request statuses)"
       submit_button: "Save"
       tag_list: "Tags"
+      survey_completion_alerts: "Survey Alert"
 
     related_services_form:
       add_service: "Search for service to link"

--- a/config/locales/surveyor.en.yml
+++ b/config/locales/surveyor.en.yml
@@ -96,6 +96,10 @@ en:
         sctr_customer_satisfaction:
           grant_reminder: "Please remember to cite the CTSA grant in any related publications:"
           grant_info: "&quot;This publication [or project] was supported by the South Carolina Clinical & Translation Research (SCTR) Institute, with an academic home at the Medical University of South Carolina <strong class='din-gray-text'>NIH - NCATS Grant Number UL1 TR001450.</strong>&quot;"
+        service_survey_completed:
+          subject: "Service Survey Completed in %{site_name}"
+          text1: "has completed a service survey."
+          text2: "Results can be found "
       tooltips:
         complete: "Forms to collect additional information related to requesting a service"
         view: "View Response"

--- a/config/locales/surveyor.en.yml
+++ b/config/locales/surveyor.en.yml
@@ -82,6 +82,7 @@ en:
           actions: "Actions"
           by: "By"
       emails:
+        link_to: "here"
         system_satisfaction:
           subject: "System Satisfaction Survey Completed in %{site_name}"
           text1: "has completed a system satisfaction survey."

--- a/db/migrate/20191023184015_add_survey_completion_alerts_to_organizations.rb
+++ b/db/migrate/20191023184015_add_survey_completion_alerts_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddSurveyCompletionAlertsToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organizations, :survey_completion_alerts, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_31_190917) do
+ActiveRecord::Schema.define(version: 2020_03_11_190154) do
 
   create_table "admin_rates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "line_item_id"
@@ -414,6 +414,7 @@ ActiveRecord::Schema.define(version: 2019_10_31_190917) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.boolean "use_default_statuses", default: true
+    t.boolean "survey_completion_alerts", default: false
     t.index ["is_available"], name: "index_organizations_on_is_available"
     t.index ["parent_id"], name: "index_organizations_on_parent_id"
   end
@@ -951,6 +952,7 @@ ActiveRecord::Schema.define(version: 2019_10_31_190917) do
     t.datetime "deleted_at"
     t.boolean "access_empty_protocols", default: false
     t.boolean "billing_manager"
+    t.boolean "allow_credit"
     t.index ["identity_id"], name: "index_super_users_on_identity_id"
     t.index ["organization_id"], name: "index_super_users_on_organization_id"
   end

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
     process_ssrs  { false }
     is_available  { true }
     use_default_statuses { true }
+    survey_completion_alerts { false }
     order         { 1 }
 
     trait :ctrc do
@@ -68,6 +69,10 @@ FactoryBot.define do
 
     trait :without_validations do
       to_create { |instance| instance.save(validate: false) }
+    end
+
+    trait :survey_completion_alerts do
+      survey_completion_alerts {false}
     end
 
     transient do

--- a/spec/features/catalog_manager/organization_forms/general_information/user_edits_general_info_spec.rb
+++ b/spec/features/catalog_manager/organization_forms/general_information/user_edits_general_info_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'User edits organization general info', js: true do
 
   before :each do
     @institution = create(:institution)
-    @provider = create(:provider, :with_subsidy_map, parent_id: @institution.id, process_ssrs: true)
+    @provider = create(:provider, :with_subsidy_map, parent_id: @institution.id, process_ssrs: true, survey_completion_alerts: false)
     create(:catalog_manager, organization_id: @institution.id, identity_id: Identity.where(ldap_uid: 'jug2').first.id)
     create(:tag, name: "clinical work fulfillment")
   end
@@ -121,6 +121,15 @@ RSpec.describe 'User edits organization general info', js: true do
 
         @provider.reload
         expect(@provider.tag_list.include?("clinical work fulfillment")).to eq(true)
+      end
+
+      it 'should toggle survey alert' do
+        find('.survey_alert_container div.toggle.btn').click
+        click_button 'Save'
+        wait_for_javascript_to_finish
+
+        @provider.reload
+        expect(@provider.survey_completion_alerts).to eq(true)
       end
 
     end

--- a/spec/mailers/survey_notification_spec.rb
+++ b/spec/mailers/survey_notification_spec.rb
@@ -23,6 +23,7 @@ require 'rails_helper'
 RSpec.describe SurveyNotification do
 
   let(:identity)  { create(:identity, email: 'nobody@nowhere.com') }
+  let(:su)        { create(:identity, email: 'super.user@test.com') }
   let(:org)       { create(:organization) }
   let(:ssr)       { create(:sub_service_request_without_validations, organization: org, protocol: protocol, service_request: service_request, owner: build(:identity)) }
   let(:protocol)  { create(:protocol_without_validations, type: "Study") }
@@ -43,13 +44,13 @@ RSpec.describe SurveyNotification do
       expect(mail).to have_subject("System Satisfaction Survey Completed in SPARCRequest")
     end
 
-    #ensure that the receiver is correct
-    it 'should render the receiver email' do
+    #ensure that the sender is correct
+    it 'should render the sender email' do
       expect(mail).to deliver_from(identity.email)
     end
 
-    #ensure that the sender is correct
-    it 'should render the sender email' do
+    #ensure that the receiver is correct
+    it 'should render the receiver email' do
       expect(mail).to deliver_to(Setting.get_value("admin_mail_to"))
     end
 
@@ -119,6 +120,41 @@ RSpec.describe SurveyNotification do
 
     it 'should contain the SCTR grant citation paragraph' do
       expect(mail.body.include?("id='sctr-grant-citation'")).to eq(true)
+    end
+  end
+
+  before :each do
+    org.update_attributes(survey_completion_alerts: true)
+  end
+
+  describe 'service system satisfaction survey completed ' do
+    context 'and Survey Alert is checked for the organization' do
+      let(:super_user) { create(:super_user, identity: su, organization: org, access_empty_protocols: true) }
+      let(:survey)    { create(:system_survey, title: "System Satisfaction survey", access_code: "system-satisfaction-survey") }
+      let(:response)   { create(:response, identity: identity, survey: survey, respondable: ssr) }
+      let(:mail)       { SurveyNotification.service_survey_completed(response, ssr, super_user) }
+
+
+      #ensure that the subject is correct
+      it 'should render the subject' do
+        expect(mail).to have_subject("Service Survey Completed in SPARCRequest")
+      end
+
+      #ensure that the sender is correct
+      it 'should render the sender email' do
+        expect(mail).to deliver_from(identity.email)
+      end
+
+      #ensure that the receiver is correct
+      it 'should render the receiver email' do
+        expect(mail).to deliver_to(su.email)
+      end
+
+      #ensure that the e-mail contains a link to view the survey results
+      it 'should contain the survey response link' do
+        survey_link_path = "surveyor/responses/#{response.id}"
+        expect(mail.body.include?(survey_link_path)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
Pivotal Tracker: https://www.pivotaltracker.com/n/projects/1918597/stories/167076277

Add an option (possibly in the catalog manager under General Information) for the service provider's super users to receive an email notification when a user completes a service survey.