### PR TITLE
Add Division column to SPARC Account report

### DIFF
--- a/app/lib/reports/sparc_account.rb
+++ b/app/lib/reports/sparc_account.rb
@@ -45,8 +45,9 @@ class SPARCAccountReport < ReportingModule
     attrs["First Name"] = :first_name
     attrs["Email"] = :email
     attrs["Institution"] = "try(:professional_org_lookup, 'institution')"
-    attrs["College"] = "try(:professional_org_lookup, 'college')"
-    attrs["Department"] = "try(:professional_org_lookup, 'department')"
+    attrs["College"]     = "try(:professional_org_lookup, 'college')"
+    attrs["Department"]  = "try(:professional_org_lookup, 'department')"
+    attrs["Division"]    = "try(:professional_org_lookup, 'division')"
     attrs["Account Created Date"] = "self.created_at.try(:strftime, \"%D\")"
     attrs["ID"] = :id
     attrs["LDAP_UID"] = :ldap_uid


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/166271935

Background:
The SPARC Account report in the SPARCReport module is designed to export the SPARC accounts with related information that were created during a time frame.

Acceptance Criteria:
Please add "Division"column to show the user's affiliated division.