### PR TITLE
Hide federal grant information when not funded is selected

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -286,6 +286,7 @@ toggleFundingSource = (val) ->
       $('#fundingRfaContainer').addClass('d-none')
       $('#fundingStartDateContainer').addClass('d-none')
       $('#potentialFundingStartDateContainer').addClass('d-none')
+      $('#federalGrantInformation').addClass('d-none')
     $('#protocol_funding_source, #protocol_potential_funding_source').attr('disabled', false).selectpicker('refresh')
 
 


### PR DESCRIPTION
PT:
https://www.pivotaltracker.com/n/projects/1918597/stories/172245800

Fixed a bug where the federal grant information section remained after switching funding status from funded with 'federal' as funding source to not funded.