### PR TITLE
Add development login for outside users

### DIFF
--- a/app/controllers/identities/sessions_controller.rb
+++ b/app/controllers/identities/sessions_controller.rb
@@ -1,0 +1,40 @@
+# Copyright © 2011-2018 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class Identities::SessionsController < Devise::SessionsController
+
+  def create
+    if Rails.env.development? && params[:identity][:password] == "adminadmin"
+      @identity = Identity.where(ldap_uid: params[:identity][:ldap_uid]).first
+
+      if params[:service_request_id]
+        # redirect back to catalog page
+        store_location_for @identity, catalog_service_request_path(params[:service_request_id])
+      end
+
+      sign_in_and_redirect @identity, :event => :authentication #this will throw if @identity is not activated
+      set_flash_message(:notice, :success, :kind => "Shibboleth") if is_navigational_format?
+
+    else
+      super
+    end
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,17 +28,20 @@ SparcRails::Application.routes.draw do
       devise_for :identities,
                  controllers: {
                    omniauth_callbacks: 'identities/omniauth_callbacks',
+                   sessions: 'identities/sessions',
                  }, path_names: { sign_in: 'auth/shibboleth' }
 
     elsif Setting.get_value("use_cas_only")
       devise_for :identities,
                  controllers: {
                    omniauth_callbacks: 'identities/omniauth_callbacks',
+                   sessions: 'identities/sessions'
                  }, path_names: { sign_in: 'auth/cas' }
     else
       devise_for :identities,
                  controllers: {
                    omniauth_callbacks: 'identities/omniauth_callbacks',
+                   sessions: 'identities/sessions',
                    registrations: 'identities/registrations',
                    passwords: 'identities/passwords'
                  }


### PR DESCRIPTION
This is something that has been useful for me when I need to troubleshoot user rights or permissions. It will allow me to log in as any user via the outside user login. 

Allows you to impersonate a user in development
environments