### PR TITLE
KG - Random Spec Failures

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -19,9 +19,9 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Question < ActiveRecord::Base
-
   belongs_to :section
   belongs_to :depender, class_name: 'Option'
+
   has_many :options, dependent: :destroy
   has_many :question_responses, dependent: :destroy
 

--- a/spec/features/surveyor/surveys/user_edits_question_fields_spec.rb
+++ b/spec/features/surveyor/surveys/user_edits_question_fields_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe 'User edits question fields', js: true do
       context 'with options that appear in a dependent selectpicker' do
         scenario 'and sees updated dependent selectpickers' do
           @option    = create(:option, question: @question)
-          @question2 = create(:question, section: @section, is_dependent: true)
+          @question2 = create(:question, section: @section, is_dependent: true, depender: @option)
 
           visit surveyor_surveys_path
           wait_for_javascript_to_finish
@@ -225,10 +225,8 @@ RSpec.describe 'User edits question fields', js: true do
           confirm_swal
           wait_for_javascript_to_finish
 
-          find('.select-depender').click
-          wait_for_javascript_to_finish
-
-          expect(page).to have_no_selector('.select-depender .text', text: @option.content, visible: true)
+          expect(page).to have_no_selector('.select-depender')
+          expect(page).to have_field("question-#{@question2.id}-is_dependent", checked: false, disabled: true)
         end
       end
     end


### PR DESCRIPTION
Random Spec Failures worked on:

`rspec spec/features/surveyor/surveys/user_edits_question_fields_spec:228`
This spec was actually _randomly passing_. The spec expected to have an empty depender dropdown, but what actually happens in this scenario is that the dropdown is hidden and the checkbox unchecked/disabled. I updated the spec to actually have the right expectation.