### PR TITLE
KG - Update "Get a Cost Estimate" Available/Editable Statuses for Default Status Orgs

### DIFF
--- a/db/migrate/20200402195743_remove_get_a_cost_estimate_default.rb
+++ b/db/migrate/20200402195743_remove_get_a_cost_estimate_default.rb
@@ -38,6 +38,9 @@ class RemoveGetACostEstimateDefault < ActiveRecord::Migration[5.2]
       s.update_attribute(:value, statuses)
     end
 
+    AvailableStatus.joins(:organization).where(status: 'get_a_cost_estimate', organizations: { use_default_statuses: true }).update_all(selected: false)
+    EditableStatus.joins(:organization).where(status: 'get_a_cost_estimate', organizations: { use_default_statuses: true }).update_all(selected: false)
+
     ServiceRequest.eager_load(:sub_service_requests).where(status: 'get_a_cost_estimate').each do |sr|
       if sr.previously_submitted?
         sr.update_attribute(:status, 'submitted')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168670315

The "Get a Cost Estimate" status was set to `default: false` previously, but it was still being considered a default status on organizations that had default statuses already selected.