### PR TITLE
Configurable Confidentiality and Epic Study Type Questions

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -74,10 +74,16 @@ $(document).ready ->
       $('#protocol_research_master_id').siblings('label').addClass('required')
       $('#protocol_human_subjects_info_attributes_approval_pending').bootstrapToggle('enable')
       $('[name="protocol[human_subjects_info_attributes][approval_pending]"').attr('disabled', false)
+      if $('#protocol_selected_for_epic_false').prop('checked')
+        $('#studyTypeQuestionsContainer').removeClass('d-none')
+        hideStudyTypeQuestion($(certificateOfConfidence))
+        showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
     else
       $('#protocol_research_master_id').siblings('label').removeClass('required')
       $('#protocol_human_subjects_info_attributes_approval_pending').bootstrapToggle('disable')
       $('[name="protocol[human_subjects_info_attributes][approval_pending]"').attr('disabled', true)
+      if $('#protocol_selected_for_epic_false').prop('checked')
+        $('#studyTypeQuestionsContainer').addClass('d-none')
     setRequiredFields()
 
   $(document).on 'keyup', '#protocol_investigational_products_info_attributes_ind_number', ->
@@ -143,20 +149,22 @@ $(document).ready ->
   $(document).on 'change', '[name="protocol[selected_for_epic]"]', ->
     $('[for=protocol_selected_for_epic]').addClass('required')
 
-    if $('#studyTypeQuestionsContainer').hasClass('d-none')
-      $('#studyTypeQuestionsContainer').removeClass('d-none')
-
     if $(this).val() == 'true'
       $('label[for=protocol_study_type_questions]').addClass('required')
+      if $('#studyTypeQuestionsContainer').hasClass('d-none')
+        $('#studyTypeQuestionsContainer').removeClass('d-none')
       setRequiredFields()
       hideStudyTypeQuestion($(certificateOfConfidenceNoEpic))
       showStudyTypeQuestion($(certificateOfConfidence))
-    else
+    else if $('#protocol_research_types_info_attributes_human_subjects').prop('checked')
+      if $('#studyTypeQuestionsContainer').hasClass('d-none')
+        $('#studyTypeQuestionsContainer').removeClass('d-none')
       $('label[for=protocol_study_type_questions]').removeClass('required')
       setRequiredFields()
       hideStudyTypeQuestion($(certificateOfConfidence))
-      if $('#protocol_research_types_info_attributes_human_subjects').prop('checked')
-        showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
+      showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
+    else
+      $('#studyTypeQuestionsContainer').addClass('d-none')
 
   $(document).on 'change', certificateOfConfidence, (e) ->
     if $(this).val() == 'true'
@@ -330,6 +338,7 @@ toggleFundingSourceOther = (val) ->
 
     $('#fundingSourceOtherContainer').addClass('d-none')
     $('#protocol_funding_source_other').val('')
+
 
 certificateOfConfidence       = '#study_type_answer_certificate_of_conf_answer'
 higherLevelOfPrivacy          = '#study_type_answer_higher_level_of_privacy_answer'

--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -155,7 +155,8 @@ $(document).ready ->
       $('label[for=protocol_study_type_questions]').removeClass('required')
       setRequiredFields()
       hideStudyTypeQuestion($(certificateOfConfidence))
-      showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
+      if $('#protocol_research_types_info_attributes_human_subjects').prop('checked')
+        showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
 
   $(document).on 'change', certificateOfConfidence, (e) ->
     if $(this).val() == 'true'

--- a/app/assets/stylesheets/protocols.scss
+++ b/app/assets/stylesheets/protocols.scss
@@ -36,7 +36,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 3%;
+  max-width: 17%;
 
   .sticky-top {
     top: 1rem !important;

--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -50,10 +50,10 @@ module ProtocolsHelper
     end
   end
 
-  # If USE_EPIC is false and any of the CofC questions have been answered, display them OR
+  # If USE_CONDIFIDENTIALITY_QUESTIONBS is true any of the CofC questions have been answered, display them OR
   # If USE_EPIC is true and any of the Epic questions have been answered, display them
   def display_readonly_study_type_questions?(protocol)
-    (Setting.get_value("use_epic") && protocol.display_answers.where.not(answer: nil).any?) || (!Setting.get_value("use_epic") && protocol.active? && protocol.display_answers.joins(:study_type_question).where(study_type_questions: { friendly_id: ['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'] }).where.not(answer: nil).any?)
+    (Setting.get_value("use_epic") && protocol.display_answers.where.not(answer: nil).any?) || (Setting.get_value("use_confidentiality_questions") && protocol.active? && protocol.display_answers.joins(:study_type_question).where(study_type_questions: { friendly_id: ['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'] }).where.not(answer: nil).any?)
   end
 
   def display_study_type_question?(protocol, study_type_answer, view_protocol=false)

--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -50,7 +50,7 @@ module ProtocolsHelper
     end
   end
 
-  # If USE_CONDIFIDENTIALITY_QUESTIONBS is true any of the CofC questions have been answered, display them OR
+  # If USE_CONDIFIDENTIALITY_QUESTIONS is true any of the CofC questions have been answered, display them OR
   # If USE_EPIC is true and any of the Epic questions have been answered, display them
   def display_readonly_study_type_questions?(protocol)
     (Setting.get_value("use_epic") && protocol.display_answers.where.not(answer: nil).any?) || (Setting.get_value("use_confidentiality_questions") && protocol.active? && protocol.display_answers.joins(:study_type_question).where(study_type_questions: { friendly_id: ['certificate_of_conf_no_epic', 'higher_level_of_privacy_no_epic'] }).where.not(answer: nil).any?)

--- a/app/views/protocols/form/_confidentiality_epic_questions.html.haml
+++ b/app/views/protocols/form/_confidentiality_epic_questions.html.haml
@@ -18,20 +18,31 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
--  use_epic = Setting.get_value('use_epic')
-%aside.form-navigation.d-none.d-xl-block
-  .card.sticky-top
-    .card-header
-      %h3.mb-0
-        = t("protocols.form.navigation.header.#{action_name}", protocol_type: protocol.model_name.human)
-    .card-body.p-0
-      %nav.flex-column#protocolNavigation
-        - if protocol.is_a?(Study) && Setting.get_value('research_master_enabled')
-          = link_to Protocol.human_attribute_name(:research_master_id), '#protocolHeader', class: 'nav-link h5 mb-0'
-        - if protocol.is_a?(Study) && (use_epic || Setting.get_value('use_confidentiality_questions'))
-          = link_to t("protocols.form.confidentiality#{use_epic ? '_epic' : ''}_questions.header"), '#confidentialityEpicQuestions', class: 'nav-link h5 mb-0'
-        = link_to t('protocols.form.information.header'), '#protocolInformation', class: 'nav-link h5 mb-0'
-        = link_to t('protocols.form.financial_information.header'), '#financialInformation', class: 'nav-link h5 mb-0'
-        - if protocol.is_a?(Study)
-          = link_to t('protocols.form.research_involving.header'), '#researchInvolving', class: 'nav-link h5 mb-0'
-          = link_to t('protocols.form.other_details.header'), '#otherDetails', class: 'nav-link h5 mb-0'
+- use_epic = Setting.get_value("use_epic")
+
+%section.pt-3#confidentialityEpicQuestions
+  .card
+    .card-body.p-5
+      %h2.text-center.mb-5
+        = t("protocols.form.confidentiality#{use_epic ? '_epic' : ''}_questions.header")
+
+      = render 'layouts/required_fields'
+
+      - if use_epic
+        .form-group
+          = f.label :selected_for_epic, class: [protocol.bypass_stq_validation ? '' : 'required'], title: t('protocols.tooltips.epic'), data: { toggle: 'tooltip', placement: 'right' }
+          .d-block
+            .custom-control.custom-radio.custom-control-inline
+              = f.radio_button :selected_for_epic, true, class: 'custom-control-input'
+              = f.label :selected_for_epic_true, t('constants.yes_select'), class: 'custom-control-label'
+            .custom-control.custom-radio.custom-control-inline
+              = f.radio_button :selected_for_epic, false, class: 'custom-control-input'
+              = f.label "selected_for_epic_false", t('constants.no_select'), class: 'custom-control-label'
+
+      - if Setting.get_value("use_confidentiality_questions")
+        = render 'protocols/form/study_type_questions', f: f, protocol: protocol
+
+      - if Setting.get_value('use_epic')
+        #studyTypeNote
+          - if protocol.active? && note = protocol.determine_study_type_note
+            = render 'protocols/form/study_type_note', protocol: protocol, note: note

--- a/app/views/protocols/form/_protocol_form.html.haml
+++ b/app/views/protocols/form/_protocol_form.html.haml
@@ -31,6 +31,8 @@
       = f.hidden_field :requester_id, value: current_user.id
 
       = render 'protocols/form/header', f: f, protocol: protocol
+      - if protocol.is_a?(Study) && (Setting.get_value("use_epic") || Setting.get_value("use_confidentiality_questions"))
+        = render 'protocols/form/confidentiality_epic_questions', f: f, protocol: protocol
       = render 'protocols/form/protocol_information', f: f, protocol: protocol
       = render 'protocols/form/financial_information', f: f, protocol: protocol
 

--- a/app/views/protocols/form/_protocol_information.html.haml
+++ b/app/views/protocols/form/_protocol_information.html.haml
@@ -50,22 +50,3 @@
           = hidden_field_tag :lazy_identity_id, ff_ppi.object.identity.try(&:ldap_uid)
           %span.form-text.text-muted
             = t('protocols.form.information.primary_pi.note')
-
-      - if protocol.is_a?(Study) && Setting.get_value("use_epic")
-        .form-group
-          = f.label :selected_for_epic, class: [protocol.bypass_stq_validation ? '' : 'required'], title: t('protocols.tooltips.epic'), data: { toggle: 'tooltip', placement: 'right' }
-          .d-block
-            .custom-control.custom-radio.custom-control-inline
-              = f.radio_button :selected_for_epic, true, class: 'custom-control-input'
-              = f.label :selected_for_epic_true, t('constants.yes_select'), class: 'custom-control-label'
-            .custom-control.custom-radio.custom-control-inline
-              = f.radio_button :selected_for_epic, false, class: 'custom-control-input'
-              = f.label "selected_for_epic_false", t('constants.no_select'), class: 'custom-control-label'
-
-      - if protocol.is_a?(Study)
-        = render 'protocols/form/study_type_questions', f: f, protocol: protocol
-
-        - if Setting.get_value('use_epic')
-          #studyTypeNote
-            - if protocol.active? && note = protocol.determine_study_type_note
-              = render 'protocols/form/study_type_note', protocol: protocol, note: note

--- a/app/views/protocols/form/_study_type_questions.html.haml
+++ b/app/views/protocols/form/_study_type_questions.html.haml
@@ -18,7 +18,7 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-.form-group#studyTypeQuestionsContainer{ class: Setting.get_value('use_epic') && protocol.selected_for_epic?.nil? ? 'd-none' : '' }
+.form-group#studyTypeQuestionsContainer{ class: Setting.get_value("use_epic") && (protocol.selected_for_epic.nil? || (!protocol.selected_for_epic && !protocol.research_types_info.human_subjects)) ? 'd-none' : ''}
   = f.hidden_field :study_type_question_group_id, value: StudyTypeQuestionGroup.active_id
   = f.label :study_type_questions, class: [Setting.get_value("use_epic") && protocol.selected_for_epic? && !protocol.bypass_stq_validation ? 'required' : ''], title: t(:protocols)[:tooltips][:study_type_questions], data: { toggle: 'tooltip', placement: 'right' }
   = f.fields_for :study_type_answers, protocol.study_type_answers.select(&:active?) do |ff_sta|

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -880,6 +880,16 @@
     "parent_value":   "true"
   },
   {
+    "key":            "use_confidentiality_questions",
+    "value":          "true",
+    "friendly_name":  "Use Confidentiality Questions",
+    "description":    "This determines whether the application will display Confidentiality Questions section on a Study Form.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "",
+    "parent_value":   ""
+  },
+  {
     "key":            "use_epic",
     "value":          "false",
     "friendly_name":  "Use Epic",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -804,6 +804,10 @@ en:
         primary_pi:
           note: "If you are not the Primary PI you will be added as a general access user and you may change your role later"
         study_type_note: "Note: %{note}"
+      confidentiality_epic_questions:
+        header: "Confidentiality and Epic Questions"
+      confidentiality_questions:
+        header: "Confidentiality Questions"
       financial_information:
         header: "Financial Information"
         guarantor_header: "Guarantor Information"

--- a/spec/features/dashboard/protocols/new/user_selects_publish_in_epic_spec.rb
+++ b/spec/features/dashboard/protocols/new/user_selects_publish_in_epic_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'User edits study type questions', js: true do
 
   context 'Using Epic' do
     stub_config("use_epic", true)
+    stub_config("use_confidentiality_questions", true)
 
     before :each do
       visit new_dashboard_protocol_path(type: Study.name)
@@ -63,6 +64,7 @@ RSpec.describe 'User edits study type questions', js: true do
 
   context 'Not Using Epic' do
     stub_config("use_epic", false)
+    stub_config("use_confidentiality_questions", true)
 
     before :each do
       visit new_dashboard_protocol_path(type: Study.name)

--- a/spec/features/dashboard/protocols/new/user_selects_publish_in_epic_spec.rb
+++ b/spec/features/dashboard/protocols/new/user_selects_publish_in_epic_spec.rb
@@ -26,64 +26,78 @@ RSpec.describe 'User edits study type questions', js: true do
   build_study_type_question_groups
   build_study_type_questions
 
-  context 'Using Epic' do
-    stub_config("use_epic", true)
+  context 'Use Confidentiality Questions' do
     stub_config("use_confidentiality_questions", true)
 
-    before :each do
-      visit new_dashboard_protocol_path(type: Study.name)
+    context 'Using Epic' do
+      stub_config("use_epic", true)
+
+      before :each do
+        visit new_dashboard_protocol_path(type: Study.name)
+      end
+
+      context 'selects "Yes" to "Publish Study in Epic"' do
+        it 'should show notes for various scenarios' do
+          find("[for='protocol_selected_for_epic_true']").click
+
+          bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'Yes'
+          wait_for_javascript_to_finish
+
+          expect(page).to have_content('De-identified Research Participant')
+
+          bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'No'
+          bootstrap_select '#study_type_answer_higher_level_of_privacy_answer', 'No'
+          bootstrap_select '#study_type_answer_epic_inbasket_answer', 'No'
+          bootstrap_select '#study_type_answer_research_active_answer', 'No'
+          bootstrap_select '#study_type_answer_restrict_sending_answer', 'No'
+          wait_for_javascript_to_finish
+
+          expect(page).to have_content('Full Epic Functionality: no notification, no pink header, no MyChart access.')
+        end
+      end
+
+      context 'selects "No" to "Publish Study in Epic"' do
+        context 'Human Subjects is checked' do
+          it 'should show certificate of confidentiality questions without Epic language' do
+            find("[for='protocol_selected_for_epic_false']").click
+            wait_for_javascript_to_finish
+
+            find('#protocol_research_types_info_attributes_human_subjects + label').click
+            wait_for_javascript_to_finish
+
+            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
+
+            bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
+            wait_for_javascript_to_finish
+
+            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
+          end
+        end
+      end
     end
 
-    it 'should show notes for various scenarios' do
-      find("[for='protocol_selected_for_epic_true']").click
+    context 'Not Using Epic' do
+      stub_config("use_epic", false)
 
-      bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'Yes'
-      wait_for_javascript_to_finish
+      before :each do
+        visit new_dashboard_protocol_path(type: Study.name)
+      end
 
-      expect(page).to have_content('De-identified Research Participant')
+      it 'should show questions but not notes' do
+        bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
+        expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
 
-      bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'No'
-      bootstrap_select '#study_type_answer_higher_level_of_privacy_answer', 'No'
-      bootstrap_select '#study_type_answer_epic_inbasket_answer', 'No'
-      bootstrap_select '#study_type_answer_research_active_answer', 'No'
-      bootstrap_select '#study_type_answer_restrict_sending_answer', 'No'
-      wait_for_javascript_to_finish
-
-      expect(page).to have_content('Full Epic Functionality: no notification, no pink header, no MyChart access.')
-
-      find("[for='protocol_selected_for_epic_false']").click
-
-      expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
-
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-      wait_for_javascript_to_finish
-
-      expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
-    end
-  end
-
-  context 'Not Using Epic' do
-    stub_config("use_epic", false)
-    stub_config("use_confidentiality_questions", true)
-
-    before :each do
-      visit new_dashboard_protocol_path(type: Study.name)
-    end
-
-    it 'should show questions but not notes' do
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-      expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
-
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'Yes'
-      wait_for_javascript_to_finish
-      expect(page).not_to have_selector('#study_type_note')
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-      bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'Yes'
-      wait_for_javascript_to_finish
-      expect(page).not_to have_selector('#study_type_note')
-      bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'No'
-      wait_for_javascript_to_finish
-      expect(page).not_to have_selector('#study_type_note')
+        bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'Yes'
+        wait_for_javascript_to_finish
+        expect(page).not_to have_selector('#studyTypeNote')
+        bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
+        bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'Yes'
+        wait_for_javascript_to_finish
+        expect(page).not_to have_selector('#studyTypeNote')
+        bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'No'
+        wait_for_javascript_to_finish
+        expect(page).not_to have_selector('#studyTypeNote')
+      end
     end
   end
 end

--- a/spec/features/proper/protocol/protocols/user_selects_publish_in_epic_spec.rb
+++ b/spec/features/proper/protocol/protocols/user_selects_publish_in_epic_spec.rb
@@ -34,63 +34,78 @@ RSpec.describe 'User edits study type questions', js: true do
               create(:line_item, service_request: @sr, sub_service_request: ssr, service: service)
   end
 
-  context 'Using Epic' do
-    stub_config("use_epic", true)
+  context 'Use Confidentiality Questions' do
     stub_config("use_confidentiality_questions", true)
 
-    before :each do
-      visit new_protocol_path(type: Study.name)
+    context 'Using Epic' do
+      stub_config("use_epic", true)
+
+      before :each do
+        visit new_protocol_path(type: Study.name)
+      end
+
+      context 'Study is selected for Epic' do
+        it 'should show notes for various scenarios' do
+          find("[for='protocol_selected_for_epic_true']").click
+
+          bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'Yes'
+          wait_for_javascript_to_finish
+
+          expect(page).to have_content('De-identified Research Participant')
+
+          bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'No'
+          bootstrap_select '#study_type_answer_higher_level_of_privacy_answer', 'No'
+          bootstrap_select '#study_type_answer_epic_inbasket_answer', 'No'
+          bootstrap_select '#study_type_answer_research_active_answer', 'No'
+          bootstrap_select '#study_type_answer_restrict_sending_answer', 'No'
+          wait_for_javascript_to_finish
+
+          expect(page).to have_content('Full Epic Functionality: no notification, no pink header, no MyChart access.')
+        end
+      end
+
+      context 'selects "No" to "Publish Study in Epic"' do
+        context 'Human Subjects is checked' do
+          it 'should show certificate of confidentiality questions without Epic language' do
+            find("[for='protocol_selected_for_epic_false']").click
+            wait_for_javascript_to_finish
+
+            find('#protocol_research_types_info_attributes_human_subjects + label').click
+            wait_for_javascript_to_finish
+
+            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
+
+            bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
+            wait_for_javascript_to_finish
+
+            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
+          end
+        end
+      end
     end
 
-    it 'should show notes for various scenarios' do
-      find("[for='protocol_selected_for_epic_true']").click
+    context 'Not Using Epic' do
+      stub_config("use_epic", false)
 
-      bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'Yes'
-      wait_for_javascript_to_finish
+      before :each do
+        visit new_protocol_path(type: Study.name)
+      end
 
-      expect(page).to have_content('De-identified Research Participant')
+      it 'should show questions but not notes' do
+        bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
+        expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
 
-      bootstrap_select '#study_type_answer_certificate_of_conf_answer', 'No'
-      bootstrap_select '#study_type_answer_higher_level_of_privacy_answer', 'No'
-      bootstrap_select '#study_type_answer_epic_inbasket_answer', 'No'
-      bootstrap_select '#study_type_answer_research_active_answer', 'No'
-      bootstrap_select '#study_type_answer_restrict_sending_answer', 'No'
-      wait_for_javascript_to_finish
-
-      expect(page).to have_content('Full Epic Functionality: no notification, no pink header, no MyChart access.')
-
-      find("[for='protocol_selected_for_epic_false']").click
-
-      expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
-
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-      wait_for_javascript_to_finish
-
-      expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
-    end
-  end
-
-  context 'Not Using Epic' do
-    stub_config("use_epic", false)
-
-    before :each do
-      visit new_protocol_path(type: Study.name)
-    end
-
-    it 'should show questions but not notes' do
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-      expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
-
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'Yes'
-      wait_for_javascript_to_finish
-      expect(page).not_to have_selector('#study_type_note')
-      bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-      bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'Yes'
-      wait_for_javascript_to_finish
-      expect(page).not_to have_selector('#study_type_note')
-      bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'No'
-      wait_for_javascript_to_finish
-      expect(page).not_to have_selector('#study_type_note')
+        bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'Yes'
+        wait_for_javascript_to_finish
+        expect(page).not_to have_selector('#studyTypeNote')
+        bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
+        bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'Yes'
+        wait_for_javascript_to_finish
+        expect(page).not_to have_selector('#studyTypeNote')
+        bootstrap_select '#study_type_answer_higher_level_of_privacy_no_epic_answer', 'No'
+        wait_for_javascript_to_finish
+        expect(page).not_to have_selector('#studyTypeNote')
+      end
     end
   end
 end

--- a/spec/features/proper/protocol/protocols/user_selects_publish_in_epic_spec.rb
+++ b/spec/features/proper/protocol/protocols/user_selects_publish_in_epic_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'User edits study type questions', js: true do
 
   context 'Using Epic' do
     stub_config("use_epic", true)
+    stub_config("use_confidentiality_questions", true)
 
     before :each do
       visit new_protocol_path(type: Study.name)

--- a/spec/models/study/validate_study_type_answers_spec.rb
+++ b/spec/models/study/validate_study_type_answers_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Protocol, type: :model do
   build_study_type_answers()
 
   stub_config("use_epic", true)
+  stub_config("use_confidentiality_questions", true)
   
   describe 'should validate study_type_answers for study' do
     it 'should not add errors if the first answer is true' do

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -27,6 +27,7 @@ def populate_settings_before_suite
     SettingsPopulator.new().populate
 
     Setting.find_by_key("use_epic").update_attribute(:value, true)
+    Setting.find_by_key("use_confidentiality_questions").update_attribute(:value, true)
     Setting.find_by_key("use_ldap").update_attribute(:value, false)
     Setting.find_by_key("use_funding_module").update_attribute(:value, true)
     Setting.find_by_key("suppress_ldap_for_user_search").update_attribute(:value, true)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/170601945

**Background:**
Currently, the confidentiality questions are showing up for all studies no matter a study is chosen to send to Epic or not (under configuration use_epic = yes), and the first 2 questions are also showing up when the institution is not using Epic interface (use_epic = no). We need a way to de-coupling the confidentiality questions and the epic configuration, and allow adopting institutions to choose whether they want their users to see the confidentiality questions or not.

**Acceptance Criteria:**
1). On SPARCRequest Step 2 and SPARCDashboard Study Information page, Please separate the "Do you want to have your Study Published in Epic" and the "Study Type Questions" contents into their own section. When use_epic = true, this section should be called "Confidentiality and Epic Questions"; When use_epic = false, this section should be called "Confidentiality Questions".

2). Create a new settings for the study type questions. when this new setting is turned off, then the 2 study type questions (when use_epic = true) should not show, and when use_epic = false, no study type questions should show up, and the "Confidentiality Questions" section should be hidden.
When this new setting is turned on and use_epic = true and send_to_epic = yes on a study, the Study Type Questions should always show up, as required section to fill out, same as current logic.
When this new setting is turned on and use_epic = true and send_to_epic = no, please add additional logic, to only display the study type questions when "Human Subjects" checkbox is selected.

