### PR TITLE
SAW - Dashboard Service Request Table Not Displaying

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -39,6 +39,7 @@ class ProtocolsController < ApplicationController
       end
 
       @protocol.service_requests << @service_request
+      @service_request.sub_service_requests.each{ |ssr| @protocol.sub_service_requests << ssr }
       @protocol.save
       @service_request.update_status('draft', current_user)
 


### PR DESCRIPTION
[#172485868](https://www.pivotaltracker.com/story/show/172485868)

The Service Requests table on the dashboard was not displaying because sub service requests were not being associated to the protocol when services were added to a new protocol on the homepage. to solve this problem, sub service requests are now added to the protocol's sub service requests when the protocol is created.