### PR TITLE
Labels for cost-analysis report better reflect non clinical services

### DIFF
--- a/app/lib/cost_analysis/generators/pdf.rb
+++ b/app/lib/cost_analysis/generators/pdf.rb
@@ -69,7 +69,7 @@ module CostAnalysis
 
       def render_header
         @doc.bounding_box([0,@doc.y], :width => 700, :height => 50) do
-          @doc.text "CRU Protocol#: #{@study_information.protocol_number}", :align => :left, :valign => :center, :size => 16
+          @doc.text "#{@study_information.header_for(:protocol_number)}: #{@study_information.protocol_number}", :align => :left, :valign => :center, :size => 16
           @doc.text @study_information.enrollment_period, :align => :right, :valign => :top
           @study_information.primary_investigators.each do |pi|
             @doc.text pi.name, :align => :right, :valign => :bottom
@@ -278,7 +278,7 @@ module CostAnalysis
 
         @otf_tables.each do |otf_table|
           grand_total_data << {
-              :category => "One Time Fees",
+              :category => OtfTable::HEADER_LABEL,
               :total => otf_table.total,
               :total_as_money => otf_table.total_as_money
             }

--- a/app/lib/cost_analysis/otf_table.rb
+++ b/app/lib/cost_analysis/otf_table.rb
@@ -7,6 +7,8 @@ module CostAnalysis
     end
 
     class OtfTable
+        HEADER_LABEL = "Non-clinical Services"
+
         attr_accessor :line_items
 
         include ActionView::Helpers::NumberHelper
@@ -52,7 +54,7 @@ module CostAnalysis
             col_labels = get_col_labels
             
             table = TableWithGroupHeaders.new
-            table.add_column_labels(title_row("One Time Fees", col_labels.length))
+            table.add_column_labels(title_row(HEADER_LABEL, col_labels.length))
             table.add_column_labels(col_labels)
 
             ssr_ids.each do |ssr_id|

--- a/app/lib/cost_analysis/study_information.rb
+++ b/app/lib/cost_analysis/study_information.rb
@@ -33,6 +33,7 @@ module CostAnalysis
     attr_accessor :protocol_number, :enrollment_period, :short_title, :study_title, :funding_source, :target_enrollment, :contacts
 
     def initialize(protocol)
+      
       @protocol_number = protocol.id
       @enrollment_period = "#{protocol.start_date.strftime("%m/%d/%Y")} - #{protocol.end_date.strftime("%m/%d/%Y")}"
       @short_title = protocol.short_title
@@ -42,11 +43,17 @@ module CostAnalysis
       
       @contacts = protocol.project_roles.map do |au|
         ProjectContact.new(au.role, au.identity.full_name, au.identity.email)
+
       end
     end
 
     def header_for(field)
-      HEADERS[field]
+
+      if field == :protocol_number
+        I18n.t 'activerecord.attributes.protocol.id'
+      else
+        HEADERS[field]
+      end
     end
 
     def primary_investigators

--- a/spec/lib/cost_analysis/generator_spec.rb
+++ b/spec/lib/cost_analysis/generator_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe CostAnalysis::Generator do
     subject.protocol = protocol
     subject.to_pdf(doc)
     pdf_text = PDF::Inspector::Text.analyze(doc.render)
-    expect(pdf_text.strings).to include(match(/CRU Protocol#: [0-9]+/))
+    expect(pdf_text.strings).to include(match(/Protocol ID: [0-9]+/))
   end
 end


### PR DESCRIPTION
See also: https://www.pivotaltracker.com/story/show/171649105

Updates the header label and one time fee labels per Kyle request.

If there's a better way to determine the title I'm all ears. I debated checking if the protocol was a study or not and using that, but decided it would be less intrusive to the user to have the title not change for study or project. Our users at last call things protocols.
