### PR TITLE
KG - Documents "Share with all providers" checkbox

### DIFF
--- a/app/assets/javascripts/documents.js.coffee
+++ b/app/assets/javascripts/documents.js.coffee
@@ -28,3 +28,11 @@ $(document).ready ->
   $(document).on 'change', '#document_document', -> 
    fileName = $(this).val().split('\\').pop()
    $(this).next('.custom-file-label').addClass("selected").html(fileName)
+
+  $(document).on 'change', '#document_share_all', ->
+    if $(this).prop('checked')
+      $('#org_ids').parents('.form-group').addClass('d-none')
+      $('#org_ids').prop('disabled', true).selectpicker('refresh')
+    else
+      $('#org_ids').parents('.form-group').removeClass('d-none')
+      $('#org_ids').prop('disabled', false).selectpicker('refresh')

--- a/app/assets/javascripts/documents.js.coffee
+++ b/app/assets/javascripts/documents.js.coffee
@@ -31,8 +31,8 @@ $(document).ready ->
 
   $(document).on 'change', '#document_share_all', ->
     if $(this).prop('checked')
-      $('#org_ids').parents('.form-group').addClass('d-none')
+      $('#org_ids').parents('.form-group').addClass('d-none').removeClass('d-flex')
       $('#org_ids').prop('disabled', true).selectpicker('refresh')
     else
-      $('#org_ids').parents('.form-group').removeClass('d-none')
+      $('#org_ids').parents('.form-group').removeClass('d-none').addClass('d-flex')
       $('#org_ids').prop('disabled', false).selectpicker('refresh')

--- a/app/controllers/concerns/documents_controller_shared.rb
+++ b/app/controllers/concerns/documents_controller_shared.rb
@@ -35,7 +35,7 @@ module DocumentsControllerShared
   def new
     respond_to :js
 
-    @document = @protocol.documents.new
+    @document = @protocol.documents.new(share_all: true)
   end
 
   def create
@@ -101,8 +101,8 @@ module DocumentsControllerShared
       :document,
       :doc_type,
       :doc_type_other,
-      :sub_service_requests,
-      :protocol_id
+      :protocol_id,
+      :share_all
     )
   end
 end

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -38,14 +38,18 @@ module DocumentsHelper
   end
 
   def display_document_providers(document)
-    organizations = document.organizations.uniq
-
-    if organizations.length > 3
-      link_to 'javascript:void(0)', data: { toggle: 'popover', trigger: 'hover', boundary: 'window', html: 'true', content: organizations.map(&:name).join('<br>') } do
-        t('documents.providers', provider_count: organizations.length)
-      end
+    if document.share_all?
+      t('documents.table.all_providers', protocol_type: document.protocol.model_name.human)
     else
-      organizations.map(&:name).join('<br>')
+      organizations = document.organizations.uniq
+
+      if organizations.length > 3
+        link_to 'javascript:void(0)', data: { toggle: 'popover', trigger: 'hover', boundary: 'window', html: 'true', content: organizations.map(&:name).join('<br>') } do
+          t('documents.table.providers', provider_count: organizations.length)
+        end
+      else
+        organizations.map(&:name).join('<br>')
+      end
     end
   end
 
@@ -76,11 +80,5 @@ module DocumentsHelper
 
   def document_file_types_as_string
     Document::SUPPORTED_FILE_TYPES.map(&:source).map{ |d| d.gsub('\\', '').gsub('$', '').gsub('?', '') }.join(' ')
-  end
-
-  def document_org_access_collection(document)
-    default_select = action_name == 'new' ? document.protocol.organizations.ids : document.sub_service_requests.pluck(:organization_id)
-
-    options_from_collection_for_select(document.protocol.organizations.distinct.order(:name), :id, :name, default_select)
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -47,6 +47,10 @@ class Document < ApplicationRecord
   end
 
   def all_organizations
-    sub_service_requests.map(&:org_tree).flatten.uniq
+    if self.share_all?
+      self.protocol.sub_service_requests.map(&:org_tree).flatten.uniq
+    else
+      self.sub_service_requests.map(&:org_tree).flatten.uniq
+    end
   end
 end

--- a/app/views/documents/_form.html.haml
+++ b/app/views/documents/_form.html.haml
@@ -31,23 +31,28 @@
           %span{ aria: { hidden: 'true' } } &times;
       .modal-body
         .form-group
-          = f.label :doc_type, class: 'required'
-          = f.select :doc_type, options_for_select(PermissibleValue.get_inverted_hash('document_type'), document.doc_type), { prompt: t(:documents)[:select_type] }, class: 'selectpicker'
-        .form-group#doc-type-other-field{ class: document.doc_type == 'other' ? '' : 'd-none' }
-          = f.label :doc_type_other, t('constants.prompts.please_specify'), class: 'required'
-          = f.text_field :doc_type_other, class: 'form-control'
-        .form-group
           = f.label :document, class: 'required'
           .custom-file
             = f.file_field :document, class: 'custom-file-input'
-            = f.label :document, document.document_file_name, class: 'custom-file-label text-truncate'
+            = f.label :document, document.document_file_name || 'No file selected', class: 'custom-file-label text-truncate'
           %small.form-text.text-muted
-            = raw t('documents.supported_types', file_types: document_file_types_as_string)
-        - document_orgs = document_org_access_collection(document)
-        - unless document_orgs.empty?
-          .form-group
-            = f.label :org_ids, title: t(:documents)[:tooltips][:access], data: { toggle: 'tooltip' }
-            = select_tag :org_ids, document_orgs, class: 'selectpicker', multiple: true, data: { actions_box: 'true' }
+            = raw t('documents.form.supported_types', file_types: document_file_types_as_string)
+        .form-row
+          .form-group.col
+            = f.label :doc_type, class: 'required'
+            = f.select :doc_type, options_for_select(PermissibleValue.get_inverted_hash('document_type'), document.doc_type), { prompt: t('documents.form.select_type') }, class: 'selectpicker'
+          .form-group.col#doc-type-other-field{ class: document.doc_type == 'other' ? '' : 'd-none' }
+            = f.label :doc_type_other, t('constants.prompts.please_specify'), class: 'required'
+            = f.text_field :doc_type_other, class: 'form-control'
+        .form-row
+          .form-group.col-4
+            = f.label :org_ids, title: t('documents.tooltips.access', protocol_type: document.protocol.model_name.human), data: { toggle: 'tooltip' }
+            .custom-control.custom-checkbox.mt-2.mb-1
+              = f.check_box :share_all, class: 'custom-control-input'
+              = f.label :share_all, class: 'custom-control-label',title: t('documents.tooltips.share_all', protocol_type: document.protocol.model_name.human), data: { toggle: 'tooltip' }
+          .form-group.col-8{ class: document.share_all? ? 'd-none' : '' }
+            %label &nbsp;
+            = select_tag :org_ids, options_from_collection_for_select(document.protocol.organizations.distinct.order(:name), :id, :name, document.sub_service_requests.pluck(:organization_id)), class: 'selectpicker', multiple: true, disabled: document.share_all?, data: { actions_box: 'true', none_selected_text: t('documents.form.select_providers') }
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t(:actions)[:close]

--- a/app/views/documents/_form.html.haml
+++ b/app/views/documents/_form.html.haml
@@ -50,8 +50,7 @@
             .custom-control.custom-checkbox.mt-2.mb-1
               = f.check_box :share_all, class: 'custom-control-input'
               = f.label :share_all, class: 'custom-control-label',title: t('documents.tooltips.share_all', protocol_type: document.protocol.model_name.human), data: { toggle: 'tooltip' }
-          .form-group.col-8{ class: document.share_all? ? 'd-none' : '' }
-            %label &nbsp;
+          .form-group.col-8.align-items-end{ class: document.share_all? ? 'd-none' : 'd-flex' }
             = select_tag :org_ids, options_from_collection_for_select(document.protocol.organizations.distinct.order(:name), :id, :name, document.sub_service_requests.pluck(:organization_id)), class: 'selectpicker', multiple: true, disabled: document.share_all?, data: { actions_box: 'true', none_selected_text: t('documents.form.select_providers') }
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
         document: "Document"
         document_updated_at: "Uploaded"
         org_ids: "Service Providers With Access"
+        share_all: "Share with all providers"
       form:
         respondable_id: "SRID"
         surveyable: "Association"
@@ -572,14 +573,18 @@ en:
     created: "Document Uploaded!"
     updated: "Document Updated!"
     destroyed: "Document Destroyed!"
-    supported_types: "Supported File Types:<br>%{file_types}"
-    providers: "%{provider_count} Service Providers"
+    form:
+      supported_types: "Supported File Types:<br>%{file_types}"
+      select_type: "Please Select Type"
+      select_providers: "Choose Service Providers"
+    table:
+      providers: "%{provider_count} Service Providers"
+      all_providers: "All Service Providers on this %{protocol_type}"
     tooltips:
       new: "Visible to Authorized Users and selected Service Providers"
-      access: "Uploaded documents are made viewable to all service providers unless checkmark is removed"
+      access: "Share this document with all current and future service providers on this %{protocol_type} or choose which providers this document should be shared with"
       add_document: "Upload document(s) in repository"
-    select_type: "Please Select Type"
-    delete_confirm: "Are you sure you want to delete the selected Document from this protocol?"
+      share_all: "Share this document with all current and future service providers on this %{protocol_type}"
 
   ###############
   # ERROR PAGES #

--- a/db/migrate/20200805132132_add_share_all_to_documents.rb
+++ b/db/migrate/20200805132132_add_share_all_to_documents.rb
@@ -1,0 +1,5 @@
+class AddShareAllToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :share_all, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_134540) do
+ActiveRecord::Schema.define(version: 2020_08_05_132132) do
 
   create_table "admin_rates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "line_item_id"
@@ -166,6 +166,7 @@ ActiveRecord::Schema.define(version: 2020_06_17_134540) do
     t.datetime "document_updated_at"
     t.string "doc_type_other"
     t.bigint "protocol_id"
+    t.boolean "share_all"
     t.index ["protocol_id"], name: "index_documents_on_protocol_id"
   end
 

--- a/spec/factories/document.rb
+++ b/spec/factories/document.rb
@@ -20,13 +20,14 @@
 
 FactoryBot.define do
   factory :document do
-    doc_type             { 'other' }
-    doc_type_other       { Faker::Lorem.word }
-    document_file_name   { Faker::Lorem.word + '.docx' }
-    document_content_type{ 'application/msword' }
-    document_file_size   { Random.rand(100000) }
-    document_updated_at  { Time.now }
-    created_at           { Time.now }
-    updated_at           { Time.now }
+    doc_type              { 'other' }
+    doc_type_other        { Faker::Lorem.word }
+    document_file_name    { Faker::Lorem.word + '.docx' }
+    document_content_type { 'application/msword' }
+    document_file_size    { Random.rand(100000) }
+    document_updated_at   { Time.now }
+    created_at            { Time.now }
+    updated_at            { Time.now }
+    share_all             { true }
   end
 end

--- a/spec/factories/document.rb
+++ b/spec/factories/document.rb
@@ -28,6 +28,6 @@ FactoryBot.define do
     document_updated_at   { Time.now }
     created_at            { Time.now }
     updated_at            { Time.now }
-    share_all             { true }
+    share_all             { false }
   end
 end

--- a/spec/features/dashboard/documents/user_adds_document_spec.rb
+++ b/spec/features/dashboard/documents/user_adds_document_spec.rb
@@ -25,27 +25,50 @@ RSpec.feature 'User wants to add a document', js: true do
   fake_login_for_each_test
 
   before :each do
-    @protocol       = create(:study_federally_funded, primary_pi: jug2)
-    organization    = create(:organization)
-    service_request = create(:service_request_without_validations, protocol: @protocol)
-                      create(:sub_service_request_without_validations, service_request: service_request, organization: organization, status: 'draft', protocol: @protocol)
+    @protocol = create(:study_federally_funded, primary_pi: jug2)
+    @org      = create(:organization)
+    sr        = create(:service_request_without_validations, protocol: @protocol)
+    @ssr      = create(:sub_service_request_without_validations, service_request: sr, organization: @org, status: 'draft', protocol: @protocol)
 
     visit dashboard_protocol_path(@protocol)
     wait_for_javascript_to_finish
   end
 
-  it 'should add the new document' do
-    click_link I18n.t('documents.new')
-    wait_for_javascript_to_finish
+  context 'selecting share with all providers' do
+    it 'should add the new document' do
+      click_link I18n.t('documents.new')
+      wait_for_javascript_to_finish
 
-    bootstrap_select '#document_doc_type', 'Budget'
-    attach_file 'document_document', File.expand_path('spec/fixtures/files/text_document.txt'), make_visible: true
+      bootstrap_select '#document_doc_type', 'Budget'
+      attach_file 'document_document', File.expand_path('spec/fixtures/files/text_document.txt'), make_visible: true
 
-    click_button I18n.t('actions.upload')
-    wait_for_javascript_to_finish
+      click_button I18n.t('actions.upload')
+      wait_for_javascript_to_finish
 
-    expect(@protocol.reload.documents.count).to eq(1)
-    expect(@protocol.documents.first.doc_type).to eq('budget')
-    expect(@protocol.documents.first.sub_service_requests.to_a).to eq([@protocol.sub_service_requests.first])
+      expect(@protocol.reload.documents.count).to eq(1)
+      expect(@protocol.documents.first.share_all).to eq(true)
+      expect(@protocol.documents.first.sub_service_requests.count).to eq(0)
+    end
+  end
+
+  context 'selecting to share with individual providers' do
+    it 'should add the new document' do
+      click_link I18n.t('documents.new')
+      wait_for_javascript_to_finish
+
+      bootstrap_select '#document_doc_type', 'Budget'
+      attach_file 'document_document', File.expand_path('spec/fixtures/files/text_document.txt'), make_visible: true
+
+      find('#document_share_all + label').click
+      bootstrap_select '#org_ids', @org.name
+      find('.modal-title').click
+
+      click_button I18n.t('actions.upload')
+      wait_for_javascript_to_finish
+
+      expect(@protocol.reload.documents.count).to eq(1)
+      expect(@protocol.documents.first.share_all).to eq(false)
+      expect(@protocol.documents.first.sub_service_requests.to_a).to eq([@ssr])
+    end
   end
 end

--- a/spec/features/proper/document_management/user_adds_document_spec.rb
+++ b/spec/features/proper/document_management/user_adds_document_spec.rb
@@ -25,29 +25,52 @@ RSpec.describe 'User adds a new document', js: true do
   fake_login_for_each_test
 
   before :each do
-    org       = create(:organization, :with_subsidy_map, name: "Program", process_ssrs: true, pricing_setup_count: 1)
-    service   = create(:service, name: "Service", abbreviation: "Service", organization: org, pricing_map_count: 1, one_time_fee: true)
+    @org      = create(:organization, :with_subsidy_map, name: "Program", process_ssrs: true, pricing_setup_count: 1)
+    service   = create(:service, name: "Service", abbreviation: "Service", organization: @org, pricing_map_count: 1, one_time_fee: true)
     @protocol = create(:study_federally_funded, primary_pi: jug2)
     @sr       = create(:service_request_without_validations, status: 'draft', protocol: @protocol)
-    @ssr      = create(:sub_service_request_without_validations, service_request: @sr, organization: org, status: 'draft', protocol: @protocol)
+    @ssr      = create(:sub_service_request_without_validations, service_request: @sr, organization: @org, status: 'draft', protocol: @protocol)
                 create(:line_item, service_request: @sr, sub_service_request: @ssr, service: service)
 
     visit document_management_service_request_path(srid: @sr.id)
     wait_for_javascript_to_finish
   end
 
-  it 'should create the document' do
-    click_link I18n.t('documents.new')
-    wait_for_javascript_to_finish
+  context 'selecting share with all providers' do
+    it 'should add the new document' do
+      click_link I18n.t('documents.new')
+      wait_for_javascript_to_finish
 
-    bootstrap_select '#document_doc_type', 'Budget'
-    attach_file 'document_document', File.expand_path('spec/fixtures/files/text_document.txt'), make_visible: true
+      bootstrap_select '#document_doc_type', 'Budget'
+      attach_file 'document_document', File.expand_path('spec/fixtures/files/text_document.txt'), make_visible: true
 
-    click_button I18n.t('actions.upload')
-    wait_for_javascript_to_finish
+      click_button I18n.t('actions.upload')
+      wait_for_javascript_to_finish
 
-    expect(@protocol.reload.documents.count).to eq(1)
-    expect(@protocol.documents.first.doc_type).to eq('budget')
-    expect(@protocol.documents.first.sub_service_requests.to_a).to eq([@protocol.sub_service_requests.first])
+      expect(@protocol.reload.documents.count).to eq(1)
+      expect(@protocol.documents.first.share_all).to eq(true)
+      expect(@protocol.documents.first.sub_service_requests.count).to eq(0)
+    end
+  end
+
+  context 'selecting to share with individual providers' do
+    it 'should add the new document' do
+      click_link I18n.t('documents.new')
+      wait_for_javascript_to_finish
+
+      bootstrap_select '#document_doc_type', 'Budget'
+      attach_file 'document_document', File.expand_path('spec/fixtures/files/text_document.txt'), make_visible: true
+
+      find('#document_share_all + label').click
+      bootstrap_select '#org_ids', @org.name
+      find('.modal-title').click
+
+      click_button I18n.t('actions.upload')
+      wait_for_javascript_to_finish
+
+      expect(@protocol.reload.documents.count).to eq(1)
+      expect(@protocol.documents.first.share_all).to eq(false)
+      expect(@protocol.documents.first.sub_service_requests.to_a).to eq([@ssr])
+    end
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -47,16 +47,34 @@ RSpec.describe Document, type: :model do
   end
 
   describe '#all_organizations' do
-    it 'should return SSR organizations and their trees' do
-      document = create(:document)
-      org1     = create(:organization)
-      org2     = create(:organization, parent: org1)
-      ssr1     = create(:sub_service_request_without_validations, organization: org1)
-      ssr2     = create(:sub_service_request_without_validations, organization: org2)
-      
-      document.sub_service_requests = [ssr1, ssr2]
+    context 'share_all is true' do
+      it 'should return SSR organizations and their trees' do
+        org1      = create(:organization)
+        org2      = create(:organization)
+        org3      = create(:organization, parent: org1)
+        protocol  = create(:study_federally_funded)
+        document  = create(:document, share_all: true, protocol: protocol)
+        ssr1      = create(:sub_service_request_without_validations, organization: org3, protocol: protocol)
+        ssr2      = create(:sub_service_request_without_validations, organization: org2, protocol: protocol)
+        
+        expect(document.reload.all_organizations.sort_by(&:id)).to eq([org1, org2, org3])
+      end
+    end
 
-      expect(document.reload.all_organizations).to eq([org1, org2])
+    context 'share_all is false' do
+      it 'should return all protocol SSR organizations and their trees' do
+        org1      = create(:organization)
+        org2      = create(:organization)
+        org3      = create(:organization, parent: org1)
+        protocol  = create(:study_federally_funded)
+        document  = create(:document, share_all: false, protocol: protocol)
+        ssr1      = create(:sub_service_request_without_validations, organization: org3, protocol: protocol)
+        ssr2      = create(:sub_service_request_without_validations, organization: org2, protocol: protocol)
+
+        document.sub_service_requests = [ssr1]
+
+        expect(document.reload.all_organizations.sort_by(&:id)).to eq([org1, org3])
+      end
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171759634

The `share_all` attribute is designed so that as new service requests are made, documents are still accessible to those new providers. The checkbox is checked by default on a new document (pic 1). Unchecking it will show the list of providers for the user to choose which ones they want to share the document with (pic 2).
<img width="585" alt="image" src="https://user-images.githubusercontent.com/12898988/89457657-b64c9e80-d733-11ea-83dc-a4317c2c56cf.png">

<img width="578" alt="image" src="https://user-images.githubusercontent.com/12898988/89457576-94ebb280-d733-11ea-8c85-194d54a3c0c1.png">
