### PR TITLE
Jl - Set All Indicated Visits to Default Quantity

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -65,7 +65,18 @@ class ProtocolsController < ApplicationController
   end
 
   def update_billing
-    @protocol.update_attributes(protocol_params)
+    @protocol.all_research_billing = protocol_params[:all_research_billing]
+    @protocol.save(validate: false)
+    @service_request = @protocol.service_requests.first
+    @tab = 'billing_strategy'
+    setup_calendar_pages
+    research_billing = @protocol.all_research_billing
+    @protocol.visits.each do |visit|
+      if visit.indicated? 
+        unit_minimum = visit.service.displayed_pricing_map.unit_minimum
+        visit.update_attributes(research_billing_qty: research_billing ? unit_minimum : 0, insurance_billing_qty: research_billing ? 0 : unit_minimum)
+      end
+    end
   end
 
   def update

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -71,8 +71,13 @@ class Visit < ApplicationRecord
     return self.visit_group.position
   end
 
+  #TODO It does not look like this is being used any longer.  
   def to_be_performed?
     self.research_billing_qty > 0
+  end
+
+  def indicated?
+    (research_billing_qty > 0 || insurance_billing_qty > 0)
   end
 
   ### audit reporting methods ###

--- a/app/views/protocols/update_billing.js.coffee
+++ b/app/views/protocols/update_billing.js.coffee
@@ -19,3 +19,5 @@
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 $('#modalContainer').modal('hide')
+
+$("#<%= @tab.camelize(:lower) %>Tab").html("<%= j render 'service_calendars/table', service_request: @service_request, sub_service_request: nil, tab: @tab, merged: false, consolidated: false, pages: @pages, page: @page %>").addClass('active show')


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/165912000

This is an enhancement requested to the above story that sets all visits already indicated (on all sub service requests) under a protocol to the default billing quantity when set. 

One quick note is that I changed this code `@protocol.update_attributes(protocol_params)` to just setting the billing attribute and saving without validation. At this point the protocol is already valid, the attribute being set will always have a value (it defaults to 'true'), and saving without validating ALL protocol fields saves the user about 10 seconds.

