### PR TITLE
KG - Fix typo in epic queue push rake task

### DIFF
--- a/lib/tasks/send_to_epic.rake
+++ b/lib/tasks/send_to_epic.rake
@@ -25,7 +25,7 @@ task send_to_epic: :environment do
   epic_queues.each do |eq|
     begin
       eq.protocol.push_to_epic(EPIC_INTERFACE, eq.user_change? ? 'protocol_update' : 'admin_push', eq.identity_id, true)
-      if p.last_epic_push_status == 'complete'
+      if eq.protocol.last_epic_push_status == 'complete'
         eq.update_attribute(:attempted_push, true)
         eq.destroy
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164840135

When I refactored this code in the previous story #2273, I apparently forgot to change the code checking if the protocol was pushed successfully. This caused the epic queue objects to never be destroyed, even after a successful push.