### PR TITLE
add a hold_emails attrirbute to super users 

### DIFF
--- a/app/assets/javascripts/catalog_manager/form.js.coffee
+++ b/app/assets/javascripts/catalog_manager/form.js.coffee
@@ -84,6 +84,15 @@ $ ->
       type: 'PUT'
       url: "/catalog_manager/super_user?super_user[identity_id]=#{identity_id}&super_user[organization_id]=#{organization_id}&super_user[access_empty_protocols]=#{access_empty_protocols}"
 
+  $(document).on 'change', '.su-hold_emails', ->
+    identity_id = $(this).data('identity-id')
+    organization_id = $(this).data('organization-id')
+    hold_emails = $(this).prop('checked')
+
+    $.ajax
+      type: 'PUT'
+      url: "/catalog_manager/super_user?super_user[identity_id]=#{identity_id}&super_user[organization_id]=#{organization_id}&super_user[hold_emails]=#{hold_emails}"
+
   $(document).on 'change', '.su-allow-credit', ->
     identity_id = $(this).data('identity-id')
     organization_id = $(this).data('organization-id')

--- a/app/assets/javascripts/catalog_manager/form.js.coffee
+++ b/app/assets/javascripts/catalog_manager/form.js.coffee
@@ -84,7 +84,7 @@ $ ->
       type: 'PUT'
       url: "/catalog_manager/super_user?super_user[identity_id]=#{identity_id}&super_user[organization_id]=#{organization_id}&super_user[access_empty_protocols]=#{access_empty_protocols}"
 
-  $(document).on 'change', '.su-hold_emails', ->
+  $(document).on 'change', '.su-hold-emails', ->
     identity_id = $(this).data('identity-id')
     organization_id = $(this).data('organization-id')
     hold_emails = $(this).prop('checked')

--- a/app/controllers/catalog_manager/super_users_controller.rb
+++ b/app/controllers/catalog_manager/super_users_controller.rb
@@ -75,6 +75,7 @@ class CatalogManager::SuperUsersController < CatalogManager::AppController
       :organization_id,
       :access_empty_protocols,
       :billing_manager,
-      :allow_credit)
+      :allow_credit,
+      :hold_emails)
   end
 end

--- a/app/controllers/surveyor/responses_controller.rb
+++ b/app/controllers/surveyor/responses_controller.rb
@@ -134,8 +134,10 @@ class Surveyor::ResponsesController < Surveyor::BaseController
   def complete
     @response = Response.find(params[:response_id])
     if @response.respondable_id && @response.respondable.organization.survey_completion_alerts
-      ### sent emails to all relevant super users for an organization of which survey_completion_alerts is true
+      ### Per discussions, if Survey Alert is checked for the organization, email alerts go out
+      ### to those relevant super users who want to receive emails.
       @response.respondable.organization.all_super_users.each do |su|
+        next if su.hold_emails
         SurveyNotification.service_survey_completed(@response, @response.respondable, su).deliver_later
       end
     end

--- a/app/views/catalog_manager/organizations/_user_rights_row.html.haml
+++ b/app/views/catalog_manager/organizations/_user_rights_row.html.haml
@@ -37,14 +37,18 @@
     - if !su.nil?
       .form_row
       .row
-        .col-sm-6
+        .col-sm-4
+          = label_tag :hold_emails, t(:catalog_manager)[:organization_form][:user_rights][:su_hold_emails], class: 'non_bold_label'
+        .col-sm-4
           = label_tag :access_empty_protocols, t(:catalog_manager)[:organization_form][:user_rights][:access_empty_protocols], class: 'non_bold_label'
-        .col-sm-6
+        .col-sm-4
           = label_tag :billing_manager, t(:catalog_manager)[:organization_form][:user_rights][:billing_manager], class: 'non_bold_label'
       .row
-        .col-sm-6
+        .col-sm-4
+          = check_box_tag :hold_emails, true, su.try(:hold_emails), { id: "su-access-empty-protocols-#{user.id}", class: "su-hold_emails", data: { identity_id: user.id, organization_id: organization.id } }
+        .col-sm-4
           = check_box_tag :access_empty_protocols, true, su.try(:access_empty_protocols), { id: "su-access-empty-protocols-#{user.id}", class: "su-access-empty-protocols", data: { identity_id: user.id, organization_id: organization.id } }
-        .col-sm-6
+        .col-sm-4
           = check_box_tag :billing_manager, true, su.try(:billing_manager), { id: "su-billing-manager-#{user.id}", class: "su-billing-manager", data: { identity_id: user.id, organization_id: organization.id } }
       - if su.try(:billing_manager).present?
         .form_row

--- a/app/views/catalog_manager/organizations/_user_rights_row.html.haml
+++ b/app/views/catalog_manager/organizations/_user_rights_row.html.haml
@@ -45,7 +45,7 @@
           = label_tag :billing_manager, t(:catalog_manager)[:organization_form][:user_rights][:billing_manager], class: 'non_bold_label'
       .row
         .col-sm-4
-          = check_box_tag :hold_emails, true, su.try(:hold_emails), { id: "su-access-empty-protocols-#{user.id}", class: "su-hold_emails", data: { identity_id: user.id, organization_id: organization.id } }
+          = check_box_tag :hold_emails, true, su.hold_emails, { id: "su-hold-emails-#{user.id}", class: "su-hold-emails", data: { identity_id: user.id, organization_id: organization.id } }
         .col-sm-4
           = check_box_tag :access_empty_protocols, true, su.try(:access_empty_protocols), { id: "su-access-empty-protocols-#{user.id}", class: "su-access-empty-protocols", data: { identity_id: user.id, organization_id: organization.id } }
         .col-sm-4

--- a/config/locales/catalog_manager.en.yml
+++ b/config/locales/catalog_manager.en.yml
@@ -60,6 +60,7 @@ en:
         allow_credit: "Allow Credit"
         name_email: "Name, Email"
         super_user: "Super User"
+        su_hold_emails: "Hold Email"
         access_empty_protocols: "Empty Protocols"
         billing_manager: "Billing Manager"
         catalog_manager: "Catalog Manager"

--- a/db/migrate/20200423153027_add_hold_emails_to_super_users.rb
+++ b/db/migrate/20200423153027_add_hold_emails_to_super_users.rb
@@ -1,0 +1,5 @@
+class AddHoldEmailsToSuperUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :super_users, :hold_emails,  :boolean, default: true
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/167076277

Per Wenjun, keep the existing logic and add an attribute on Super Users (in SPARCCatalog) to be "Hold Emails" the same way we have that for service providers? That way, we could default that Hold Emails = Yes for all super users, and set it to not hold for those who wants to receive the survey emails.