### PR TITLE
Jl - Protocol-only and multiple epic queue record bug

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -163,7 +163,9 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
 
       if @protocol.update_attributes(protocol_params)
         if Setting.get_value("use_epic") && @protocol.selected_for_epic && (@protocol.last_epic_push_time != nil) && Setting.get_value("queue_epic")
-          EpicQueue.create(protocol_id: @protocol.id, identity_id: current_user.id)
+          if EpicQueue.where(protocol_id: @protocol.id).size == 0
+            EpicQueue.create(protocol_id: @protocol.id, identity_id: current_user.id, user_change: true)
+          end
         end
         
         flash[:success] = I18n.t('protocols.updated', protocol_type: @protocol.type)

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -71,7 +71,9 @@ class ProtocolsController < ApplicationController
       end
 
       if Setting.get_value("use_epic") && @protocol.selected_for_epic && (@protocol.last_epic_push_time != nil) && Setting.get_value("queue_epic")
-        EpicQueue.create(protocol_id: @protocol.id, identity_id: current_user.id)
+        if EpicQueue.where(protocol_id: @protocol.id).size == 0
+          EpicQueue.create(protocol_id: @protocol.id, identity_id: current_user.id, user_change: true)
+        end
       end
       
       flash[:success] = I18n.t('protocols.updated', protocol_type: @protocol.type)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/160802882

Only one epic queue update record for a protocol at a time. Also needed to add the user_change equals true to make the push protocol-only.