### PR TITLE
SAW - Epic Interface Logs Request and Response

### DIFF
--- a/lib/epic_interface.rb
+++ b/lib/epic_interface.rb
@@ -67,7 +67,9 @@ class EpicInterface
     # attribute (ensuring that all the children of the
     # RetrieveProtocolDefResponse element are in the right namespace).
     @client = Savon.client(
+        log: true,
         logger: @logger,
+        log_level: :debug,
         soap_version: 2,
         pretty_print_xml: true,
         convert_request_keys_to: :none,


### PR DESCRIPTION
[#172565986](https://www.pivotaltracker.com/story/show/172565986)

The Savon client in the Epic interface needed to be set to log and use log level "debug" in order to log the sent requests and received responses.