### PR TITLE
KG - Service Request Resubmission Epic Queue Push Logic Change

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -114,7 +114,7 @@ class ServiceRequestsController < ApplicationController
         @protocol = @service_request.protocol
         @service_request.previous_submitted_at = @service_request.submitted_at
 
-        if Setting.get_value("use_epic") && @service_request.should_push_to_epic? && @protocol.selected_for_epic?
+        if Setting.get_value("use_epic") && @protocol.selected_for_epic? && @service_request.should_push_to_epic?
           # Send a notification to Lane et al to create users in Epic.  Once
           # that has been done, one of them will click a link which calls
           # approve_epic_rights.

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -114,7 +114,7 @@ class ServiceRequestsController < ApplicationController
         @protocol = @service_request.protocol
         @service_request.previous_submitted_at = @service_request.submitted_at
 
-        if Setting.get_value("use_epic") && @protocol.selected_for_epic? && @service_request.should_push_to_epic?
+        if @service_request.should_push_to_epic?
           # Send a notification to Lane et al to create users in Epic.  Once
           # that has been done, one of them will click a link which calls
           # approve_epic_rights.

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -254,10 +254,6 @@ class LineItem < ApplicationRecord
     end
   end
 
-  def should_push_to_epic?
-    return self.service.send_to_epic
-  end
-
   ### audit reporting methods ###
 
   def audit_field_value_mapping

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -572,7 +572,7 @@ class Protocol < ApplicationRecord
   end
 
   def should_push_to_epic?
-    service_requests.any?(&:should_push_to_epic?)
+    self.service_requests.any?(&:should_push_to_epic?)
   end
 
   def has_nexus_services?

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -397,11 +397,12 @@ class ServiceRequest < ApplicationRecord
 
   def should_push_to_epic?(ssrids=nil)
     # https://www.pivotaltracker.com/story/show/156705787
-    if self.previously_submitted?
-      self.line_items.joins(:sub_service_request, :service).where(services: { send_to_epic: true }, sub_service_requests: { id: (ssrids.present? ? ssrids : self.sub_service_requests.ids), status: 'draft' })
-    else
-      self.services.where(send_to_epic: true).any?
-    end
+    Setting.get_value("use_epic") && self.protocol.selected_for_epic? &&
+      if self.previously_submitted?
+        self.line_items.joins(:sub_service_request, :service).where(services: { send_to_epic: true }, sub_service_requests: { id: (ssrids.present? ? ssrids : self.sub_service_requests.ids), status: 'draft' }).any?
+      else
+        self.services.where(send_to_epic: true).any?
+      end
   end
 
   def has_ctrc_clinical_services?

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -396,8 +396,13 @@ class ServiceRequest < ApplicationRecord
     self.sub_service_requests.any?(&:eligible_for_subsidy?)
   end
 
-  def should_push_to_epic?
-    return self.line_items.any? { |li| li.should_push_to_epic? }
+  def should_push_to_epic?(ssrids=nil)
+    # https://www.pivotaltracker.com/story/show/156705787
+    if self.previously_submitted?
+      self.line_items.joins(:sub_service_request, :service).where(services: { send_to_epic: true }, sub_service_requests: { id: (ssrids.present? ? ssrids : self.sub_service_requests.ids), status: 'draft' })
+    else
+      self.services.where(send_to_epic: true).any?
+    end
   end
 
   def has_ctrc_clinical_services?

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -126,10 +126,6 @@ class SubServiceRequest < ApplicationRecord
     end
   end
 
-  def should_push_to_epic?
-    return self.line_items.any? { |li| li.should_push_to_epic? }
-  end
-
   def update_org_tree
     my_tree = nil
     if organization.type == "Core"

--- a/spec/models/service_request/should_push_to_epic_spec.rb
+++ b/spec/models/service_request/should_push_to_epic_spec.rb
@@ -1,0 +1,109 @@
+# Copyright © 2011-2019 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+require 'rails_helper'
+
+RSpec.describe ServiceRequest, type: :model do
+  let!(:organization)     { create(:organization) }
+  let!(:service_epic)     { create(:service, organization: organization, send_to_epic: true) }
+  let!(:service_no_epic)  { create(:service, organization: organization, send_to_epic: false) }
+
+  describe '#should_push_to_epic?' do
+    context 'epic is enabled' do
+      stub_config('use_epic', true)
+
+      context 'protocol is selected for epic' do
+        let!(:protocol) { create(:study_federally_funded, primary_pi: create(:identity), selected_for_epic: true) }
+
+        context 'new ServiceRequest' do
+          let!(:sr) { create(:service_request, protocol: protocol, submitted_at: nil) }
+          let!(:ssr) { create(:sub_service_request, service_request: sr, organization: organization) }
+
+          context 'services are selected for epic' do
+            let!(:li) { create(:line_item, service_request: sr, sub_service_request: ssr, service: service_epic) }
+
+            it 'should return true' do
+              expect(sr.should_push_to_epic?).to eq(true)
+            end
+          end
+
+          context 'services are not selected for epic' do
+            let!(:li) { create(:line_item, service_request: sr, sub_service_request: ssr, service: service_no_epic) }
+
+            it 'should return false' do
+              expect(sr.should_push_to_epic?).to eq(false)
+            end
+          end
+        end
+
+        context 'ServiceRequest is previously submitted' do
+          let!(:sr) { create(:service_request, :submitted, protocol: protocol) }
+
+          context 'Draft SSR to be resubmitted' do
+            let!(:ssr) { create(:sub_service_request, service_request: sr, organization: organization, status: 'draft', submitted_at: DateTime.now) }
+
+            context 'services are selected for epic' do
+              let!(:li) { create(:line_item, service_request: sr, sub_service_request: ssr, service: service_epic) }
+
+              it 'should return true' do
+                expect(sr.should_push_to_epic?).to eq(true)
+              end
+            end
+
+            context 'services are not selected for epic' do
+              let!(:li) { create(:line_item, service_request: sr, sub_service_request: ssr, service: service_no_epic) }
+
+              it 'should return false' do
+                expect(sr.should_push_to_epic?).to eq(false)
+              end
+            end
+          end
+
+          context 'No draft SSRs to be resubmitted' do
+            let!(:ssr) { create(:sub_service_request, :submitted, service_request: sr, organization: organization) }
+            let!(:li) { create(:line_item, service_request: sr, sub_service_request: ssr, service: service_epic) }
+
+            it 'should return false' do
+              expect(sr.should_push_to_epic?).to eq(false)
+            end
+          end
+        end
+
+        context 'protocol is not selected for epic' do
+          let!(:protocol) { create(:study_federally_funded, primary_pi: create(:identity), selected_for_epic: false) }
+          let!(:sr)       { create(:service_request, protocol: protocol) }
+
+          it 'should return false' do
+            expect(sr.should_push_to_epic?).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'epic is disabled' do
+      stub_config('use_epic', false)
+
+      let!(:sr) { create(:service_request_without_validations) }
+
+      it 'should return false' do
+        expect(sr.should_push_to_epic?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -19,22 +19,35 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 def populate_settings_before_suite
-  Setting.auditing_enabled = false
-  SettingsPopulator.new().populate
+  @settings_populated ||= false
 
-  Setting.find_by_key("use_epic").update_attribute(:value, true)
-  Setting.find_by_key("use_ldap").update_attribute(:value, false)
-  Setting.find_by_key("use_funding_module").update_attribute(:value, true)
-  Setting.find_by_key("suppress_ldap_for_user_search").update_attribute(:value, true)
-  Setting.find_by_key("ldap_auth_username").update_attribute(:value, nil)
-  Setting.find_by_key("ldap_auth_password").update_attribute(:value, nil)
-  Setting.find_by_key("ldap_filter").update_attribute(:value, nil)
+  # Don't re-run settings population
+  unless @settings_populated
+    Setting.auditing_enabled = false
+    SettingsPopulator.new().populate
 
-  load File.expand_path("../../../app/lib/directory.rb", __FILE__)
+    Setting.find_by_key("use_epic").update_attribute(:value, true)
+    Setting.find_by_key("use_ldap").update_attribute(:value, false)
+    Setting.find_by_key("use_funding_module").update_attribute(:value, true)
+    Setting.find_by_key("suppress_ldap_for_user_search").update_attribute(:value, true)
+    Setting.find_by_key("ldap_auth_username").update_attribute(:value, nil)
+    Setting.find_by_key("ldap_auth_password").update_attribute(:value, nil)
+    Setting.find_by_key("ldap_filter").update_attribute(:value, nil)
+
+    load File.expand_path("../../../app/lib/directory.rb", __FILE__)
+
+    @settings_populated = true
+  end
 end
 
 def stub_config(key, value)
-  setting = Setting.find_by_key(key)
+  unless setting = Setting.find_by_key(key)
+    # Scenario: The specs are run such that a stub_config is called before
+    # a test causes there to be no Settings yet. before :suite doesn't work
+    populate_settings_before_suite
+    setting = Setting.find_by_key(key)
+  end
+
   default_value = setting.value
 
   before :each do
@@ -47,7 +60,17 @@ def stub_config(key, value)
 end
 
 RSpec.configure do |config|
+  config.before :all do
+    populate_settings_before_suite
+  end
+
   config.before :each do
+    # This sometimes triggers a failure because of missing settings depending on
+    # the order that specs are run. This method wastes processing during the suite
+    # so let's stub it
+    allow_any_instance_of(Identity).to receive(:send_admin_mail).and_return(true)
+
+    # Cache settings for slight efficiency boost during tests
     Setting.preload_values
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/156705787

### Background:
Currently, when a user is submitting or re-submitting a protocol and that protocol has been flagged to "send to epic", our API logic is to put it into the protocol Epic queue. This causes confusion some times, because the user could have re-submitted a protocol without changing anything on the calendar.

### Acceptance Criteria: 
For a previously successfully submitted to Epic protocol, only when the protocol contains sub-service-requests (SSRs) with Epic services that are changing from Draft to Submitted should be put into the Epic queue instead.