### PR TITLE
Bug Fix-perform fulfillment synch check only when SPARCFulfillment is not enabled

### DIFF
--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -114,7 +114,7 @@ class ServiceRequestsController < ApplicationController
         @protocol = @service_request.protocol
         @service_request.previous_submitted_at = @service_request.submitted_at
 
-        perform_fulfillment_synch_check(@service_request)
+        perform_fulfillment_synch_check(@service_request) if Setting.get_value("fulfillment_contingent_on_catalog_manager")
 
         if @service_request.should_push_to_epic?
           # Send a notification to Lane et al to create users in Epic.  Once


### PR DESCRIPTION
PR: https://www.pivotaltracker.com/n/projects/1918597/stories/173472814

The bug was found in the OS V3.7.0 Release - issue occurs only when  fulfillment_contingent_on_catalog_manager is false. Please update the PR base branch as needed.
