### PR TITLE
KG - Service Calendar Cell Wrapping

### DIFF
--- a/app/assets/stylesheets/service_calendar.scss
+++ b/app/assets/stylesheets/service_calendar.scss
@@ -118,12 +118,6 @@
       cursor: pointer;
     }
   }
-
-  tbody td, tbody th {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 }
 
 // Admin Styling

--- a/app/views/service_calendars/_quantity.html.haml
+++ b/app/views/service_calendars/_quantity.html.haml
@@ -20,8 +20,8 @@
 
 - editable = editable && !merged
 
-%td.quantity.text-center{ class: editable ? 'editable' : '', title: line_item.quantity, data: { toggle: 'tooltip' } }
+%td.quantity.text-center{ class: editable ? 'editable' : '', title: number_with_delimiter(line_item.quantity, delimiter: ','), data: { toggle: 'tooltip' } }
   - if editable
-    = link_to line_item.quantity, edit_line_item_path(line_item, srid: service_request.id, field: 'quantity'), remote: true
+    = link_to number_with_delimiter(line_item.quantity, delimiter: ','), edit_line_item_path(line_item, srid: service_request.id, field: 'quantity'), remote: true
   - else
-    = line_item.quantity
+    = number_with_delimiter(line_item.quantity, delimiter: ',')

--- a/app/views/service_calendars/_subject_count.html.haml
+++ b/app/views/service_calendars/_subject_count.html.haml
@@ -20,8 +20,8 @@
 
 - editable = editable && !(service_request.protocol.locked? || merged)
 
-%td.subject-count.text-center{ colspan: 2, class: editable ? 'editable' : '', title: liv.subject_count, data: { toggle: 'tooltip' } }
+%td.subject-count.text-center{ colspan: 2, class: editable ? 'editable' : '', title: number_with_delimiter(liv.subject_count, delimiter: ','), data: { toggle: 'tooltip' } }
   - if editable
-    = link_to liv.subject_count, edit_line_items_visit_path(liv, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), field: 'subject_count', page: page, tab: tab), remote: true
+    = link_to number_with_delimiter(liv.subject_count, delimiter: ','), edit_line_items_visit_path(liv, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), field: 'subject_count', page: page, tab: tab), remote: true
   - else
-    = liv.subject_count
+    = number_with_delimiter(liv.subject_count, delimiter: ',')

--- a/app/views/service_calendars/_units_per_quantity.html.haml
+++ b/app/views/service_calendars/_units_per_quantity.html.haml
@@ -20,8 +20,8 @@
 
 - editable = editable && !merged
 
-%td.units-per-quantity.text-center{ class: editable ? 'editable' : '', title: line_item.units_per_quantity, data: { toggle: 'tooltip' } }
+%td.units-per-quantity.text-center{ class: editable ? 'editable' : '', title: number_with_delimiter(line_item.units_per_quantity, delimiter: ','), data: { toggle: 'tooltip' } }
   - if editable
-    = link_to line_item.units_per_quantity, edit_line_item_path(line_item, srid: service_request.id, field: 'units_per_quantity'), remote: true
+    = link_to number_with_delimiter(line_item.units_per_quantity, delimiter: ','), edit_line_item_path(line_item, srid: service_request.id, field: 'units_per_quantity'), remote: true
   - else
-    = line_item.units_per_quantity
+    = number_with_delimiter(line_item.units_per_quantity, delimiter: ',')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171770670

### Background:
Currently we show the CPT codes in "()" along with the service name for the cpt-coded services on SR Step 3 calendar page and SPARCDashboard Admin Edit. However, most hospital services CPT codes are partially or not displayed because the service name could run long.
Hovering over each service to be able to see the CPT codes have been a big issue with our calendar users.

### Acceptance Criteria:
1). wrap the service column into 2 rows and adjust the font in that column to still keep enough lines on the same view displayed;