### PR TITLE
SAW - OnCore Endpoint UI

### DIFF
--- a/app/controllers/oncore_endpoint_controller.rb
+++ b/app/controllers/oncore_endpoint_controller.rb
@@ -144,16 +144,15 @@ class OncoreEndpointController < ApplicationController
     :to     => :retrieve_protocol_def
   def retrieve_protocol_def
     begin
-      # find the protocol
-      protocol = find_valid_protocol
+      find_valid_protocol
 
       # Don't try to build calendar information if it doesn't exist (RPE messages don't have calendar info)
-      if !is_rpe_message?
+      unless is_rpe_message?
         # Add arms to the protocol
-        get_arms_from_cells(protocol)
+        get_arms_from_cells
 
         # Build out calendar info (visit groups, line items, line item visits, visits, etc.) from VISIT elements for each arm
-        protocol.arms.each do |arm|
+        @protocol.arms.each do |arm|
           build_calendar_info(arm)
         end
       end
@@ -176,11 +175,9 @@ class OncoreEndpointController < ApplicationController
   def find_valid_protocol
     id = oncore_endpoint_params[:plannedStudy][:id][:extension] #protocol ID as a string with the format "STUDY#{id}"
     id.try(:slice!, "STUDY")
-    if !id.nil? && protocol = Protocol.find(id)
-      if protocol.has_clinical_services?
+    if !id.nil? && @protocol = Protocol.find(id)
+      if @protocol.has_clinical_services?
         raise "Error: SPARC Protocol #{id} has an existing calendar and cannot be overwritten."
-      else
-        return protocol
       end
     else
       raise "Error: No existing SPARC Protocol with identifier #{id}."
@@ -189,7 +186,7 @@ class OncoreEndpointController < ApplicationController
 
   # Creates arms on the protocol and
   # assigns a hash with the structure { SPARC_arm_id => arm_code } since arm_code is used like an ID that isn't stored in SPARC
-  def get_arms_from_cells(protocol)
+  def get_arms_from_cells
     # component4 CELL elements contain arm and visit imformation including calendar and budget version.
     @arm_codes = {}
     oncore_endpoint_params[:plannedStudy][:component4].select{ |c4| c4[:timePointEventDefinition][:code][:code] == "CELL" }.each do |cell|
@@ -198,7 +195,7 @@ class OncoreEndpointController < ApplicationController
       # Remove bad characters from the arm name
       arm_name.gsub!(/[\[\]\*\/\\\?\:]/, '')
 
-      calendar_version = cell[:timePointEventDefinition][:title].split(/[\s\:]/)[1] # can't do this for arm name because the name can have a :
+      @calendar_version = cell[:timePointEventDefinition][:title].split(/[\s\:]/)[1] # can't do this for arm name because the name can have a :
 
       budget_version = cell[:timePointEventDefinition][:title].split(/[\s\:]/)[3]
 
@@ -208,7 +205,7 @@ class OncoreEndpointController < ApplicationController
         c4[:timePointEventDefinition][:code][:code] == "VISIT" && c4[:timePointEventDefinition][:id][:extension].split('.').first == arm_code
       }.count
 
-      if arm = protocol.arms.create(name: arm_name, subject_count: 1, visit_count: visit_count)
+      if arm = @protocol.arms.create(name: arm_name, subject_count: 1, visit_count: visit_count)
         @arm_codes[arm.id] = arm_code
       end
     end
@@ -217,8 +214,7 @@ class OncoreEndpointController < ApplicationController
   def build_calendar_info(arm)
     # component4 VISIT elements contain visit group information and procedures.
     # VISITS are like visit groups and PROCS are like line item visits, including service information.
-    protocol = arm.protocol
-    service_request = protocol.service_requests.first
+    service_request = @protocol.service_requests.first
 
     oncore_endpoint_params[:plannedStudy][:component4].select{ |c4| 
       c4[:timePointEventDefinition][:code][:code] == "VISIT" && c4[:timePointEventDefinition][:id][:extension].split('.').first == @arm_codes[arm.id]
@@ -272,7 +268,7 @@ class OncoreEndpointController < ApplicationController
   # The only difference between RPE messages and CRPC messages is that CRPC messages contain calendar information (component4's)
   # and RPE messages do not have any calendar information (no component4 elements).
   def is_rpe_message?
-    oncore_endpoint_params[:plannedStudy][:component4].nil?
+    @is_rpe = oncore_endpoint_params[:plannedStudy][:component4].nil?
   end
 
   # Returns an integer representing the number of days since Jan 1, 2000
@@ -283,10 +279,18 @@ class OncoreEndpointController < ApplicationController
   end
 
   def print_params_to_log(e=nil)
+    if !@is_rpe && @protocol.present?
+      status = e.present? ? "failure" : "success"
+      oncore_record = OncoreRecord.create(protocol_id: @protocol.id, calendar_version: @calendar_version, status: status)
+      timestamp = oncore_record.created_at
+    end
+
+    timestamp ||= DateTime.now
+
     logfile = File.join(Rails.root, '/log/', "OnCore-#{Rails.env}.log")
     logger = ActiveSupport::Logger.new(logfile)
     logger.info "\n----------------------------------------------------------------------------------"
-    logger.info "RetrieveProtocolDefResponse request ---------- Timestamp: #{DateTime.now.to_formatted_s(:long)}"
+    logger.info "RetrieveProtocolDefResponse request ---------- Timestamp: #{timestamp.to_formatted_s(:long)}"
     logger.info "Params received by OncoreEndpointController:"
     logger.info JSON.pretty_generate(oncore_endpoint_params.to_h)
     unless e.nil?

--- a/app/helpers/dashboard/oncore_records_helper.rb
+++ b/app/helpers/dashboard/oncore_records_helper.rb
@@ -18,48 +18,13 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-module Dashboard::EpicQueuesHelper
-  def format_pis(protocol)
-    protocol.principal_investigators.map(&:full_name).join(', ')
+module Dashboard::OncoreRecordsHelper
+  def format_push_date(date)
+    # Use the epic queues date format
+    date.strftime(t(:dashboard)[:epic_queues][:date_formatter])
   end
 
-  def epic_queue_delete_button(epic_queue)
-    link_to icon('fas', 'trash-alt'), dashboard_epic_queue_path(epic_queue.id), remote: true, method: :delete, class: 'btn btn-danger', data: { confirm_swal: 'true' }
-  end
-
-  def epic_queue_send_button(epic_queue)
-    link_to icon('fas', 'hand-point-right'), push_to_epic_protocol_path(epic_queue.protocol.id, eq_id: epic_queue.id), remote: true, method: :get, class: 'btn btn-success push-to-epic mr-1', data: { permission: 'true' }
-  end
-
-  def epic_queue_actions(epic_queue)
-    content_tag :div, class: 'd-flex justify-content-center' do
-      raw([
-        epic_queue_send_button(epic_queue),
-        epic_queue_delete_button(epic_queue)
-      ].join(''))
-    end
-  end
-
-  def format_epic_queue_date(protocol)
-    date = protocol.last_epic_push_time
-    if date.present?
-      date.strftime(t(:dashboard)[:epic_queues][:date_formatter])
-    else
-      ''
-    end
-  end
-
-  def format_epic_queue_created_at(epic_queue)
-    created_at = epic_queue.created_at
-    created_at.strftime(t(:dashboard)[:epic_queues][:date_formatter])
-  end
-
-  def format_status(protocol)
-    status = protocol.last_epic_push_status
-    if status.present?
-      "#{status.capitalize}"
-    else
-      ''
-    end
+  def protocol_oncore_history_button(protocol_id)
+    link_to icon('fas', 'history'), dashboard_protocol_oncore_records_path(protocol_id), remote: true, method: :get, class: 'btn btn-info protocol-oncore-history'
   end
 end

--- a/app/helpers/dashboard/protocols_helper.rb
+++ b/app/helpers/dashboard/protocols_helper.rb
@@ -48,6 +48,10 @@ module Dashboard::ProtocolsHelper
     content_tag(:div, short_title) + content_tag(:div, (display_rmid_validated_protocol(protocol, Protocol.human_attribute_name(:short_title))) )
   end
 
+  def format_protocol(protocol)
+    link_to "#{protocol.type.capitalize}: #{protocol.id} - #{protocol.short_title}", dashboard_protocol_path(protocol)
+  end
+
   def pis_display(protocol)
     content_tag(:div, class: 'd-flex flex-column align-items-start') do
       if protocol.primary_pi

--- a/app/models/oncore_record.rb
+++ b/app/models/oncore_record.rb
@@ -1,0 +1,27 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+class OncoreRecord < ApplicationRecord
+  belongs_to :protocol
+
+  scope :most_recent_push_per_protocol, -> do
+    where(id: OncoreRecord.select("MAX(id) AS latest").group(:protocol_id).collect(&:latest))
+  end
+end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -49,6 +49,7 @@ class Protocol < ApplicationRecord
   has_many :study_type_answers,           dependent: :destroy
   has_many :notes, as: :notable,          dependent: :destroy
   has_many :documents,                    dependent: :destroy
+  has_many :oncore_records,               dependent: :destroy
   has_many :protocol_merges,              foreign_key: :master_protocol_id
 
   has_many :identities,                   through: :project_roles

--- a/app/views/dashboard/oncore_records/_history_modal.html.haml
+++ b/app/views/dashboard/oncore_records/_history_modal.html.haml
@@ -1,0 +1,40 @@
+-# Copyright © 2011-2020 MUSC Foundation for Research Development~
+-# All rights reserved.~
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+-# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+-# derived from this software without specific prior written permission.~
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+.modal-dialog{ role: 'document' }
+  .modal-content
+    .modal-header
+      %h3.modal-title
+        = t("dashboard.oncore.log.history_title", protocol_id: protocol_id)
+      %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
+        %span{ aria: { hidden: 'true' } } &times;
+    .modal-body
+      %table.table-interactive.protocol-oncore-records-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', pagination: 'true', url: dashboard_protocol_oncore_records_path(protocol_id) } }
+        %thead.bg-light
+          %tr
+            %th{data: { field: 'calendar_version', align: 'left', sortable: 'false' } }
+              = t(:dashboard)[:oncore][:log][:calendar_version]
+            %th{data: { field: 'created_at', align: 'left', sortable: 'true' } }
+              = t(:dashboard)[:oncore][:log][:created_at]
+            %th{data: { field: 'status', align: 'left', sortable: 'true' } }
+              = t(:dashboard)[:oncore][:log][:status]
+    .modal-footer
+      %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+        = t('actions.close')

--- a/app/views/dashboard/oncore_records/history.js.coffee
+++ b/app/views/dashboard/oncore_records/history.js.coffee
@@ -1,0 +1,22 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+$('#modalContainer').html("<%= j render 'dashboard/oncore_records/history_modal', protocol_id: @protocol_id %>")
+$('#modalContainer').modal('show')

--- a/app/views/dashboard/oncore_records/history.json.jbuilder
+++ b/app/views/dashboard/oncore_records/history.json.jbuilder
@@ -1,0 +1,5 @@
+json.(@oncore_records) do |ocr|
+  json.calendar_version   ocr.calendar_version
+  json.status             ocr.status.capitalize
+  json.created_at         format_push_date(ocr.created_at)
+end

--- a/app/views/dashboard/oncore_records/index.html.haml
+++ b/app/views/dashboard/oncore_records/index.html.haml
@@ -1,0 +1,39 @@
+-# Copyright © 2011-2020 MUSC Foundation for Research Development~
+-# All rights reserved.~
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+-# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+-# derived from this software without specific prior written permission.~
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+.card.w-100.border-top-0#oncoreRecords
+  .card-header.bg-primary.text-white
+    %h3.mb-0
+      = t(:dashboard)[:oncore][:log][:header]
+  %table.table-interactive.oncore-records-table{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', pagination: 'true', url: dashboard_oncore_records_path } }
+    %thead.bg-light
+      %tr
+        %th.col-3{data: { field: 'protocol', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:oncore][:log][:protocol]
+        %th{data: { field: 'pis', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:oncore][:log][:PIs]
+        %th{data: { field: 'calendar_version', align: 'left', sortable: 'false' } }
+          = t(:dashboard)[:oncore][:log][:calendar_version]
+        %th.col-2{data: { field: 'created_at', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:oncore][:log][:created_at]
+        %th.col-2{data: { field: 'status', align: 'left', sortable: 'true' } }
+          = t(:dashboard)[:oncore][:log][:status]
+        %th.col-1.last{data: {class: 'history', align: 'center', field: 'history'}}
+          = t(:dashboard)[:oncore][:log][:history]

--- a/app/views/dashboard/oncore_records/index.json.jbuilder
+++ b/app/views/dashboard/oncore_records/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.(@oncore_records) do |ocr|
+  json.protocol           format_protocol(ocr.protocol)
+  json.pis                pis_display(ocr.protocol)
+  json.calendar_version   ocr.calendar_version
+  json.status             ocr.status.capitalize
+  json.created_at         format_push_date(ocr.created_at)
+  json.history            protocol_oncore_history_button(ocr.protocol_id)
+end

--- a/app/views/layouts/dashboard/_dashboard_navbar.html.haml
+++ b/app/views/layouts/dashboard/_dashboard_navbar.html.haml
@@ -32,6 +32,10 @@
         = link_to dashboard_epic_queues_path, class: 'btn btn-info ml-1' do
           = icon('fas', 'eye mr-2')
           = t('layout.dashboard.navigation.epic_queue')
+      - if Setting.get_value('use_oncore') && Setting.get_value('oncore_endpoint_access').include?(current_user.ldap_uid)
+        = link_to dashboard_oncore_records_path, class: 'btn btn-info-alt text-white ml-1' do
+          = icon('fas', 'eye mr-2')
+          = t('layout.dashboard.navigation.oncore_log')
       - if current_user.catalog_overlord?
         = link_to new_dashboard_protocol_merge_path, remote: true, class: 'btn btn-warning ml-1' do
           = icon('far', 'object-ungroup mr-2')

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -650,6 +650,16 @@
     "parent_value":   ""
   },
   {
+    "key":            "oncore_endpoint_access",
+    "value":          "[]",
+    "friendly_name":  "OnCore Endpoint Access",
+    "description":    "This is a list of users who will have full access to the OnCore functionality in SPARC.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
     "key":            "queue_epic",
     "value":          "false",
     "friendly_name":  "Queue Epic",
@@ -968,6 +978,16 @@
     "version":        "",
     "parent_key":     "use_news_feed",
     "parent_value":   "true"
+  },
+    {
+    "key":            "use_oncore",
+    "value":          "false",
+    "friendly_name":  "Use OnCore",
+    "description":    "This determines whether the application will use OnCore integration.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "",
+    "parent_value":   ""
   },
   {
     "key":            "use_redcap_api",

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -103,6 +103,20 @@ en:
         main_button: "Send SPARC system notification to an Authorized User or Service Provider"
         shared: "Share this message with super users of your group and overlords."
 
+    ###################
+    # ONCORE ENDPOINT #
+    ###################
+    oncore:
+      log:
+        header: "OnCore CRPC Push Log"
+        protocol: "Protocol"
+        PIs: "PI(s)"
+        calendar_version: "Calendar Version"
+        created_at: "Last Push Date"
+        status: "Status"
+        history: "Push History"
+        history_title: "Protocol #%{protocol_id} CRPC Push History"
+
     ######################
     #  PROTOCOL FILTERS  #
     ######################

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -665,6 +665,7 @@ en:
       navigation:
         short_interaction: "Short Interaction"
         epic_queue: "Epic Queue"
+        oncore_log: "OnCore Log"
         protocol_merge: "Merge Protocols"
     footer:
       version: "SPARCRequest %{version}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,9 @@ SparcRails::Application.routes.draw do
     resources :epic_queues, only: [:index, :destroy]
     resources :epic_queue_records, only: [:index]
 
+    resources :oncore_records, only: [:index]
+    get "/protocols/:protocol_id/oncore_records", to: "oncore_records#history", as: :protocol_oncore_records
+
     resource :protocol_merge do
       put :perform_protocol_merge
     end

--- a/db/migrate/20200805161558_create_oncore_records.rb
+++ b/db/migrate/20200805161558_create_oncore_records.rb
@@ -1,0 +1,10 @@
+class CreateOncoreRecords < ActiveRecord::Migration[5.2]
+  def change
+    create_table :oncore_records do |t|
+      t.references :protocol
+      t.integer    :calendar_version
+      t.string     :status
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_134540) do
+ActiveRecord::Schema.define(version: 2020_08_05_161558) do
 
   create_table "admin_rates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "line_item_id"
@@ -410,6 +410,15 @@ ActiveRecord::Schema.define(version: 2020_06_17_134540) do
     t.boolean "shared"
     t.index ["originator_id"], name: "index_notifications_on_originator_id"
     t.index ["sub_service_request_id"], name: "index_notifications_on_sub_service_request_id"
+  end
+
+  create_table "oncore_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "protocol_id"
+    t.integer "calendar_version"
+    t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["protocol_id"], name: "index_oncore_records_on_protocol_id"
   end
 
   create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/spec/factories/oncore_record.rb
+++ b/spec/factories/oncore_record.rb
@@ -1,0 +1,27 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FactoryBot.define do
+  factory :oncore_record do
+    status       { rand(2) == 1 ? 'success' : 'failure' }
+    created_at   { Time.now }
+    updated_at   { Time.now }
+  end
+end

--- a/spec/models/oncore_record_spec.rb
+++ b/spec/models/oncore_record_spec.rb
@@ -1,0 +1,40 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rails_helper'
+
+RSpec.describe OncoreRecord, type: :model do
+
+  it { is_expected.to belong_to(:protocol) }
+
+  describe 'scopes' do
+    describe '#most_recent_push_per_protocol' do
+      it 'should return the most recent OncoreRecord for each protocol' do
+        study1 = create(:study_federally_funded)
+        study2 = create(:study_federally_funded)
+        ocr1   = create(:oncore_record, protocol_id: study1.id, calendar_version: 1)
+        ocr2   = create(:oncore_record, protocol_id: study1.id, calendar_version: 2)
+        ocr3   = create(:oncore_record, protocol_id: study2.id, calendar_version: 1)
+
+        expect(OncoreRecord.most_recent_push_per_protocol.count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/views/layouts/dashboard/_dashboard_navbar.html.haml_spec.rb
+++ b/spec/views/layouts/dashboard/_dashboard_navbar.html.haml_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe 'layouts/dashboard/_dashboard_navbar.html.haml', view: true do
     end
   end
 
+  context 'OnCore configuration turned on' do
+    stub_config("use_oncore", true)
+    stub_config("oncore_endpoint_access", ['jug2'])
+
+    it 'should display view OnCore Log button' do
+      render 'layouts/dashboard/dashboard_navbar', current_user: @user
+
+      expect(response).to have_selector('a', text: I18n.t('layout.dashboard.navigation.oncore_log'))
+    end
+  end
+
   context 'short interaction turned on' do
     stub_config('use_short_interaction', true)
 


### PR DESCRIPTION
[#172245441](https://www.pivotaltracker.com/story/show/172245441)

Created page in SPARCDashboard to show all CRPC pushes from OnCore to SPARC. This included updating the OnCore SOAP endpoint to create a log of all CRPC pushes with a valid protocol and displaying the most recent log for a protocol on the log table. All CRPC push history can be viewed by clicking the history button in the table. The OnCore Log is only accessible if the setting `use_oncore` is true and the current user is included in the setting list `oncore_endpoint_access`. Both settings are new and will need to be set accordingly in testing, etc.

![image](https://user-images.githubusercontent.com/19152930/89684476-884c9300-d8c8-11ea-814c-2096210e59e1.png)
![image](https://user-images.githubusercontent.com/19152930/89684487-913d6480-d8c8-11ea-9c37-501f48d182f7.png)
