### PR TITLE
SAW - OnCore Error Messages

### DIFF
--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -176,13 +176,13 @@ class OncoreEndpointController < ApplicationController
   def find_valid_protocol_by_rmid
     rmid = oncore_endpoint_params[:plannedStudy][:id][:extension] #protocol RMID as a string
     if !rmid.nil? && protocol = Protocol.find_by(research_master_id: rmid)
-      return protocol
+      if protocol.has_clinical_services?
+        raise "Error: SPARC Protocol #{rmid} has an existing calendar and cannot be overwritten."
+      else
+        return protocol
+      end
     else
-      raise "Error: No existing SPARC protocol with identifier #{rmid}."
-    end
-
-    if protocol.has_clinical_services?
-      raise "Error: SPARC Protocol #{rmid} has an existing calendar and cannot be overwritten."
+      raise "Error: No existing SPARC Protocol with identifier #{rmid}."
     end
   end
 

--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -145,7 +145,7 @@ class OncoreEndpointController < ApplicationController
   def retrieve_protocol_def
     begin
       # find the protocol
-      protocol = find_protocol_by_rmid
+      protocol = find_valid_protocol_by_rmid
 
       # Don't try to build calendar information if it doesn't exist (RPE messages don't have calendar info)
       if !is_rpe_message?
@@ -173,12 +173,16 @@ class OncoreEndpointController < ApplicationController
 
   private
 
-  def find_protocol_by_rmid
+  def find_valid_protocol_by_rmid
     rmid = oncore_endpoint_params[:plannedStudy][:id][:extension] #protocol RMID as a string
     if !rmid.nil? && protocol = Protocol.find_by(research_master_id: rmid)
       return protocol
     else
-      raise "Protocol with RMID #{rmid} not found in SPARC."
+      raise "Error: No existing SPARC protocol with identifier #{rmid}."
+    end
+
+    if protocol.has_clinical_services?
+      raise "Error: SPARC Protocol #{rmid} has an existing calendar and cannot be overwritten."
     end
   end
 


### PR DESCRIPTION
[#172804388](https://www.pivotaltracker.com/story/show/172804388)

Added custom language for errors when a protocol pushed to SPARC doesn't exist or already has existing calendar information (has clinical services).