### PR TITLE
(SPARC NavBar) UI Improvement Needed for Narrow Screens

### DIFF
--- a/app/assets/stylesheets/custom/bootstrap-custom.scss
+++ b/app/assets/stylesheets/custom/bootstrap-custom.scss
@@ -658,7 +658,7 @@ nav.navbar {
         padding: 1rem 1.5rem !important;
         border-right: 0 !important;
         border-bottom: 1px solid theme-color-level('light', 1);
-        justify-content: right;
+        justify-content: left;
       }
     }
 

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -32,8 +32,8 @@ nav#siteNav {
 
     .profile {
       .notification-badge {
-        top: 2px;
         right: 10px;
+        position: relative;
       }
     }
   }

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -24,6 +24,8 @@
       .navbar-nav.mr-auto
         - Setting.get_value("navbar_links").each do |identifier, data|
           = navbar_link(identifier, data, @highlighted_link)
+    %button.btn.btn-primary.navbar-toggler.p-0.border-0.text-light{ type: 'button', data: { toggle: 'collapse', target: '#navbarLinks' }, aria: { controls: 'navbarLinks', expanded: 'false', label: t('layout.navigation.toggle') } }
+      = icon('fas', 'bars fa-2x')
     .navbar-nav#navbarUtilities
       - if Setting.get_value('use_news_feed')
         = render 'layouts/news'
@@ -31,5 +33,3 @@
         = render 'layouts/events'
       = render 'layouts/profile'
       = render 'layouts/help'
-    %button.btn.btn-primary.navbar-toggler.p-0.border-0.text-light{ type: 'button', data: { toggle: 'collapse', target: '#navbarLinks' }, aria: { controls: 'navbarLinks', expanded: 'false', label: t('layout.navigation.toggle') } }
-      = icon('fas', 'bars fa-2x')

--- a/app/views/layouts/_profile.html.haml
+++ b/app/views/layouts/_profile.html.haml
@@ -21,9 +21,10 @@
 - if current_user
   .nav-item.dropdown.no-caret.profile
     = link_to 'javascript:void(0)', class: 'nav-link dropdown-toggle', id: 'profileDropdown', role: 'button', aria: { haspopup: 'true', expanded: 'false' } do
-      = icon('fas', 'user-circle fa-2x')
-      - if current_user.unread_notification_count > 0
-        %span.badge.badge-pill.badge-c.badge-danger.notification-badge &nbsp;
+      .d-flex.justify-content-center
+        = icon('fas', 'user-circle fa-2x')
+        - if current_user.unread_notification_count > 0
+          %span.badge.badge-pill.badge-c.badge-danger.notification-badge &nbsp;
     .dropdown-menu.dropdown-menu-xl-right{ aria: { labelledby: 'profileDropdown' } }
       = link_to 'javascript:void(0)', class: 'dropdown-header d-flex text-secondary' do
         = icon('fas', 'user-circle fa-3x mr-2')


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/172087903

**Background:**
When using SPARCRequest on different sized screens, we are trying to improve the UI experience by making the buttons as consistent as possible. 
The SPARC Navigation bar has a couple of behaviors that could be improved on smaller/narrower screens:

**Acceptance Criteria:**
1). Please adjust the sequence of the menu button, and make it show up on the left side instead to maintain consistency;

2). The notification count gadget (red dot) is out of place on a really narrow screen. Please fix that.

see below for an updated screenshot 
![updated navbar](https://user-images.githubusercontent.com/7648699/81321357-1b6ef600-9058-11ea-8e54-0cf7c5772f07.PNG)

