### PR TITLE
'Not Funded' funding status related UI updates

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -263,7 +263,7 @@ toggleFundingSource = (val) ->
 
       toggleFederalFields(potentialFundingSource)
       toggleFundingSourceOther(potentialFundingSource)
-    else
+    else if val == 'funded'
       potentialFundingSource    = $('#protocol_potential_funding_source').val()
       potentialFundingStartDate = $('#protocol_potential_funding_start_date').val()
 
@@ -279,7 +279,13 @@ toggleFundingSource = (val) ->
 
       toggleFederalFields(fundingSource)
       toggleFundingSourceOther(fundingSource)
-
+    else
+      $('#fundingSourceContainer').addClass('d-none')
+      $('#potentialFundingSourceContainer').addClass('d-none')
+      $('#fundingSourceOtherContainer').addClass('d-none')
+      $('#fundingRfaContainer').addClass('d-none')
+      $('#fundingStartDateContainer').addClass('d-none')
+      $('#potentialFundingStartDateContainer').addClass('d-none')
     $('#protocol_funding_source, #protocol_potential_funding_source').attr('disabled', false).selectpicker('refresh')
 
 

--- a/app/views/protocols/_summary.html.haml
+++ b/app/views/protocols/_summary.html.haml
@@ -76,9 +76,17 @@
               = Protocol.human_attribute_name(:sponsor_name)
           %td.d-inline-block.col-10
             = protocol.sponsor_name
-      %tr.d-flex
-        %td.d-inline-block.col-2
-          %label.mb-0{ title: protocol.funded? ? t('protocols.tooltips.funding_source') : t('protocols.tooltips.potential_funding_source'), data: { toggle: 'tooltip', placement: 'right' } }<
-            = Protocol.human_attribute_name(protocol.funded? ? :funding_source : :potential_funding_source)
-        %td.d-inline-block.col-10
-          = protocol.display_funding_source_value
+      - if protocol.funded? || protocol.pending_funding?
+        %tr.d-flex
+          %td.d-inline-block.col-2
+            %label.mb-0{ title: protocol.funded? ? t('protocols.tooltips.funding_source') : t('protocols.tooltips.potential_funding_source'), data: { toggle: 'tooltip', placement: 'right' } }<
+              = Protocol.human_attribute_name(protocol.funded? ? :funding_source : :potential_funding_source)
+          %td.d-inline-block.col-10
+            = protocol.display_funding_source_value
+      - else
+        %tr.d-flex
+          %td.d-inline-block.col-2
+            %label.mb-0
+              = Protocol.human_attribute_name(:funding_status)
+          %td.d-inline-block.col-10
+            = PermissibleValue.get_value('funding_status', protocol.funding_status)

--- a/app/views/protocols/view_details/_financial_information.html.haml
+++ b/app/views/protocols/view_details/_financial_information.html.haml
@@ -30,11 +30,12 @@
             = label :protocol, :funding_status, class: 'mb-0', title: t('protocols.tooltips.funding_status'), data: { toggle: 'tooltip', placement: 'right' }
           %td.w-75
             = PermissibleValue.get_value('funding_status', protocol.funding_status)
-        %tr
-          %td.w-25
-            = label :protocol, protocol.funded? ? :funding_source : :potential_funding_source, class: 'mb-0', title: protocol.funded? ? t(:protocols)[:tooltips][:funding_source] : t(:protocols)[:tooltips][:potential_funding_source], data: { toggle: 'tooltip', placement: 'right' }
-          %td.w-75
-            = protocol.display_funding_source_value
+        - if protocol.funded? || protocol.pending_funding?
+          %tr
+            %td.w-25
+              = label :protocol, protocol.funded? ? :funding_source : :potential_funding_source, class: 'mb-0', title: protocol.funded? ? t(:protocols)[:tooltips][:funding_source] : t(:protocols)[:tooltips][:potential_funding_source], data: { toggle: 'tooltip', placement: 'right' }
+            %td.w-75
+              = protocol.display_funding_source_value
         - if protocol.is_a?(Study)
           - if protocol.funded?
             %tr
@@ -42,7 +43,7 @@
                 = label :protocol, :funding_start_date, class: 'mb-0'
               %td.w-75
                 = protocol.funding_start_date.present? ? format_date(protocol.funding_start_date) : t('constants.na')
-          - else
+          - elsif protocol.pending_funding?
             %tr
               %td.w-25
                 = label :protocol, :potential_funding_start_date, class: 'mb-0'


### PR DESCRIPTION
Pivotal Tracker:
https://www.pivotaltracker.com/n/projects/1918597/stories/172245800

If 'Not Funded' is the selected funding source, LA CaTS also made the following UI changes:
1) Funding Source, Funding Start Date, and Federal Grant Information under Financial Information should not be displayed on Edit and View Protocol form

2) Under 'Study/Project Summary', display the (Pending) Funding Source only if the funding status is Funded or Pending Funding, otherwise, shown Funding Status instead.