### PR TITLE
SAW - OnCore uses STUDY<id> instead of RMID

### DIFF
--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -145,7 +145,7 @@ class OncoreEndpointController < ApplicationController
   def retrieve_protocol_def
     begin
       # find the protocol
-      protocol = find_valid_protocol_by_rmid
+      protocol = find_valid_protocol
 
       # Don't try to build calendar information if it doesn't exist (RPE messages don't have calendar info)
       if !is_rpe_message?
@@ -173,16 +173,17 @@ class OncoreEndpointController < ApplicationController
 
   private
 
-  def find_valid_protocol_by_rmid
-    rmid = oncore_endpoint_params[:plannedStudy][:id][:extension] #protocol RMID as a string
-    if !rmid.nil? && protocol = Protocol.find_by(research_master_id: rmid)
+  def find_valid_protocol
+    id = oncore_endpoint_params[:plannedStudy][:id][:extension] #protocol ID as a string with the format "STUDY#{id}"
+    id.try(:slice!, "STUDY")
+    if !id.nil? && protocol = Protocol.find(id)
       if protocol.has_clinical_services?
-        raise "Error: SPARC Protocol #{rmid} has an existing calendar and cannot be overwritten."
+        raise "Error: SPARC Protocol #{id} has an existing calendar and cannot be overwritten."
       else
         return protocol
       end
     else
-      raise "Error: No existing SPARC Protocol with identifier #{rmid}."
+      raise "Error: No existing SPARC Protocol with identifier #{id}."
     end
   end
 

--- a/spec/controllers/oncore_endpoint_controller_spec.rb
+++ b/spec/controllers/oncore_endpoint_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe OncoreEndpointController do
 
     it 'should render a SOAP fault if there is an error' do
       begin
-        @client.call(:retrieve_protocol_def_response, message: crpc_message(@study, "nonexistant_rmid"))
+        @client.call(:retrieve_protocol_def_response, message: crpc_message(@study, "nonexistant_id"))
       rescue Savon::Error => error
         expect(error.instance_of?(Savon::SOAPFault)).to eq(true)
       end

--- a/spec/support/oncore_endpoint_helper.rb
+++ b/spec/support/oncore_endpoint_helper.rb
@@ -63,7 +63,7 @@ module OnCoreEndpointHelper
                     "@code": "PROTOCOLNO"
                   },
                   "value": {
-                    "@value": study.id
+                    "@value": "STUDY#{study.id}"
                   }
                 }
               },
@@ -92,7 +92,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.id}.BLD",
+                    "@extension": "STUDY#{study.id}.BLD",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:BLD: Arm BLD",
@@ -431,7 +431,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.id}.Biomarker",
+                    "@extension": "STUDY#{study.id}.Biomarker",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:Biomarker: Arm Biomarker",
@@ -799,7 +799,7 @@ module OnCoreEndpointHelper
       { "protocolDef":
         { "plannedStudy": {
             "id": {
-              "@extension": study.id,
+              "@extension": "STUDY#{study.id}",
               "@root": "1.2.5.2.3.4"
             },
             "title": "null",
@@ -830,7 +830,7 @@ module OnCoreEndpointHelper
                     "@code": "PROTOCOLNO"
                   },
                   "value": {
-                    "@value": study.id
+                    "@value": "STUDY#{study.id}"
                   }
                 }
               },
@@ -859,7 +859,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.id}.BLD",
+                    "@extension": "STUDY#{study.id}.BLD",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:BLD: Arm BLD",
@@ -1072,7 +1072,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.id}.Biomarker",
+                    "@extension": "STUDY#{study.id}.Biomarker",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:Biomarker: Arm Biomarker",
@@ -1311,7 +1311,7 @@ module OnCoreEndpointHelper
       { "protocolDef": {
             "plannedStudy": {
               "id": {
-                "@extension": study.id,
+                "@extension": "STUDY#{study.id}",
                 "@root": "1.2.5.2.3.4"
               },
               "title": "A Phase 2 Trial of Nivolumab Plus Ipilimumab, Ipilimumab Alone, or Cabazitaxel ",
@@ -1343,7 +1343,7 @@ module OnCoreEndpointHelper
                       "@code": "PROTOCOLNO"
                     },
                     "value": {
-                      "value": study.id
+                      "@value": "STUDY#{study.id}"
                     }
                   }
                 },

--- a/spec/support/oncore_endpoint_helper.rb
+++ b/spec/support/oncore_endpoint_helper.rb
@@ -22,7 +22,7 @@ module OnCoreEndpointHelper
   # Return an example CRPC message with 2 arms, 3 VISITS (not SPARC Visits), and 2 Procedures
   # VISITS are most similar to Visit Groups and Procedures are most like Line Item Visits
   # Visit groups are on days 1, 5 and 10, with day 10 having a window and a window after of 3 days.
-  def crpc_message(study, bad_rmid=nil)
+  def crpc_message(study, bad_id=nil)
     service1 = create(:service_with_process_ssrs_organization, :with_pricing_map, name: "Service 1", eap_id: "9999")
     service2 = create(:service_with_process_ssrs_organization, :with_pricing_map, name: "Service 2", cpt_code: "9999")
     day1      = Date.new(2000,1,1)
@@ -32,7 +32,7 @@ module OnCoreEndpointHelper
       { "protocolDef":
         { "plannedStudy": {
             "id": {
-              "@extension": bad_rmid.nil? ? study.research_master_id : bad_rmid,
+              "@extension": bad_id.nil? ? study.id : bad_id,
               "@root": "1.2.5.2.3.4"
             },
             "title": "null",
@@ -63,7 +63,7 @@ module OnCoreEndpointHelper
                     "@code": "PROTOCOLNO"
                   },
                   "value": {
-                    "@value": study.research_master_id
+                    "@value": study.id
                   }
                 }
               },
@@ -92,7 +92,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.research_master_id}.BLD",
+                    "@extension": "#{study.id}.BLD",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:BLD: Arm BLD",
@@ -431,7 +431,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.research_master_id}.Biomarker",
+                    "@extension": "#{study.id}.Biomarker",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:Biomarker: Arm Biomarker",
@@ -799,7 +799,7 @@ module OnCoreEndpointHelper
       { "protocolDef":
         { "plannedStudy": {
             "id": {
-              "@extension": study.research_master_id,
+              "@extension": study.id,
               "@root": "1.2.5.2.3.4"
             },
             "title": "null",
@@ -830,7 +830,7 @@ module OnCoreEndpointHelper
                     "@code": "PROTOCOLNO"
                   },
                   "value": {
-                    "@value": study.research_master_id
+                    "@value": study.id
                   }
                 }
               },
@@ -859,7 +859,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.research_master_id}.BLD",
+                    "@extension": "#{study.id}.BLD",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:BLD: Arm BLD",
@@ -1072,7 +1072,7 @@ module OnCoreEndpointHelper
               {
                 "timePointEventDefinition": {
                   "id": {
-                    "@extension": "#{study.research_master_id}.Biomarker",
+                    "@extension": "#{study.id}.Biomarker",
                     "@root": "1.2.3.4.8.2"
                   },
                   "title": "Calendar:4 Budget:1 Arm:Biomarker: Arm Biomarker",
@@ -1311,7 +1311,7 @@ module OnCoreEndpointHelper
       { "protocolDef": {
             "plannedStudy": {
               "id": {
-                "@extension": study.research_master_id,
+                "@extension": study.id,
                 "@root": "1.2.5.2.3.4"
               },
               "title": "A Phase 2 Trial of Nivolumab Plus Ipilimumab, Ipilimumab Alone, or Cabazitaxel ",
@@ -1343,7 +1343,7 @@ module OnCoreEndpointHelper
                       "@code": "PROTOCOLNO"
                     },
                     "value": {
-                      "value": study.research_master_id
+                      "value": study.id
                     }
                   }
                 },


### PR DESCRIPTION
[#173036404](https://www.pivotaltracker.com/story/show/173036404)

The OnCore endpoint accepts a protocol ID in the format "STUDY#{id}" to find a protocol instead of the protocol's RMID.