### PR TITLE
Fix Survey Responses Resend Button Bugs

### DIFF
--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -143,12 +143,8 @@ class Surveyor::ResponsesController < Surveyor::BaseController
 
   def resend_survey
     @response = Response.find(params[:response_id])
-    if @response.survey.access_code == 'system-satisfaction-survey'
-      SurveyNotification.system_satisfaction_survey(@response).deliver
-      @response.update_attribute(:updated_at, Time.now)
-    else
-      SurveyNotification.service_survey([@response.survey], @response.identity, @response.try(:respondable)).deliver
-    end
+    ## resend button is disabled for surveys that are not tied to any organization
+    SurveyNotification.service_survey([@response.survey], @response.identity, @response.try(:respondable)).deliver
     flash[:success] = t(:surveyor)[:responses][:resent]
   end
 

--- a/app/helpers/surveyor/responses_helper.rb
+++ b/app/helpers/surveyor/responses_helper.rb
@@ -50,7 +50,7 @@ module Surveyor::ResponsesHelper
       if response.completed?
         false
       else
-        current_user.is_site_admin? || accessible_surveys.include?(response.survey)
+        response.respondable_type == "SubServiceRequest" && (current_user.is_site_admin? || accessible_surveys.include?(response.survey))
       end
 
     content_tag(:div,


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/172319951
 
Currently, when users click on the Resend button of an incomplete system satisfaction survey from Responses View (SPARCForms), a 'System Satisfaction Survey Completed in SPARCRequest' email is sent to admin_email with a link to an blank survey. 
**Issues:**
1. The resend button should be disabled if the response doesn't tie to any organization
2. If the response is associated with a SSR, a 'SPARCRequest Survey Notification (Request xxxx-000x)' email should be sent to the assigned user.