### PR TITLE
Fixes error trying to add new user with ldap uid

### DIFF
--- a/app/controllers/catalog_manager/organizations_controller.rb
+++ b/app/controllers/catalog_manager/organizations_controller.rb
@@ -93,7 +93,7 @@ class CatalogManager::OrganizationsController < CatalogManager::AppController
   ####Actions for User Rights sub-form####
   def add_user_rights_row
     @organization = Organization.find(params[:organization_id])
-    @new_ur_identity = Identity.find(params[:new_ur_identity_id])
+    @new_ur_identity = Identity.find_by_suggestion_value(params[:new_ur_identity_id])
     @user_rights  = user_rights(@organization.id)
   end
 

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -88,6 +88,16 @@ class Identity < ApplicationRecord
     Setting.get_value("use_ldap") && Setting.get_value("lazy_load_ldap") ? ldap_uid : id
   end
 
+  ## This method is meant to mirror the suggestion_value
+  #  So if the logic for how that value is provided changes
+  #  this method should change with it.
+  def self.find_by_suggestion_value(suggestion_value)
+    if Setting.get_value("use_ldap") && Setting.get_value("lazy_load_ldap") 
+      find_by_ldap_uid(suggestion_value)
+    else
+      find(suggestion_value)
+    end
+  end
   ###############################################################################
   ############################## HELPER METHODS #################################
   ###############################################################################


### PR DESCRIPTION
If we're using ldap and lazy_ldap the suggestion value
is the `ldap_uid` and not the `id` but the query used find
which only looks at `id`