### PR TITLE
SAW - OnCore Endpoint Removed Code with Typo

### DIFF
--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -245,13 +245,6 @@ class OncoreEndpointController < ApplicationController
         #   service_request.create_line_items_for_service(service: service)
         # end
         # -------------------------------------------------------------------------------------
-
-        # Make a line item visit for all clinical line items on the protocol.
-        service_request.per_patient_per_visit_line_items.each do |li|
-          unless arm.line_items_visits.any?{ |liv| liv.line_item_id == li.id }
-            arm.line_item_visits.create(line_item_id: li.id, subject_count: 1) # assumed subject_count: 1
-          end
-        end
       end
 
       # create a visit group for each VISIT


### PR DESCRIPTION
[#172245019](https://www.pivotaltracker.com/story/show/172245019)

There was an error caused by calling `arm.line_item_visits` instead of `line_items_visits`, except that method never needed to be called. When making line items by calling `service_request.create_line_items_for_service` it calls a callback to make line items visits, so we don't have to specifically go back and create them. The only reason why it was ever being called was because `arm` in `build_calendar_info` was not reloaded.