### PR TITLE
SAW - OnCore Study Minimum Footprint Push

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -21,7 +21,7 @@
 class Dashboard::ProtocolsController < Dashboard::BaseController
   include ProtocolsControllerShared
 
-  before_action :find_protocol,             only: [:show, :edit, :update, :update_protocol_type, :display_requests, :archive, :request_access]
+  before_action :find_protocol,             only: [:show, :edit, :update, :update_protocol_type, :display_requests, :archive, :request_access, :push_to_oncore]
   before_action :find_admin_for_protocol,   only: [:show, :edit, :update, :update_protocol_type, :display_requests, :archive]
   before_action :protocol_authorizer_view,  only: [:show, :view_full_calendar, :display_requests]
   before_action :protocol_authorizer_edit,  only: [:edit, :update, :update_protocol_type, :archive]
@@ -188,6 +188,20 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
     @protocol = controller.instance_variable_get(:@protocol)
 
     flash[:success] = t('protocols.change_type.updated')
+
+    respond_to :js
+  end
+
+  def push_to_oncore
+    if @protocol.is_a?(Study)
+      oncore_protocol = OncoreProtocol.new(@protocol)
+      response = oncore_protocol.create_oncore_protocol
+      if response.success?
+        flash[:success] = I18n.t('protocols.summary.oncore.pushed_to_oncore')
+      else
+        @http_error = "#{response.code}: #{response.message}"
+      end
+    end
 
     respond_to :js
   end

--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -36,6 +36,16 @@ module ProtocolsHelper
     end
   end
 
+  def push_to_oncore_button(protocol)
+    # Do not display outside the dashboard, on Projects, if OnCore isn't in use, or if the user does not have OnCore access
+    if in_dashboard? && protocol.is_a?(Study) &&
+       Setting.get_value('use_oncore') && Setting.get_value('oncore_endpoint_access').include?(current_user.ldap_uid)
+      link_to push_to_oncore_dashboard_protocol_path(protocol), remote: true, class: 'btn btn-info-alt text-white mr-1 oncore-push-protocol', title: t('protocols.summary.tooltips.edit'), data: { toggle: 'tooltip' } do
+        icon('fas', 'sync mr-2') + t('protocols.summary.oncore.push_to_oncore', protocol_type: protocol.model_name.human)
+      end
+    end
+  end
+
   def archive_protocol_button(protocol, opts={})
     unless in_dashboard? && !opts[:permission]
       link_to archive_dashboard_protocol_path(protocol), remote: true, method: :patch, class: ['btn archive-protocol', protocol.archived? ? 'btn-success' : 'btn-danger'], title: t("protocols.summary.tooltips.#{protocol.archived ? "unarchive" : "archive"}"), data: { toggle: 'tooltip' } do

--- a/app/helpers/protocols_helper.rb
+++ b/app/helpers/protocols_helper.rb
@@ -40,7 +40,7 @@ module ProtocolsHelper
     # Do not display outside the dashboard, on Projects, if OnCore isn't in use, or if the user does not have OnCore access
     if in_dashboard? && protocol.is_a?(Study) &&
        Setting.get_value('use_oncore') && Setting.get_value('oncore_endpoint_access').include?(current_user.ldap_uid)
-      link_to push_to_oncore_dashboard_protocol_path(protocol), remote: true, class: 'btn btn-info-alt text-white mr-1 oncore-push-protocol', title: t('protocols.summary.tooltips.edit'), data: { toggle: 'tooltip' } do
+      link_to push_to_oncore_dashboard_protocol_path(protocol), remote: true, class: 'btn btn-info-alt text-white mr-1 oncore-push-protocol', title: t('protocols.summary.tooltips.push_to_oncore'), data: { toggle: 'tooltip' } do
         icon('fas', 'sync mr-2') + t('protocols.summary.oncore.push_to_oncore', protocol_type: protocol.model_name.human)
       end
     end

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -53,7 +53,7 @@ class OncoreProtocol
                                   protocolType: self.protocol_type
                                 })
     else
-      auth_response
+      return auth_response
     end
   end
 
@@ -66,10 +66,9 @@ class OncoreProtocol
                                 grant_type: 'client_credentials'
                               })
     if response.success?
-      token = response['access_token']
-      self.auth = "Bearer " + token
-    else
-      response
+      self.auth = "Bearer " + JSON.parse(response)['access_token']
     end
+
+    return response
   end
 end

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -30,7 +30,7 @@ class OncoreProtocol
     self.title               = study.title
     self.short_title         = study.short_title
     self.library             = Setting.get_value("oncore_default_library")
-    self.department          = study.primary_pi.professional_organization.try(:department) || "Other" #default to Other if there is no department
+    self.department          = study.primary_pi.professional_organization.try(:department) || Setting.get_value("oncore_default_department")
     self.organizational_unit = Setting.get_value("oncore_default_organizational_unit")
     self.protocol_type       = Setting.get_value("oncore_default_protocol_type")
   end

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -25,13 +25,14 @@ class OncoreProtocol
   attr_accessor :auth, :protocol_no, :title, :short_title, :library, :department, :organizational_unit, :protocol_type
 
   def initialize(study)
+    # Use default values for fields that do not correlate to SPARC values
     self.protocol_no         = "STUDY#{study.id}"
     self.title               = study.title
     self.short_title         = study.short_title
-    self.library             = "Non-Oncology" #default
+    self.library             = Setting.get_value("oncore_default_library")
     self.department          = study.primary_pi.professional_organization.try(:department) || "Other" #default to Other if there is no department
-    self.organizational_unit = "MUSC Enterprise" #default
-    self.protocol_type       = "Treatment" #default
+    self.organizational_unit = Setting.get_value("oncore_default_organizational_unit")
+    self.protocol_type       = Setting.get_value("oncore_default_protocol_type")
   end
 
   def create_oncore_protocol

--- a/app/models/professional_organization.rb
+++ b/app/models/professional_organization.rb
@@ -60,4 +60,10 @@ class ProfessionalOrganization < ApplicationRecord
   def self_and_siblings
     ProfessionalOrganization.where(parent_id: parent_id)
   end
+
+  def department
+    return self.parent if self.org_type == 'division'
+    return self if self.org_type == 'department'
+    return nil
+  end
 end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -637,6 +637,12 @@ class Protocol < ApplicationRecord
     self.funding_source_based_on_status == 'industry'
   end
 
+  def push_to_oncore
+    # POST /protocols.json
+    oncore_protocol = OncoreProtocol.new(self)
+    oncore_protocol.create_oncore_protocol
+  end
+
   #############
   ### FORMS ###
   #############

--- a/app/views/dashboard/protocols/push_to_oncore.js.coffee
+++ b/app/views/dashboard/protocols/push_to_oncore.js.coffee
@@ -1,0 +1,29 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+<% if @http_error %>
+AlertSwal.fire(
+  type: 'error'
+  title: I18n.t('protocols.summary.oncore.error')
+  text: "<%= @http_error %>"
+)
+<% else %>
+$("#flashContainer").replaceWith("<%= j render 'layouts/flash' %>")
+<% end %>

--- a/app/views/protocols/_summary.html.haml
+++ b/app/views/protocols/_summary.html.haml
@@ -30,6 +30,7 @@
         = notes_button(protocol, protocol_id: protocol.id, model: protocol, tooltip: t(:protocols)[:summary][:tooltips][:notes], class: 'mr-1')
         = protocol_details_button(protocol)
         = edit_protocol_button(protocol, permission: permission_to_edit || admin)
+        = push_to_oncore_button(protocol)
         = archive_protocol_button(protocol, permission: permission_to_edit || Protocol.for_super_user(current_user.id).include?(protocol))
       - else
         = notes_button(protocol, srid: service_request.id, model: protocol, tooltip: t(:protocols)[:summary][:tooltips][:notes], class: 'mr-1')

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -650,6 +650,16 @@
     "parent_value":   ""
   },
   {
+    "key":            "oncore_api",
+    "value":          "https://youroncoreserver.yourinstitution.tld",
+    "friendly_name":  "OnCore API URL",
+    "description":    "The URL for your institution's OnCore API.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
     "key":            "oncore_endpoint_access",
     "value":          "[]",
     "friendly_name":  "OnCore Endpoint Access",

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -660,6 +660,16 @@
     "parent_value":   "true"
   },
   {
+    "key":            "oncore_default_department",
+    "value":          "Other",
+    "friendly_name":  "OnCore Department Default Value",
+    "description":    "Default value for Primary PI's Department field when pushing studies to OnCore.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
     "key":            "oncore_default_library",
     "value":          "Non-Oncology",
     "friendly_name":  "OnCore Library Default Value",

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -660,6 +660,36 @@
     "parent_value":   "true"
   },
   {
+    "key":            "oncore_default_library",
+    "value":          "Non-Oncology",
+    "friendly_name":  "OnCore Library Default Value",
+    "description":    "Default value for Library field when pushing studies to OnCore.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
+    "key":            "oncore_default_organizational_unit",
+    "value":          "MUSC Enterprise",
+    "friendly_name":  "OnCore Organizational Unit Default Value",
+    "description":    "Default value for Organizational Unit when pushing studies to OnCore.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
+    "key":            "oncore_default_protocol_type",
+    "value":          "Treatment",
+    "friendly_name":  "OnCore Protocol Type Default Value",
+    "description":    "Default value for Protocol Type when pushing studies to OnCore.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
     "key":            "oncore_endpoint_access",
     "value":          "[]",
     "friendly_name":  "OnCore Endpoint Access",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -790,6 +790,10 @@ en:
       unarchive: "Unarchive"
       unarchive_note: "%{protocol_type} was unarchived."
       id: "%{protocol_type} ID:"
+      oncore:
+        push_to_oncore: "Push to OnCore"
+        pushed_to_oncore: "Study Pushed to OnCore!"
+        error: "Unable to push Study to OnCore"
       tooltips:
         notes: "Protocol notes viewable to Administrators and Authorized Users"
         details: "Quick access to protocol information"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -798,6 +798,7 @@ en:
         notes: "Protocol notes viewable to Administrators and Authorized Users"
         details: "Quick access to protocol information"
         edit: "Quick access to edit protocol information"
+        push_to_oncore: "Create Study in OnCore"
         archive: "Ability to hide study from all Authorized User dashboards"
         unarchive: "Click to reveal on all associated Authorized User dashboards"
     view_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ SparcRails::Application.routes.draw do
       member do
         get :display_requests
         get :request_access
+        get :push_to_oncore
         patch :archive
         patch :update_protocol_type
       end
@@ -284,6 +285,7 @@ SparcRails::Application.routes.draw do
           member do
             put :update_protocol_type
             get :display_requests
+            get :push_to_oncore
             patch :archive
           end
         end

--- a/dotenv.example
+++ b/dotenv.example
@@ -27,3 +27,5 @@ sender_address=no-reply@sample.org
 content_security_report_only=true
 script_src_domain=*.musc.edu
 ROOT_URL=https://sparc.musc.edu
+oncore_client_id=client_id_from_oncore
+oncore_client_secret=client_secret_from_oncore

--- a/lib/oncore_protocol.rb
+++ b/lib/oncore_protocol.rb
@@ -20,7 +20,7 @@
 
 class OncoreProtocol
   include HTTParty
-  base_uri 'This will come from settings'
+  base_uri Setting.get_value('oncore_api')
 
   attr_accessor :auth, :protocol_no, :title, :short_title, :library, :department, :organizational_unit, :protocol_type
 

--- a/lib/oncore_protocol.rb
+++ b/lib/oncore_protocol.rb
@@ -1,0 +1,77 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+class OncoreProtocol
+  include HTTParty
+  base_uri 'This will come from settings'
+
+  attr_accessor :auth, :protocol_no, :title, :short_title, :library, :department, :organizational_unit, :protocol_type
+
+  def initialize(study)
+    self.protocol_no         = "STUDY" + study.id
+    self.title               = study.title
+    self.short_title         = study.short_title
+    self.library             = "Non-Oncology" #default
+    self.department          = study.primary_pi.professional_organization.try(:department) || "Other" #default to Other if there is no department
+    self.organizational_unit = "MUSC Enterprise" #default
+    self.protocol_type       = "Treatment" #default
+  end
+
+  def create_oncore_protocol
+    self.authenticate
+
+    # Assumes that the push will fail if it already exists in OnCore, need to confirm
+    response = HTTParty.post('/oncore-api/rest/protocols.json',
+                              headers: {
+                                'Content-Type' => 'application/json',
+                                'Authorization' => self.auth
+                              },
+                              body: {
+                                protocolNo: self.protocol_no,
+                                title: self.title,
+                                short_title: self.short_title,
+                                library: self.library,
+                                department: self.department,
+                                organizationalUnit: self.organizational_unit,
+                                protocolType: self.protocol_type
+                              })
+    unless response.success?
+      raise response.response
+    end
+  end
+
+  private
+
+  def authenticate
+    response = HTTParty.post('/forte-platform-web/api/oauth/token.json',
+                              headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' },
+                              body: {
+                                client_id: Env.fetch('oncore_client_id'),
+                                client_secret: Env.fetch('oncore_client_secret'),
+                                grant_type: 'client_credentials'
+                              })
+    if response.success?
+      token = response['access_token']
+      self.auth = "Bearer " + token
+    else
+      raise response.response
+    end
+  end
+end

--- a/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
+++ b/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
@@ -17,32 +17,44 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+require 'rails_helper'
 
-WebMock.disable_net_connect!({
-  allow_localhost: true,
-  allow: ['chromedriver.storage.googleapis.com', %r{github}]
-  })
+RSpec.describe 'User pushes a study to OnCore', js: true do
+  let_there_be_lane
+  fake_login_for_each_test
 
-RSpec.configure do |config|
-  config.before(:each) do
-    stub_request(:get, "https://sparcrequest.atlassian.net/wiki").
-      to_return(status: 200, body: "")
+  stub_config("use_oncore", true)
+  stub_config("oncore_endpoint_access", ['jug2'])
 
-    stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
-      to_return(status: 201)
+  let(:auth_path) { "/forte-platform-web/api/oauth/token.json" }
+  let(:create_protocol_path) { "/oncore-api/rest/protocols.json" }
 
-    stub_request(:post, "#{Setting.get_value("oncore_api")}/oncore-api/rest/protocols.json").
-      to_return(status: 201)
+  before :each do
+    study = create(:study_federally_funded, primary_pi: jug2)
 
-    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token.json").
-      to_return(status: 200, body: { access_token: "some_token_value", expires_in: "300", token_type: "Bearer" }.to_json)
+    visit dashboard_protocol_path(study)
+    wait_for_javascript_to_finish
+    click_link I18n.t('protocols.summary.oncore.push_to_oncore')
+    wait_for_javascript_to_finish
   end
 
-  config.before(:each, remote_service: :unavailable) do
-    stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
-      to_return(status: 500)
+  context 'OnCore servers accessible' do
+    it 'should contact OnCore servers twice' do
+      # Once to authenticate, once to create the study in OnCore
+      expect(a_request(:post, Setting.get_value("oncore_api")+auth_path)).to have_been_made.once
+      expect(a_request(:post, Setting.get_value("oncore_api")+create_protocol_path)).to have_been_made.once
+    end
+  end
 
-    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token.json").
-      to_return(status: 500)
+  context 'OnCore servers inaccessible', remote_service: :unavailable do
+    it 'should contact OnCore servers once' do
+      # Authenticate once
+      expect(a_request(:post, Setting.get_value("oncore_api")+auth_path)).to have_been_made.once
+    end
+
+    it 'should display HTTP error' do
+      expect(page).to have_content(I18n.t('protocols.summary.oncore.error'))
+      expect(page).to have_content('500:')
+    end
   end
 end

--- a/spec/helpers/protocols_helper_spec.rb
+++ b/spec/helpers/protocols_helper_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe ProtocolsHelper, type: :helper do
     end
   end
 
-
-
   describe '#edit_protocol_button' do
     context 'in dashboard' do
       before(:each) { allow(helper).to receive(:in_dashboard?).and_return(true) }
@@ -73,7 +71,36 @@ RSpec.describe ProtocolsHelper, type: :helper do
     end
   end
 
+  describe '#push_to_oncore_button' do
+    before(:each) {
+      ActionView::Base.send(:define_method, :current_user) { FactoryBot.create(:identity, ldap_uid: "id@musc.edu") }
+      allow(helper).to receive(:in_dashboard?).and_return(true)
+    }
 
+    context 'with OnCore' do
+      stub_config("use_oncore", true)
+
+      context 'with permissions' do
+        stub_config("oncore_endpoint_access", ["id@musc.edu"])
+        it 'should render the button' do
+          expect(helper).to receive(:link_to).with(push_to_oncore_dashboard_protocol_path(protocol), any_args)
+          helper.push_to_oncore_button(protocol)
+        end
+      end
+
+      context 'without permissions' do
+        it 'should not render the button' do
+          expect(helper.push_to_oncore_button(protocol)).to be_nil
+        end
+      end
+    end
+
+    context 'without OnCore' do
+      it 'should not render the button' do
+        expect(helper.push_to_oncore_button(protocol)).to be_nil
+      end
+    end
+  end
 
   describe '#archive_protocol_button' do
     before(:each) { allow(helper).to receive(:in_dashboard?).and_return(true) }

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -28,4 +28,24 @@ RSpec.configure do |config|
     stub_request(:get, "https://sparcrequest.atlassian.net/wiki").
      to_return(status: 200, body: "")
   end
+
+  config.before(:each) do
+    stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
+    to_return(status: 201)
+  end
+
+  config.before(:each, remote_service: :unavailable) do
+    stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
+    to_return(status: 500)
+  end
+
+  config.before(:each) do |config|
+    stub_request(:post, "#{Setting.get_value("oncore_api")}/oncore-api/rest/protocols.json").
+      to_return(status: 201)
+  end
+
+  config.before(:each) do |config|
+    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token.json").
+      to_return(status: 200, body: { access_token: "some_token_value", expires_in: "300", token_type: "Bearer" }.to_json)
+  end
 end


### PR DESCRIPTION
[#171334725](https://www.pivotaltracker.com/story/show/171334725) (see story for full OnCore API specification documents)

Created an OnCore REST interface to push the minimum fields required to create a protocol in OnCore. The button to push from SPARC to OnCore is only displayed on studies in the dashboard to users who are listed in the `oncore_endpoint_access` setting if OnCore functionality is turned on. On a successful push, a flash message appears to say the study has been successfully pushed. If the protocol could not be created in SPARC, a Sweet Alert message appears saying the protocol could not be displayed and shows the response error code and message.

.env changes:

- `oncore_client_id=client_id_from_oncore` This needs to be set to the client ID that is generated by OnCore
- `oncore_client_secret=client_secret_from_oncore` This needs to be set to the client secret generated by OnCore. Since this is supposed to be a secure secret, I decided it would be better to store this as a .env variable instead of a setting in the database. Neither `oncore_client_id` or `oncore_client_secret` need to be set for institutions not using OnCore.

New setting:

- `oncore_api` should be set to the base URL of the OnCore instance for MUSC (or your institution).
- `oncore_default_department` Default OnCore field value for Primary PI's department if they don't have one.
- `oncore_default_library` Default OnCore field value for Library since nothing like this exists in SPARC.
- `oncore_default_organizational_unit` Default OnCore field value for Organizational Unit.
- `oncore_default_protocol_type` Default OnCore field value for Protocol Type.

Finally, I moved all of the spec REST request stubs that I could find to webmock.rb for organization.

Minimum footprint mapping from OnCore to SPARC:
![image](https://user-images.githubusercontent.com/19152930/91186013-805c6380-e6bc-11ea-9721-6806d9899720.png)
