### PR TITLE
SAW - Epic Interface Broken Bug

### DIFF
--- a/lib/epic_interface.rb
+++ b/lib/epic_interface.rb
@@ -60,10 +60,7 @@ class EpicInterface
         namespace: @namespace,
         endpoint: @config['epic_endpoint'],
         wsdl: @config['epic_wsdl'],
-        headers: {
-        },
-        soap_header: {
-        },
+        use_wsa_headers: true,
         namespaces: {
           'xmlns:wsa' => 'http://www.w3.org/2005/08/addressing',
         })


### PR DESCRIPTION
Instead of manually setting the WSA values in the SOAP headers, use Savon's default WSA headers. If this doesn't work for Epic we should be able to manually set the WSA headers using the `soap_header` option, otherwise we can override Savon again. They are nearly identical to what was originally used in the SOAP headers previously:

**Old Epic Interface Override:**
```
{
  'wsa:Action' => "#{@namespace}:#{soap_action}",
  'wsa:MessageID' => "uuid:#{SecureRandom.uuid}",
  'wsa:To' => @client.endpoint,
}
```

**Savon's WSA headers:**
```    
'wsa:Action' => @locals[:soap_action],
'wsa:To' => @globals[:endpoint],
'wsa:MessageID' => "urn:uuid:#{SecureRandom.uuid}",
attributes!: {
  'wsa:MessageID' => {
    "xmlns:wsa" => "http://schemas.xmlsoap.org/ws/2004/08/addressing"
  }
}
```
