### PR TITLE
KG - Add Service Name Display For All Calendar Field Editing

### DIFF
--- a/app/views/line_items/_form.html.haml
+++ b/app/views/line_items/_form.html.haml
@@ -28,19 +28,21 @@
   - min = nil
   - max = nil
 
-.modal-dialog.modal-sm{ role: 'document' }
+.modal-dialog{ role: 'document' }
   .modal-content
     = form_for line_item, remote: true do |f|
       = hidden_field_tag :srid, service_request.try(:id)
       = hidden_field_tag :ssrid, sub_service_request.try(:id)
       = hidden_field_tag :field, params[:field]
       .modal-header
-        %h3.modal-title
+        %h3.modal-title<
           = t("calendars.editable_fields.#{params[:field]}")
+          %small.text-muted
+            = line_item.service.display_service_name
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group
+        .form-group.mb-0
           = f.label params[:field], class: 'required'
           .input-group
             - if params[:field] == 'displayed_cost'

--- a/app/views/line_items_visits/_form.html.haml
+++ b/app/views/line_items_visits/_form.html.haml
@@ -18,7 +18,7 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-.modal-dialog.modal-sm{ role: 'document' }
+.modal-dialog{ role: 'document' }
   .modal-content
     = form_for line_items_visit, remote: true do |f|
       = hidden_field_tag :srid, service_request.try(:id)
@@ -27,12 +27,14 @@
       = hidden_field_tag :page, params[:page]
       = hidden_field_tag :tab, params[:tab]
       .modal-header
-        %h3.modal-title
+        %h3.modal-title<
           = t("calendars.editable_fields.#{params[:field]}")
+          %small.text-muted
+            = line_items_visit.service.display_service_name
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
-        .form-group
+        .form-group.mb-0
           = f.label params[:field], class: 'required'
           .input-group
             .input-group-prepend

--- a/app/views/visits/_form.html.haml
+++ b/app/views/visits/_form.html.haml
@@ -26,19 +26,21 @@
       = hidden_field_tag :tab, 'billing_strategy'
       = hidden_field_tag :page, params[:page]
       .modal-header
-        %h3.modal-title
+        %h3.modal-title<
           = t(:calendars)[:pppv][:header_fields][:edit_billing_modal]
+          %small.text-muted
+            = visit.service.display_service_name
         %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
         .form-row
-          .form-group.col-4
+          .form-group.col-4.mb-0
             = f.label :research_billing_qty, class: 'required'
             = f.text_field :research_billing_qty, class: 'form-control'
-          .form-group.col-4
+          .form-group.col-4.mb-0
             = f.label :insurance_billing_qty, class: 'required'
             = f.text_field :insurance_billing_qty, class: 'form-control'
-          .form-group.col-4
+          .form-group.col-4.mb-0
             = f.label :effort_billing_qty, class: 'required'
             = f.text_field :effort_billing_qty, class: 'form-control'
       .modal-footer


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171770941

### Background:
When people are working on a service calendar that has multiple clinical services and editing the billing quantities to change numbers for R/T, it is currently hard to tell which one they are editing.

### Acceptance Criteria:
On SPARCRequest Step 3 page and SPARCDashboard Admin Edit, on the "Edit Billing Quantities" window, please add display of service name and CPT code on the modal header region, to help with usability.

### Comments
- I also added the service name for Subject Count and for non-clinical service Quantity, and Units per Quantity so that all fields now inform the user as well.