### PR TITLE
KG - Visit Group Editing Updates

### DIFF
--- a/app/assets/javascripts/custom/bootstrap-custom.es6
+++ b/app/assets/javascripts/custom/bootstrap-custom.es6
@@ -22,6 +22,19 @@
   $.extend($.fn.modal.Constructor.Default, { backdrop: 'static' });
 
   $(document).ready( function() {
+    // Allow popovers to be closed via an optional close button
+    $(document).on('click', '.popover .close', event => {
+      event.preventDefault();
+      $(event.target).parents('.popover').popover('hide').popover('dispose');
+    })
+
+    // Allow popovers to be closed via the <esc> key
+    $(document).on('keyup', 'body', event => {
+      if (event.keyCode == 27 && $('.popover').length)
+        $('.popover').popover('hide').popover('dispose')
+        $('.tooltip').tooltip('hide')
+    })
+
     $(document).on('hide.bs.popover', '[data-toggle="popover"][data-trigger="hover"]', event => {
       var $this = $(event.target);
 

--- a/app/assets/javascripts/global.js.coffee
+++ b/app/assets/javascripts/global.js.coffee
@@ -58,7 +58,7 @@ $ ->
 
   # Smooth scroll anchors with hash
   $(document).on 'click', "a[href^='#']:not(data-toggle)", (event) ->
-    if !$(this).data('toggle')
+    if !$(this).data('toggle') && $(this).attr('href') != '#'
       event.preventDefault()
       $('html, body').animate({ scrollTop: $(this.hash).offset().top }, 'slow')
 
@@ -213,7 +213,7 @@ $ ->
 
 (exports ? this).initializeTooltips = () ->
   $('.tooltip').tooltip('hide')
-  $('[data-toggle=tooltip]').tooltip({ delay: { show: 500 }, animation: false })
+  $('[data-toggle=tooltip]').tooltip({ delay: { show: 250 }, animation: false })
 
 (exports ? this).initializePopovers = () ->
   $('[data-toggle=popover]').popover()

--- a/app/assets/javascripts/service_calendar.js.coffee
+++ b/app/assets/javascripts/service_calendar.js.coffee
@@ -51,7 +51,7 @@ $ ->
 
   # Various calendar links
   $(document).on 'click keyup', 'th.visit-group, td.visit.billing-strategy-visit, td.notes, td.displayed-cost, td.subject-count, td.units-per-quantity, td.quantity', (event) ->
-    if !$(this).hasClass('.visit-group')
+    if !$(this).hasClass('visit-group')
       hideVisitGroupPopover()
     # Click or press <return> to open
     if ((event.type == 'click' && event.target.tagName != 'A') || (event.type == 'keyup' && event.keyCode == 13)) && $(this).hasClass('editable') && $link = $(this).find('a:not(.disabled)')

--- a/app/assets/javascripts/service_calendar.js.coffee
+++ b/app/assets/javascripts/service_calendar.js.coffee
@@ -22,9 +22,9 @@ $ ->
   if $('#serviceCalendar').length
     adjustCalendarHeaders()
 
-  $(document).on('mouseenter', '.editable', ->
+  $(document).on('mouseenter focus', '.editable:not(.active)', ->
     $(this).find('a').addClass('active')
-  ).on('mouseleave', '.editable', ->
+  ).on('mouseleave focusout', '.editable:not(.active)', ->
     $(this).find('a').removeClass('active')
   )
 
@@ -45,22 +45,37 @@ $ ->
   # Visit Checkbox / Input #
   ##########################
 
-  $(document).on 'click', 'th.visit-group, td.visit.billing-strategy-visit, td.notes, td.displayed-cost, td.subject-count, td.units-per-quantity, td.quantity', (event) ->
-    if $(this).hasClass('editable') && event.target.tagName != 'A' && $link = $(this).find('a:not(.disabled)')
+  $(document).on 'show.bs.modal', 'body', ->
+    if $('.visit-group.active').length
+      hideVisitGroupPopover()
+
+  # Various calendar links
+  $(document).on 'click keyup', 'th.visit-group, td.visit.billing-strategy-visit, td.notes, td.displayed-cost, td.subject-count, td.units-per-quantity, td.quantity', (event) ->
+    if !$(this).hasClass('.visit-group')
+      hideVisitGroupPopover()
+    # Click or press <return> to open
+    if ((event.type == 'click' && event.target.tagName != 'A') || (event.type == 'keyup' && event.keyCode == 13)) && $(this).hasClass('editable') && $link = $(this).find('a:not(.disabled)')
       $.ajax
         method: $link.data('method') || 'GET'
         dataType: 'script'
         url: $link.attr('href')
 
-  $(document).on 'click', 'th.check-column.editable, td.check-row.editable', (event) ->
-    if event.target.tagName != 'A'
+  # Check row / column
+  $(document).on 'click keyup', 'th.check-column.editable, td.check-row.editable', (event) ->
+    hideVisitGroupPopover()
+    # Click or press <return> to open
+    if ((event.type == 'click' && event.target.tagName != 'A') || (event.type == 'keyup' && event.keyCode == 13))
       handleConfirm(this.querySelector('a'))
 
+  # Template checkbox
   $(document).on 'click', 'td.visit.template-visit', (event) ->
-    if event.target.tagName != 'INPUT'
+    hideVisitGroupPopover()
+    # Click or press <return> to open
+    if ((event.type == 'click' && event.target.tagName != 'INPUT') || (event.type == 'keyup' && event.keyCode == 13))
       $(this).find('input').click()
 
   $(document).on 'change', '.visit-quantity', ->
+    hideVisitGroupPopover()
     $.ajax
       method: 'PUT'
       dataType: 'script'
@@ -95,7 +110,7 @@ $ ->
 
   $(document).on 'change', '#visit_group_position', ->
     $form   = $(this).parents('form')
-    action  = if $form.is('.new_visit_group') then 'new' else 'edit'
+    action  = if $form.is('#new_visit_group') then 'new' else 'edit'
     $.ajax
       type: 'GET'
       dataType: 'script'
@@ -128,7 +143,7 @@ $ ->
       $('#calendarLoading').removeClass('show active')
 
 (exports ? this).adjustCalendarHeaders = () ->
-  zIndex = $('.service-calendar-container').length * 4
+  zIndex = $('.service-calendar-container').length * 5
 
   $('.service-calendar-container').each ->
     $head   = $(this).children('.card-header')
@@ -142,8 +157,9 @@ $ ->
     row3Height  = $row3.outerHeight()
 
     $head.css('z-index': zIndex)
-    zIndex--
+    zIndex -= 2
     $row1.children('th').css({ 'top': headHeight, 'z-index': zIndex })
+    $row1.children('th.visit-group-select').css({ 'z-index': zIndex + 1 })
     zIndex--
     $row2.children('th').css({ 'top': headHeight + row1Height, 'z-index': zIndex })
     zIndex--
@@ -155,3 +171,6 @@ $ ->
     $('#servicesToggle').parents('.toggle').removeClass('invisible')
   else
     $('#servicesToggle').parents('.toggle').addClass('invisible')
+
+(exports ? this).hideVisitGroupPopover = () ->
+  $('.visit-group.active').removeClass('active').trigger('focusout').popover('hide').popover('dispose')

--- a/app/assets/stylesheets/custom/bootstrap-custom.scss
+++ b/app/assets/stylesheets/custom/bootstrap-custom.scss
@@ -115,6 +115,14 @@
       justify-content: center;
     }
   }
+
+  &.btn-white {
+    background: white;
+
+    &:hover {
+      background: theme-color('light');
+    }
+  }
 }
 
 ////////////
@@ -688,6 +696,13 @@ nav.navbar {
 ///////////////
 /// Popover ///
 ///////////////
+
+.popover {
+  .popover-header {
+    @include clearfix;
+    font-size: 1.5rem;
+  }
+}
 
 @include media-breakpoint-up(md) {
   .popover {

--- a/app/assets/stylesheets/service_calendar.scss
+++ b/app/assets/stylesheets/service_calendar.scss
@@ -26,7 +26,6 @@
 }
 
 #serviceCalendar .service-calendar-container {
-
   &:not(:last-of-type) {
     @extend .border-bottom;
     border-bottom-left-radius: 0;
@@ -74,17 +73,31 @@
       vertical-align: middle;
       padding: 0.5rem 0.25rem;
     }
+
+    th.visit-group {
+      vertical-align: bottom;
+    }
   }
 
-  .visit-group-select .dropdown-menu {
-    li:not(.active) .vg-page-header {
-      @extend .bg-light;
+  .visit-group-select {
+    .dropdown-toggle {
+      &:focus {
+        background: darken(theme-color('light'), 10%);
+        border-color: darken(theme-color('light'), 12.5%) !important;
+        outline: 0 !important;
+      }
     }
 
-    .vg-page-header {
-      @extend .border-top;
-      @extend .border-bottom;
-      @extend .font-weight-bold;
+    .dropdown-menu {
+      li:not(.active) .vg-page-header {
+        @extend .bg-light;
+      }
+
+      .vg-page-header {
+        @extend .border-top;
+        @extend .border-bottom;
+        @extend .font-weight-bold;
+      }
     }
   }
 
@@ -96,9 +109,10 @@
     &.editable {
       transition: $btn-transition;
 
-      &:hover {
+      &:hover, &:focus, &.active {
         cursor: pointer;
-        background: theme-color('light');
+        background: theme-color-level('light', 0.5);
+        outline: 0;
       }
     }
 
@@ -113,6 +127,22 @@
     .visit-quantity {
       transform: scale(1.5);
       cursor: pointer;
+    }
+  }
+}
+
+.visit-group-popover {
+  .change-visit-btn {
+    margin-top: -0.5rem;
+
+    &:first-of-type {
+      margin-left: -0.75rem;
+      margin-right: 0.75rem;
+    }
+
+    &:last-of-type {
+      margin-left: 0.75rem;
+      margin-right: -0.75rem;
     }
   }
 }

--- a/app/helpers/visit_groups_helper.rb
+++ b/app/helpers/visit_groups_helper.rb
@@ -26,7 +26,7 @@ module VisitGroupsHelper
   end
 
   def delete_visit_group_button(visit_group, opts={})
-    link_to visit_group_path(visit_group, srid: opts[:srid], ssrid: opts[:ssrid], tab: opts[:tab], page: opts[:page], pages: opts[:pages]), remote: true, method: :delete, class: 'btn btn-danger', title: t('visit_groups.delete'), data: { toggle: 'tooltip', confirm_swal: 'true' } do
+    link_to visit_group_path(visit_group, srid: opts[:srid], ssrid: opts[:ssrid], tab: opts[:tab], page: opts[:page], pages: opts[:pages]), remote: true, method: :delete, class: 'btn btn-sm btn-danger', title: t('visit_groups.delete'), data: { toggle: 'tooltip', confirm_swal: 'true' } do
       icon('fas', 'trash-alt mr-2') + t('visit_groups.delete')
     end
   end

--- a/app/lib/dashboard/service_calendars.rb
+++ b/app/lib/dashboard/service_calendars.rb
@@ -133,7 +133,7 @@ module Dashboard
     end
 
     def self.build_visits_select(arm, page, url)
-      select_tag "visits-select-for-#{arm.id}", visits_select_options(arm, page), class: 'form-control selectpicker', data: { url: url, dropup_auto: 'false', size: 10, flip: 'false' }
+      select_tag "visits-select-for-#{arm.id}", visits_select_options(arm, page), class: 'form-control selectpicker', tabindex: 0, data: { url: url, dropup_auto: 'false', size: 10, flip: 'false' }
     end
 
     def self.visits_select_options(arm, cur_page=1)

--- a/app/views/arms/_form.html.haml
+++ b/app/views/arms/_form.html.haml
@@ -18,7 +18,7 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-.modal-dialog.modal-sm{ role: 'document' }
+.modal-dialog{ role: 'document' }
   .modal-content
     = form_for arm, remote: true do |f|
       = hidden_field_tag :tab, tab

--- a/app/views/service_calendars/_subject_count.html.haml
+++ b/app/views/service_calendars/_subject_count.html.haml
@@ -20,7 +20,7 @@
 
 - editable = editable && !(service_request.protocol.locked? || merged)
 
-%td.subject-count.text-center{ colspan: 2, class: editable ? 'editable' : '', title: number_with_delimiter(liv.subject_count, delimiter: ','), data: { toggle: 'tooltip' } }
+%td.subject-count.text-center{ colspan: 2, tabindex: 0, class: editable ? 'editable' : '', title: number_with_delimiter(liv.subject_count, delimiter: ','), data: { toggle: 'tooltip' } }
   - if editable
     = link_to number_with_delimiter(liv.subject_count, delimiter: ','), edit_line_items_visit_path(liv, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), field: 'subject_count', page: page, tab: tab), remote: true
   - else

--- a/app/views/service_calendars/master_calendar/pppv/_visit_group.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_visit_group.html.haml
@@ -21,7 +21,15 @@
 - url = edit_visit_group_path(visit_group, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), tab: tab, page: page, pages: pages)
 - editable = !(merged || visit_group.arm.protocol.locked?)
 
-%th.visit-group.px-0{ class: ["visit-group-#{visit_group.id}", editable ? 'editable' : ''], colspan: 3 }
+%th.visit-group.px-0{ class: ["visit-group-#{visit_group.id}", editable ? 'editable' : ''], colspan: 3, tabindex: 0 }
+  %table.table-sm.table-borderless.w-100
+    %tbody
+      %tr
+        %td.text-center.py-0.px-1{ colspan: 3, title: visit_group.name, data: { toggle: 'tooltip' } }
+          - if editable
+            = link_to visit_group.name, url, remote: true
+          - else
+            = visit_group.name
   %table.table-sm.table-borderless.w-100
     %thead
       %tr
@@ -52,9 +60,3 @@
             = link_to visit_group.window_after, url, remote: true
           - else
             = visit_group.window_after
-      %tr
-        %td.text-center.py-0.px-1{ colspan: 3, title: visit_group.name, data: { toggle: 'tooltip' } }
-          - if editable
-            = link_to visit_group.name, url, remote: true
-          - else
-            = visit_group.name

--- a/app/views/service_calendars/master_calendar/pppv/_visit_group_page_select.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/_visit_group_page_select.html.haml
@@ -28,6 +28,6 @@
   - path_method = method(:table_service_calendars_path)
 
 .d-flex
-  = link_to icon('fas', 'arrow-left'), path_method.call(url_data.merge(page: page - 1)), remote: true, class: ['btn btn-primary mr-1', page == 1 ? 'disabled' : ''], title: t('calendars.pppv.header_fields.page_select.previous'), data: { toggle: 'tooltip' }
+  = link_to icon('fas', 'arrow-left'), path_method.call(url_data.merge(page: page - 1)), remote: true, class: ['btn btn-primary mr-1', page == 1 ? 'disabled' : ''], tabindex: 0, title: t('calendars.pppv.header_fields.page_select.previous'), data: { toggle: 'tooltip' }
   = Dashboard::ServiceCalendars.build_visits_select(arm, page, path_method.call(url_data))
-  = link_to icon('fas', 'arrow-right'), path_method.call(url_data.merge(page: page + 1)), remote: true, class: ['btn btn-primary ml-1', ((page + 1) * 5) - 4 > arm.visit_count ? 'disabled' : ''], title: t('calendars.pppv.header_fields.page_select.next'), data: { toggle: 'tooltip' }
+  = link_to icon('fas', 'arrow-right'), path_method.call(url_data.merge(page: page + 1)), remote: true, class: ['btn btn-primary ml-1', ((page + 1) * 5) - 4 > arm.visit_count ? 'disabled' : ''], title: t('calendars.pppv.header_fields.page_select.next'), tabindex: 0, data: { toggle: 'tooltip' }

--- a/app/views/service_calendars/master_calendar/pppv/billing_strategy/_billing_strategy_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/billing_strategy/_billing_strategy_line_items.html.haml
@@ -55,7 +55,7 @@
     %tr{ class: ["line-item-#{liv.line_item.id}", "line-items-visit-#{liv.id}", "text-#{text_context}"] }
       %td.service-name{ colspan: 9, title: calendar_service(liv), data: { toggle: 'tooltip', html: 'true' } }
         = calendar_service(liv)
-      %td.notes.editable.text-center{ colspan: 2, title: "#{Service.model_name.human} #{Note.model_name.plural.capitalize}", data: { toggle: 'tooltip' } }
+      %td.notes.editable.text-center{ colspan: 2, tabindex: 0, title: "#{Service.model_name.human} #{Note.model_name.plural.capitalize}", data: { toggle: 'tooltip' } }
         = notes_button(liv, disabled: !editable, srid: service_request.try(:id), ssrid: sub_service_request.try(:id))
       %td.status.text-center{ colspan: 3, title: PermissibleValue.get_value('status', ssr.status), data: { toggle: 'tooltip' } }
         = PermissibleValue.get_value('status', ssr.status)
@@ -73,7 +73,7 @@
 
       - visits = liv.ordered_visits.page(page).eager_load(line_items_visit: { line_item: { service: :pricing_maps } })
       - visits.each do |v|
-        %td.visit.billing-strategy-visit.text-center{ class: ["visit-#{v.id}", editable ? 'editable' : ''], colspan: 3 }
+        %td.visit.billing-strategy-visit.text-center{ class: ["visit-#{v.id}", editable ? 'editable' : ''], colspan: 3, tabindex: 0 }
           = render "service_calendars/master_calendar/pppv/#{tab}/#{tab}_visit_input", service_request: service_request, sub_service_request: sub_service_request, visit: v, page: page, editable: editable
       - (Visit.per_page - visits.size).times do
         %td{ colspan: 3 }

--- a/app/views/service_calendars/master_calendar/pppv/template/_select_column.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/template/_select_column.html.haml
@@ -28,5 +28,5 @@
 - url                 = toggle_calendar_column_service_calendars_path(srid: service_request.id, visit_group_id: visit_group.id, page: page, :"#{check_param}" => 'true')
 - url                += "&ssrid=#{sub_service_request.id}" if sub_service_request
 
-%th.check-column.text-center{ colspan: 3, class: editable ? 'editable' : '', id: "toggleColumn#{visit_group.id}", title: tooltip, data: { toggle: 'tooltip' } }
+%th.check-column.text-center{ colspan: 3, tabindex: 0, class: editable ? 'editable' : '', id: "toggleColumn#{visit_group.id}", title: tooltip, data: { toggle: 'tooltip' } }
   = link_to icon('fas', icon), url, method: :post, remote: true, class: ['btn btn-sq', klass, editable ? '' : 'disabled'], data: { confirm_swal: 'true', text: t('calendars.confirm_column_select') }

--- a/app/views/service_calendars/master_calendar/pppv/template/_select_row.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/template/_select_row.html.haml
@@ -26,5 +26,5 @@
 - url          = toggle_calendar_row_service_calendars_path(srid: service_request.id, line_items_visit_id: liv.id, page: page, :"#{check_param}" => 'true')
 - url         += "&ssrid=#{sub_service_request.id}" if sub_service_request
 
-%td.check-row.text-center{ colspan: 2, class: editable ? 'editable' : '', id: "toggleRow#{liv.id}", title: tooltip, data: { toggle: 'tooltip' } }
+%td.check-row.text-center{ colspan: 2, tabindex: 0, class: editable ? 'editable' : '', id: "toggleRow#{liv.id}", title: tooltip, data: { toggle: 'tooltip' } }
   = link_to icon('fas', icon), url, method: :post, remote: true, class: ['btn btn-sq', klass, editable ? '' : 'disabled'], data: { confirm_swal: 'true', text: t('calendars.confirm_row_select') }

--- a/app/views/service_calendars/master_calendar/pppv/template/_template_line_items.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/template/_template_line_items.html.haml
@@ -39,7 +39,7 @@
     %tr{ class: ["line-item-#{liv.line_item.id}", "line-items-visit-#{liv.id}", "text-#{text_context}"] }
       %td.service-name{ colspan: 9, title: calendar_service(liv), data: { toggle: 'tooltip', html: 'true' } }
         = calendar_service(liv)
-      %td.notes.editable.text-center{ colspan: 2, title: "#{Service.model_name.human} #{Note.model_name.plural.capitalize}", data: { toggle: 'tooltip' } }
+      %td.notes.editable.text-center{ colspan: 2, tabindex: 0, title: "#{Service.model_name.human} #{Note.model_name.plural.capitalize}", data: { toggle: 'tooltip' } }
         = notes_button(liv, disabled: !editable, srid: service_request.try(:id), ssrid: sub_service_request.try(:id))
       %td.status.text-center{ colspan: 3, title: PermissibleValue.get_value('status', ssr.status), data: { toggle: 'tooltip' } }
         = PermissibleValue.get_value('status', ssr.status)
@@ -56,7 +56,7 @@
       = render 'service_calendars/master_calendar/pppv/template/select_row', liv: liv, service_request: service_request, sub_service_request: sub_service_request, editable: editable, page: page
       - visits = liv.ordered_visits.page(page).eager_load(line_items_visit: { line_item: { service: :pricing_maps } })
       - visits.each do |v|
-        %td.visit.template-visit.text-center{ class: ["visit-#{v.id}", editable ? 'editable' : ''], colspan: 3 }
+        %td.visit.template-visit.text-center{ class: ["visit-#{v.id}", editable ? 'editable' : ''], colspan: 3, tabindex: 0 }
           = render "service_calendars/master_calendar/pppv/#{tab}/#{tab}_visit_input", service_request: service_request, visit: v, tab: tab, page: page, editable: editable
       - (Visit.per_page - visits.size).times do
         %td{ colspan: 3 }

--- a/app/views/service_calendars/master_calendar/pppv/template/_template_visit_input.html.haml
+++ b/app/views/service_calendars/master_calendar/pppv/template/_template_visit_input.html.haml
@@ -21,4 +21,4 @@
 - checked = (visit.research_billing_qty + visit.insurance_billing_qty + visit.effort_billing_qty > 0)
 - unit_minimum = visit.line_items_visit.line_item.service.displayed_pricing_map.unit_minimum
 
-= check_box_tag "", 1, checked, class: "visit-quantity", data: { visit_id: visit.id, quantity: checked ? 0 : unit_minimum, research_billing_qty: checked ? 0 : unit_minimum, insurance_billing_qty: checked ? 0 : visit.insurance_billing_qty, effort_billing_qty: checked ? 0 : visit.effort_billing_qty }, disabled: !editable
+= check_box_tag "", 1, checked, class: "visit-quantity", tabindex: -1, data: { visit_id: visit.id, quantity: checked ? 0 : unit_minimum, research_billing_qty: checked ? 0 : unit_minimum, insurance_billing_qty: checked ? 0 : visit.insurance_billing_qty, effort_billing_qty: checked ? 0 : visit.effort_billing_qty }, disabled: !editable

--- a/app/views/service_calendars/table.js.coffee
+++ b/app/views/service_calendars/table.js.coffee
@@ -18,6 +18,9 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# When updating the calendar hide visit group popovers
+hideVisitGroupPopover()
+
 <% if @arm %>
 $(".arm-<%= @arm.id %>-container:visible").replaceWith("<%= j render '/service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @page, pages: @pages, merged: @merged, consolidated: @consolidated %>")
 <% else %>

--- a/app/views/service_calendars/toggle_calendar_column.js.coffee
+++ b/app/views/service_calendars/toggle_calendar_column.js.coffee
@@ -20,6 +20,7 @@
 
 # Replace checkbox
 $("#toggleColumn<%= @visit_group.id %>").replaceWith("<%= j render 'service_calendars/master_calendar/pppv/template/select_column', service_request: @service_request, sub_service_request: @sub_service_request, visit_group: @visit_group, page: @page, editable: true %>")
+$("#toggleColumn<%= @visit_group.id %>").trigger('focus')
 
 # Replace Row checkboxes
 <% @line_items_visits.each do |liv| %>

--- a/app/views/service_calendars/toggle_calendar_row.js.coffee
+++ b/app/views/service_calendars/toggle_calendar_row.js.coffee
@@ -20,6 +20,7 @@
 
 # Replace checkbox
 $("#toggleRow<%= @line_items_visit.id %>").replaceWith("<%= j render 'service_calendars/master_calendar/pppv/template/select_row', service_request: @service_request, sub_service_request: @sub_service_request, liv: @line_items_visit, page: @page, editable: true %>")
+$("#toggleRow<%= @line_items_visit.id %>").trigger('focus')
 
 # Replace Column checkboxes
 <% @visit_groups.each do |vg| %>

--- a/app/views/service_requests/service_details.html.haml
+++ b/app/views/service_requests/service_details.html.haml
@@ -18,7 +18,7 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-= form_tag navigate_service_request_path(srid: @service_request.id), id: 'serviceRequestForm', class: 'w-100' do
+.w-100
   = render '/service_requests/navigation/steps'
   = render '/service_requests/navigation/header'
   - if @errors && (@service_request.previously_submitted? || request_referrer_action != 'protocol')
@@ -27,4 +27,7 @@
   .card
     .card-body.px-0.pb-0
       = render 'service_calendars/tabs', service_request: @service_request, page: @page, pages: @pages
+
+-# Moved the form_tag to allow <return> interactions on the service calendar
+= form_tag navigate_service_request_path(srid: @service_request.id), id: 'serviceRequestForm', class: 'w-100' do
   = render 'service_requests/navigation/footer'

--- a/app/views/visit_groups/_form.html.haml
+++ b/app/views/visit_groups/_form.html.haml
@@ -18,53 +18,59 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-.modal-dialog{ role: 'document' }
-  .modal-content
-    = form_for visit_group, remote: true do |f|
-      = f.hidden_field :arm_id
-      = hidden_field_tag :arm_id, visit_group.arm_id
-      = hidden_field_tag :srid, service_request.try(:id)
-      = hidden_field_tag :ssrid, sub_service_request.try(:id)
-      = hidden_field_tag :tab, tab
-      = hidden_field_tag :page, page
-      - pages.each do |arm_id, page|
-        = hidden_field_tag "pages[#{arm_id}]", page
-      .modal-header
-        %h3.modal-title
-          = t("visit_groups.#{action_name}")
-        %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
-          %span{ aria: { hidden: 'true' } } &times;
-      .modal-body
-        .form-group
-          = f.label :name, class: 'required'
-          = f.text_field :name, class: 'form-control'
-        .form-row
-          .form-group.col-4
-            = f.label :window_before, class: 'required'
-            = f.number_field :window_before, class: 'form-control', min: 0
-          .form-group.col-4
-            - min, max = move_visit_group_boundaries(visit_group, arm)
-            - disable = min == max && min.present? # Disable if there can only be one day to choose from and the user did not select the blank option
-            = f.label :day, class: 'required'
-            = f.number_field :day, class: 'form-control', min: min, max: max, value: disable ? min : visit_group.day, readonly: disable
-            - if min || max
-              %small.form-text.text-muted
-                - if min
-                  = t('constants.min', min: min)
-                - if max
-                  = t('constants.max', max: max)
-              - if min == max && (visit_group.new_record? || visit_group.position_changed?)
-                %small.form-text.text-warning
-                  = t('visit_groups.form.move_note')
-          .form-group.col-4
-            = f.label :window_after, class: 'required'
-            = f.number_field :window_after, class: 'form-control', min: 0
-        .form-group
+- if action_name == 'edit'
+  - disable_left = visit_group.position % VisitGroup.per_page == 1
+  - disable_right = visit_group.position % VisitGroup.per_page == 0
+
+= form_for visit_group, remote: true, html: { class: 'w-100' } do |f|
+  = f.hidden_field :arm_id
+  = hidden_field_tag :arm_id, visit_group.arm_id
+  = hidden_field_tag :srid, service_request.try(:id)
+  = hidden_field_tag :ssrid, sub_service_request.try(:id)
+  = hidden_field_tag :tab, tab
+  = hidden_field_tag :page, page
+  - pages.each do |arm_id, page|
+    = hidden_field_tag "pages[#{arm_id}]", page
+  .d-flex
+    - if action_name == 'edit'
+      = link_to disable_left ? 'javascript:void(0)' : edit_visit_group_path(visit_group.higher_item, srid: @service_request.id), remote: true, class: ['btn btn-white rounded-0 d-flex align-items-center change-visit-btn', disable_left ? 'disabled' : ''], title: disable_left ? '' : t('visit_groups.previous', name: visit_group.higher_item.name), data: { toggle: 'tooltip', placement: 'left' } do
+        = icon('fas', 'chevron-left')
+    .flex-fill
+      .form-group{ class: action_name == 'edit' ? 'mb-1' : '' }
+        = f.label :name, class: 'required'
+        = f.text_field :name, class: ['form-control', action_name == 'edit' ? 'form-control-sm' : '']
+      .form-row
+        .form-group.col-6{ class: action_name == 'edit' ? 'mb-1' : '' }
+          - min, max = move_visit_group_boundaries(visit_group, arm)
+          - disable = min == max && min.present? # Disable if there can only be one day to choose from and the user did not select the blank option
+          = f.label :day, class: 'required'
+          = f.number_field :day, class: ['form-control', action_name == 'edit' ? 'form-control-sm' : ''], min: min, max: max, value: disable ? min : visit_group.day, readonly: disable
+          - if min || max
+            %small.form-text.text-muted
+              - if min
+                = t('constants.min', min: min)
+              - if max
+                = t('constants.max', max: max)
+            - if min == max && (visit_group.new_record? || visit_group.position_changed?)
+              %small.form-text.text-warning
+                = t('visit_groups.form.move_note')
+        .form-group.col-6{ class: action_name == 'edit' ? 'mb-1' : '' }
           = f.label :position, class: 'required'
-          = f.select :position, visit_position_options(arm, visit_group), { include_blank: true }, class: 'selectpicker', disabled: visit_group.nil?
-      .modal-footer
-        - if action_name == 'edit'
-          = delete_visit_group_button(visit_group, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), tab: tab, page: page, pages: pages)
-        %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
-          = t('actions.close')
-        = f.submit t('actions.submit'), class: 'btn btn-primary'
+          = f.select :position, visit_position_options(arm, visit_group), { include_blank: true }, class: 'selectpicker', disabled: visit_group.nil?, data: { style: action_name == 'edit' ? 'btn-sm btn-light dropdown-menu-right' : 'btn-light', size: 10 }
+      .form-row
+        .form-group.col-6{ class: action_name == 'edit' ? 'mb-2' : '' }
+          = f.label :window_before, class: 'required'
+          = f.number_field :window_before, class: ['form-control', action_name == 'edit' ? 'form-control-sm' : ''], min: 0
+        .form-group.col-6{ class: action_name == 'edit' ? 'mb-2' : '' }
+          = f.label :window_after, class: 'required'
+          = f.number_field :window_after, class: ['form-control', action_name == 'edit' ? 'form-control-sm' : ''], min: 0
+    - if action_name == 'edit'
+      = link_to disable_right ? 'javascript:void(0)' : edit_visit_group_path(visit_group.lower_item, srid: @service_request.id), remote: true, class: ['btn btn-white rounded-0 d-flex align-items-center change-visit-btn', disable_right ? 'disabled' : ''], title: disable_right ? '' : t('visit_groups.next', name: visit_group.lower_item.name), data: { toggle: 'tooltip', placement: 'right' } do
+        = icon('fas', 'chevron-right')
+  .modal-footer.d-flex.row.border-top.pb-0{ class: action_name == 'edit' ? 'justify-content-between pt-2' : 'pt-3' }
+    - if action_name == 'edit'
+      = delete_visit_group_button(visit_group, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), tab: tab, page: page, pages: pages)
+    - else
+      %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+        = t('actions.close')
+    = f.submit t('actions.submit'), class: ['btn btn-primary', action_name == 'edit' ? 'btn-sm' : '']

--- a/app/views/visit_groups/_form.html.haml
+++ b/app/views/visit_groups/_form.html.haml
@@ -19,8 +19,8 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
 - if action_name == 'edit'
-  - disable_left = visit_group.position % VisitGroup.per_page == 1
-  - disable_right = visit_group.position % VisitGroup.per_page == 0
+  - disable_left = visit_group.position % VisitGroup.per_page == 1 || visit_group.higher_item.nil?
+  - disable_right = visit_group.position % VisitGroup.per_page == 0 || visit_group.lower_item.nil?
 
 = form_for visit_group, remote: true, html: { class: 'w-100' } do |f|
   = f.hidden_field :arm_id

--- a/app/views/visit_groups/edit.js.coffee
+++ b/app/views/visit_groups/edit.js.coffee
@@ -18,7 +18,35 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-$('#modalContainer').html("<%= j render 'form', visit_group: @visit_group, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, tab: @tab, page: @page, pages: @pages %>")
-$('#modalContainer').modal('show')
+$vg       = $(".visit-group-<%= @visit_group.id %>")
+title     = "#{I18n.t("visit_groups.edit")} <a href='#' class='close' data-dismiss='alert'>&times;</a>"
+$content  = $("<%= j render 'form', visit_group: @visit_group, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, tab: @tab, page: @page, pages: @pages %>")
+
+if $('.visit-group-popover') && !$("form#edit_visit_group_<%= @visit_group.id %>").length
+  $('.visit-group-popover').popover('hide')
+  $('.visit-group.active').removeClass('active')
+
+if $(".visit-group-<%= @visit_group.id %>-popover").length
+  $vg.removeClass('active').popover('dispose')
+else
+  $vg.popover(
+    title:      title
+    content:    $content
+    template:   '<div class="popover visit-group-popover visit-group-<%= @visit_group.id %>-popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+    html:       true
+    trigger:    'manual'
+    placement:  'top'
+  )
+
+  # Logic for smoother closing of visit group popovers
+  $vg.on 'shown.bs.popover', ->
+    $(document).one 'hide.bs.popover', 'body', ->
+      $vg.removeClass('active').trigger('focus')
+  $vg.addClass('active').trigger('focus').popover('show')
+
+  # Force the menu to dropdown to the right
+  # bootstrap-select doees not seem to have a method to add classes
+  # to the menu
+  $('[id=visit_group_position]').siblings('.dropdown-menu').addClass('dropdown-menu-right')
 
 $(document).trigger('ajax:complete') # rails-ujs element replacement bug fix

--- a/app/views/visit_groups/new.js.coffee
+++ b/app/views/visit_groups/new.js.coffee
@@ -18,7 +18,21 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
 
-$('#modalContainer').html("<%= j render 'form', visit_group: @visit_group, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, tab: @tab, page: @page, pages: @pages %>")
+body = "<%= j render 'form', visit_group: @visit_group, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, tab: @tab, page: @page, pages: @pages %>"
+
+$('#modalContainer').html("
+  <div class='modal-dialog role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h3 class='modal-title'>#{I18n.t('visit_groups.new')}</h3>
+        <button class='close' type='button' data-dismiss='modal', aria-label='#{I18n.t('actions.close')}'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body'>#{body}</div>
+    </div>
+  </div>
+")
 $('#modalContainer').modal('show')
 
 $(document).trigger('ajax:complete') # rails-ujs element replacement bug fix

--- a/app/views/visit_groups/update.js.coffee
+++ b/app/views/visit_groups/update.js.coffee
@@ -28,10 +28,13 @@ $("[name='visit_group[<%= attr.to_s %>]']").parents('.form-group').removeClass('
 <% end %>
 <% end %>
 <% else %>
+$(".visit-group-<%= @visit_group.id %>").popover('dispose')
 $(".arm-<%= @arm.id %>-container").replaceWith("<%= j render '/service_calendars/master_calendar/pppv/pppv_calendar', tab: @tab, arm: @arm, service_request: @service_request, sub_service_request: @sub_service_request, page: @page, pages: @pages, merged: false, consolidated: false %>")
 
 adjustCalendarHeaders()
 
-$('#modalContainer').modal('hide')
+$(".visit-group-<%= @visit_group.id %>").trigger('focus')
+
 $("#flashContainer").replaceWith("<%= j render 'layouts/flash' %>")
+$(document).trigger('ajax:complete') # rails-ujs element replacement bug fix
 <% end %>

--- a/app/views/visits/_form.html.haml
+++ b/app/views/visits/_form.html.haml
@@ -43,9 +43,10 @@
           .form-group.col-4
             = f.label :effort_billing_qty, class: 'required'
             = f.text_field :effort_billing_qty, class: 'form-control'
-          .form-group.col-4
-            = f.label :set_all_insurance, t(:calendars)[:pppv][:visits][:select_all_t]
-            = check_box_tag :set_all_insurance
+        .form-group.mb-0
+          .custom-control.custom-checkbox
+            = check_box_tag :set_all_insurance, true, false, class: 'custom-control-input'
+            = label_tag :set_all_insurance, t(:calendars)[:pppv][:visits][:select_all_t], class: 'custom-control-label'
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
           = t('actions.close')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -943,6 +943,8 @@ en:
       arm: "Arm"
       visit: "Visit"
       move_note: "Note: Consecutive visits will also have their days changed."
+      previous: "Edit previous visit - %{name}"
+      next: "Edit next visit - %{name}"
 
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170546216
Also included bug fix from https://www.pivotaltracker.com/story/show/172977589 overflow visit dropdown

### Major Updates
* Visit group editing is now done via a popover which is more responsive than a modal
* Swapping between visits is now faster and easier
* Users can now tab through the service calendar and use the `<return>` key to open content. This change is intended to make editing a bit faster.

### Screenshots
Updated visit group editing popover
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/12898988/90057159-fec50880-dcad-11ea-84c7-38614831d1cb.png">
