### PR TITLE
SAW - SOAP Fault Formatting changes

### DIFF
--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -161,7 +161,7 @@ class OncoreEndpointController < ApplicationController
       # Print params and exception to testing log
       print_params_to_log(e)
       # Render a SOAP fault response for exceptions instead of the default HTML response from Rails
-      render_soap_error(e.message)
+      render_soap_error(e.message, 'soap:Server')
     else
       # Print params to testing log
       print_params_to_log

--- a/app/views/wash_out/rpc/error.builder
+++ b/app/views/wash_out/rpc/error.builder
@@ -24,9 +24,7 @@
 # so the proper format was forced in this view.
 xml.instruct!
 xml.tag! "soap:Envelope", "xmlns:soap" => 'http://schemas.xmlsoap.org/soap/envelope/',
-                          "xmlns:xsd" => 'http://www.w3.org/2001/XMLSchema',
-                          "xmlns:xsi" => 'http://www.w3.org/2001/XMLSchema-instance',
-                          "xmlns:tns" => @namespace do
+                          "xmlns:xsi" => 'http://www.w3.org/2001/XMLSchema-instance' do
   xml.tag! "soap:Header" do
     xml.tag! "MessageID", SecureRandom.uuid, { "xmlns" => "http://www.w3.org/2005/08/addressing" }
   end


### PR DESCRIPTION
[#172804388](https://www.pivotaltracker.com/story/show/172804388)

Changed the formatting of SOAP Faults sent from SPARC (using Wash Out) to OnCore to resolve SOAP parsing issues in OnCore.