### PR TITLE
SAW - Protocol Request Access Changes

### DIFF
--- a/app/helpers/dashboard/protocols_helper.rb
+++ b/app/helpers/dashboard/protocols_helper.rb
@@ -70,16 +70,14 @@ module Dashboard::ProtocolsHelper
   end
 
   def display_requests_button(protocol, access)
-    if protocol.sub_service_requests.any?
-      if access
-        link_to(display_requests_dashboard_protocol_path(protocol), remote: true, class: 'btn btn-secondary protocol-requests') do
-          content_tag :span, class: 'd-flex align-items-center' do
-            raw(Protocol.human_attribute_name(:requests) + content_tag(:span, protocol.sub_service_requests_count, class: 'badge badge-pill badge-c badge-light ml-2'))
-          end
+    if protocol.sub_service_requests.any? && access
+      link_to(display_requests_dashboard_protocol_path(protocol), remote: true, class: 'btn btn-secondary protocol-requests') do
+        content_tag :span, class: 'd-flex align-items-center' do
+          raw(Protocol.human_attribute_name(:requests) + content_tag(:span, protocol.sub_service_requests_count, class: 'badge badge-pill badge-c badge-light ml-2'))
         end
-      else
-        render "dashboard/protocols/request_access_dropdown.html.haml", protocol: protocol
       end
+    elsif !access
+      render "dashboard/protocols/request_access_dropdown.html.haml", protocol: protocol
     end
   end
 

--- a/app/views/dashboard/protocols/_request_access_dropdown.html.haml
+++ b/app/views/dashboard/protocols/_request_access_dropdown.html.haml
@@ -20,9 +20,8 @@
 
 .dropdown.no-caret
   %div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'left', title: t("dashboard.protocols.table.tooltips.request_access") } }
-    %button.btn.btn-secondary.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' } }<
-      = Protocol.human_attribute_name(:requests)
-      = icon('fas', 'exclamation-circle ml-1')
+    %button.btn.btn-primary.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' } }<
+      = t("dashboard.protocols.table.request_access")
     .dropdown-menu{ aria: { labelledby: 'newProtocolButton' } }
       - protocol.project_roles.includes(:identity).order("identities.first_name", "identities.last_name").each do |pr|
         = link_to display_authorized_user(pr), request_access_dashboard_protocol_path(protocol, recipient_id: pr.identity.id), remote: true, class: 'dropdown-item'

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -158,13 +158,14 @@ en:
         header: "Protocols"
         short_title: "Short Title"
         request_sent: "Request to access protocol %{protocol_id} sent!"
+        request_access: "Request Access"
         tooltips:
           protocol_id: "System generated from SPARCRequest"
           short_title: "An abbreviated form of the title used to identify your study/project. Special characters outside the allowed range will be removed automatically."
           pi: "Principal Investigator(s)"
           export: "Export displayed protocols to Excel"
           requests: "Quick access to requests"
-          request_access: "Request access to this protocol"
+          request_access: "Request access to this protocol from a selected authorized user"
 
       service_requests:
         header: "Requests - %{status} - %{date}"

--- a/spec/helpers/protocols_helper_spec.rb
+++ b/spec/helpers/protocols_helper_spec.rb
@@ -21,7 +21,7 @@
 require 'rails_helper'
 
 RSpec.describe ProtocolsHelper, type: :helper do
-  let!(:protocol) { create(:study_federally_funded) }
+  let!(:protocol) { create(:study_federally_funded, primary_pi: create(:identity)) }
 
   describe '#protocol_details_button' do
     context 'in dashboard' do
@@ -115,6 +115,34 @@ RSpec.describe ProtocolsHelper, type: :helper do
     context 'without permissions' do
       it 'should not render the button' do
         expect(helper.archive_protocol_button(protocol, permission: false)).to be_nil
+      end
+    end
+  end
+
+  describe '#display_requests_button' do
+    context 'with access' do
+      it 'should render Requests button with service requests' do
+        sr = create(:service_request_without_validations, protocol: protocol)
+        create(:sub_service_request_with_organization, service_request: sr, protocol: protocol)
+        expect(helper).to receive(:link_to).with(display_requests_dashboard_protocol_path(protocol), any_args)
+        helper.display_requests_button(protocol, true)
+      end
+
+      it 'should not render any button without service requests' do
+        expect(helper.display_requests_button(protocol, true)).to be_nil
+      end
+    end
+
+    context 'without access' do
+      it 'should render the Request Access button with service requests' do
+        create(:service_request_without_validations, protocol: protocol)
+        expect(helper).to receive(:link_to).with(anything, request_access_dashboard_protocol_path(protocol, recipient_id: 1), any_args)
+        helper.display_requests_button(protocol, false)
+      end
+
+      it 'should render the Request Access button without service requests' do
+        expect(helper).to receive(:link_to).with(anything, request_access_dashboard_protocol_path(protocol, recipient_id: 1), any_args)
+        helper.display_requests_button(protocol, false)
       end
     end
   end


### PR DESCRIPTION
[#171789989](https://www.pivotaltracker.com/story/show/171789989)

- Changed the "Request Access" button to be noticeably different from the "Requests" button with a more helpful tooltip:

<img width="980" alt="image" src="https://user-images.githubusercontent.com/19152930/91903749-bf1c8b80-ec71-11ea-97b1-d04853490004.png">

- Also made it so that the "Request Access" button will be displayed on all protocols a user does not have access to in the dashboard, regardless of whether or not the protocol has services.

- Added some specs to test the logic of this button.