### PR TITLE
SAW - Add Description to Service/Org Searches

### DIFF
--- a/app/assets/javascripts/catalog_manager/catalog.js.coffee
+++ b/app/assets/javascripts/catalog_manager/catalog.js.coffee
@@ -282,7 +282,7 @@ window.initialize_related_services_search = () ->
       limit: 100,
       templates: {
         suggestion: Handlebars.compile('
-          <div class="service text-left" data-container="body" data-placement="right" data-toggle="tooltip" data-animation="false" data-html="true" title="{{description}}">
+          <div class="service text-left" data-container="body" data-placement="left" data-toggle="tooltip" data-animation="false" data-html="true" title="{{description}}">
             <div class="w-100">
               <h5 class="service-name no-margin"><span class="text-service">{{type}}</span><span>: {{name}}</span></h5>
             </div>
@@ -302,8 +302,9 @@ window.initialize_related_services_search = () ->
         notFound: "<div class='tt-suggestion'>#{I18n.t('constants.search.no_results')}</div>"
       }
     }
-  )
-  .on('typeahead:select', (event, suggestion) ->
+  ).on('typeahead:render', (event, a, b, c) ->
+    $('.twitter-typeahead [data-toggle="tooltip"]').tooltip({ 'delay' : { show: 1000, hide: 500 } })
+  ).on('typeahead:select', (event, suggestion) ->
     existing_services = $("[id*='service-relation-id-']").map ->
       return $(this).data('related-service-id')
 


### PR DESCRIPTION
[#171858433](https://www.pivotaltracker.com/story/show/171858433)

Added service and organization descriptions to the search terms on SPARC homepage and SPARCCatalog searches. Also fixed an issue where the service name was not being displayed in the associated services results dropdown and the tooltip displayed on the right, making it squished and illegible.

Old:
![Screen Shot 2020-04-22 at 1 57 26 PM](https://user-images.githubusercontent.com/19152930/80018854-ac649f80-84a4-11ea-994d-0a594c7a2000.png)

New:
![Screen Shot 2020-04-22 at 2 08 45 PM](https://user-images.githubusercontent.com/19152930/80018880-b4244400-84a4-11ea-9661-8725feff82ec.png)

