### PR TITLE
Survey/Form Responses View Update [#16707638]

### DIFF
--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -29,6 +29,8 @@ class Surveyor::ResponsesController < Surveyor::BaseController
   end
 
   def index
+    @admin_org_ids = (current_user.is_site_admin? ? Organization.all : current_user.authorized_admin_organizations).pluck(:id)
+
     @filterrific  =
       initialize_filterrific(Response, params[:filterrific] && filterrific_params,
         default_filter_params: {
@@ -176,7 +178,13 @@ class Surveyor::ResponsesController < Surveyor::BaseController
   def load_responses
     @responses =
       if @type == Survey.name
-        @filterrific.find.eager_load(:survey, :question_responses, :identity)
+        ## https://www.pivotaltracker.com/n/projects/1918597/stories/167076358
+        if current_user.is_site_admin?
+          @filterrific.find.eager_load(:survey, :question_responses, :identity)
+        else
+          @filterrific.find.eager_load(:survey, :question_responses, :identity).
+            where(survey: SystemSurvey.for(current_user), respondable_id: SubServiceRequest.where(organization_id: @admin_org_ids))
+        end
       else
         existing_responses = @filterrific.find.eager_load(:survey, :question_responses, :identity).
           where(survey: Form.for(current_user))
@@ -203,7 +211,8 @@ class Surveyor::ResponsesController < Surveyor::BaseController
 
     responses = []
     Protocol.eager_load(sub_service_requests: [:responses, :service_forms, :organization_forms]).distinct.each do |p|
-      p.sub_service_requests.each do |ssr|
+      # It should only shows those admin have access to
+      p.sub_service_requests.where(organization_id: @admin_org_ids).each do |ssr|
         ssr.forms_to_complete.values.flatten.select do |f|
           # Apply the State, Survey/Form, and Start/End Date filters manually
           (@filterrific.with_state.try(&:empty?) || (@filterrific.with_state.try(&:any?) && @filterrific.with_state.include?(f.active ? 1 : 0))) &&

--- a/app/models/system_survey.rb
+++ b/app/models/system_survey.rb
@@ -30,6 +30,21 @@ class SystemSurvey < Survey
     })
   }
 
+  # forsite admins, super users and/or service providers
+  scope :for, -> (identity) {
+    if identity.is_site_admin?
+      SystemSurvey.all
+    else
+      orgs = Organization.authorized_for_super_user(identity.id).or(
+        Organization.authorized_for_service_provider(identity.id))
+
+      joins(:associated_surveys).
+      where(associated_surveys: {
+        associable: orgs
+      }).distinct
+    end
+  }
+
   def system_satisfaction?
     self.access_code == 'system-satisfaction-survey'
   end

--- a/app/views/surveyor/responses/_filter_responses_form.html.haml
+++ b/app/views/surveyor/responses/_filter_responses_form.html.haml
@@ -40,7 +40,7 @@
         .form-group.row{ id: "for-#{SystemSurvey.name}", class: filterrific.of_type == SystemSurvey.name ? "" : "d-none" }
           = form.label :with_survey, Survey.name, class: 'col-4 control-label'
           .col-8
-            = render 'surveyor/responses/surveys_dropdown', surveys: SystemSurvey.unscoped, filterrific: filterrific, form: form
+            = render 'surveyor/responses/surveys_dropdown', surveys: SystemSurvey.for(current_user), filterrific: filterrific, form: form
         .form-group.row
           .col-sm-12
             %label

--- a/app/views/surveyor/responses/index.json.jbuilder
+++ b/app/views/surveyor/responses/index.json.jbuilder
@@ -1,7 +1,7 @@
 if @type == 'Form'
-  accessible_surveys = Form.for_super_user(current_user).or(Form.for_service_provider(current_user))
+  accessible_surveys = Form.for(current_user)
 else
-  accessible_surveys = SystemSurvey.for_super_user(current_user)
+  accessible_surveys = SystemSurvey.for(current_user)
 end
 
 json.(@responses) do |response|


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/167076358
Background:
Currently, admin users (super users, service providers, and site admins) can see every form and responses in SPARCForms, although they only have access to view and/or edit the ones they have organizational level rights to. Previous related story can be found here: #156232184.

Acceptance Criteria:
1). Please update the SPARC Forms "dashboard" to only show those completed forms associated with the admin user currently logged in? For example, when you open your Dashboard, the user can only view those projects associated with them.

2). This display restriction should work for super user and service providers. For site admin users, they should still have access to every form (for ease of management).

 