### PR TITLE
Conditionally Display Sign Up Button

### DIFF
--- a/app/views/layouts/_profile.html.haml
+++ b/app/views/layouts/_profile.html.haml
@@ -18,6 +18,8 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+- hide_sign_up = Setting.get_value('use_shibboleth_only') || Setting.get_value('use_cas_only')
+
 - if current_user
   .nav-item.dropdown.no-caret.profile
     = link_to 'javascript:void(0)', class: 'nav-link dropdown-toggle', id: 'profileDropdown', role: 'button', aria: { haspopup: 'true', expanded: 'false' } do
@@ -46,6 +48,11 @@
       = link_to destroy_identity_session_path(srid: in_dashboard? ? nil : @service_request.try(:id)), method: :delete, class: 'dropdown-item text-danger' do
         = icon('fas', 'sign-out-alt mr-2')
         = t('layout.navigation.sign_out')
-- else
+- elsif hide_sign_up
   .nav-item
     = button_to t('layout.navigation.sign_in_up'), new_identity_session_path(srid: @service_request.try(:id)), class: 'nav-link btn btn-link', id: 'loginLink'
+- else
+  .nav-item
+    = link_to t('layout.navigation.sign_in'), new_identity_session_path(srid: @service_request.try(:id)), class: 'nav-link', id: 'loginLink'
+  .nav-item
+    = link_to t('layout.navigation.sign_up'), new_identity_registration_path(srid: @service_request.try(:id)), class: 'nav-link', id: 'singUpLink'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -643,6 +643,8 @@ en:
       toggle: "Toggle Navigation"
       sign_in_up: "Sign In / Sign Up"
       sign_out: "Sign Out"
+      sign_in: "SIGN IN"
+      sign_up: "SIGN UP"
       news:
         header: "Recent News"
         none: "There is no recent news. Please check back later."


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/172703801

Per Wenjun, show separate Sign In, Sign Up buttons when single-sign-on is not enabled  (i.e., (use_shibboleth_only == false) &&(use_cas_only == false) ) 