### PR TITLE
KG - Fix Protocol Search Code When Search Term Blank

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -188,7 +188,9 @@ class Protocol < ApplicationRecord
     end
   }
 
-  scope :search_query, lambda { |search_attrs|
+  scope :search_query, -> (search_attrs) {
+    return if search_attrs.search_text.blank?
+
     # Searches protocols based on 'Authorized User', 'PI', 'Protocol ID', 'PRO#', 'RMID', 'Short/Long Title', OR 'Search All'
     # Protects against SQL Injection with ActiveRecord::Base::sanitize
     # inserts ! so that we can escape special characters


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168226099

For reasons I can't quite figure out, when the search term was blank, the attached queries would cause some protocols to be removed from the list. Returning when the search text is blank to avoid filtering, however, causes a few more protocols to show up than were previously.