### PR TITLE
KG - Only prompt SSR resubmission if there are SSRs to be resubmitted

### DIFF
--- a/app/views/service_requests/navigation/_footer.html.haml
+++ b/app/views/service_requests/navigation/_footer.html.haml
@@ -46,7 +46,8 @@
             = save_as_draft_button(@service_request)
         .col.text-right
           - if action_name == 'review'
-            = link_to confirmation_service_request_path(srid: @service_request.id), remote: @service_request.previously_submitted?, class: 'btn btn-lg btn-outline-success', id: 'submitRequest' do
+            -# If the request has SSRs to be resubmitted, send a remote request to prompt the SSR Resubmission Modal, else submit the request
+            = link_to confirmation_service_request_path(srid: @service_request.id), remote: @service_request.previously_submitted? && service_request.sub_service_requests.any?{ |ssr| ['draft', 'awaiting_pi_approval'].include?(ssr.status) }, class: 'btn btn-lg btn-outline-success', id: 'submitRequest' do
               - succeed icon('fas', 'arrow-right ml-2') do
                 = t('proper.navigation.bottom.submit')
           - else


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169156333

### Per Wenjun:
The logic of the selectable SSR function on Step 5 submission is working correctly now, with locked statuses, admin statuses and complete status, and I really like the "Previously Submitted" visual cue you included in the modal.
The only suggestion I have, is that when there is no option at submission (i.e. when there is no eligible SSR to be submitted or re-submitted), could we not show the popup window? The blank window seems confusing, and it could save users one less click if we could make it smarter.

![image](https://user-images.githubusercontent.com/12898988/81429168-66a60900-912b-11ea-8508-a9aa7c1f2910.png)
