### PR TITLE
change 'Sign In / Sign Up' label to 'Sign In'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -642,7 +642,7 @@ en:
       institution_logo_alt: "Institution Logo"
     navigation:
       toggle: "Toggle Navigation"
-      sign_in_up: "Sign In / Sign Up"
+      sign_in_up: "Sign In"
       sign_out: "Sign Out"
       sign_in: "SIGN IN"
       sign_up: "SIGN UP"


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/172703801

Per Wenjun, update the 'Sign In/Sign Up' label to 'Sign In' when using shibboleth/cas only.