### PR TITLE
Add few columns to Unique PI report

### DIFF
--- a/app/lib/reports/unique_pi.rb
+++ b/app/lib/reports/unique_pi.rb
@@ -60,11 +60,13 @@ class UniquePiReport < ReportingModule
 
     attrs["Unique PI Last Name"] = :last_name
     attrs["Unique PI First Name"] = :first_name
+    attrs["Email"] = :email
     attrs["Institution"] = "try(:professional_org_lookup, 'institution')"
     attrs["College"]     = "try(:professional_org_lookup, 'college')"
     attrs["Department"]  = "try(:professional_org_lookup, 'department')"
     attrs["Division"]    = "try(:professional_org_lookup, 'division')"
-
+    attrs["ERA Commons Name"] = :era_commons_name
+    attrs["orcid"] = :orcid
     attrs
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/170882861
Background:
Currently, the Unique PI report only shows the name and affiliation of PIs, without email information, which is causing it hard to use when service provider wants to maintain a client list for notifications.

Acceptance Criteria
Please add 3 new columns to the Unique PI report, Email, ERA Commons Name, ORCID.

Email is needed for communications purpose,
ERA Commons Name and ORCID can be used for publication tracking.