### PR TITLE
Enable Other Funding Status Options[#170883735]

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -488,7 +488,7 @@ class Protocol < ApplicationRecord
     elsif self.pending_funding?
       self.potential_funding_source
     else
-      nil
+      'unfunded'  ## for other status options
     end
   end
 

--- a/db/seeds/permissible_values/2.0.5/funding_statuses.csv
+++ b/db/seeds/permissible_values/2.0.5/funding_statuses.csv
@@ -1,3 +1,4 @@
 id,key,value,concept_code,parent_id,sort_order,category,default,reserved,is_available
 ,pending_funding,Pending Funding,,,1,funding_status,,,1
 ,funded,Funded,,,2,funding_status,,,1
+,not_funded,Not Funded,,,3,funding_status,,,


### PR DESCRIPTION
PT https://www.pivotaltracker.com/n/projects/1918597/stories/170883735

**Background:**
We need to have additional Funding Status options of "Unfunded" and "Not Funded" so that 1. people entering and working on requests (both internal and investigators) are not confused with selecting or viewing Funded or Pending Funding as the status for unfunded/ not funded submissions, and 2. reporting can be pulled for unfunded/ not funded activities.

**Acceptance Criteria:**
Ability to add new Statuses -or- Unfunded and Not Funded added in as status options to select from (can be configurable to turn off if needed)

** Each institution can enable/disable any additional funding status by updating the is_available flag for the status(s) in permissible_values table.