### PR TITLE
SAW - Added logger to OnCore REST API

### DIFF
--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -54,6 +54,7 @@ class OncoreProtocol
                                   protocolType: self.protocol_type
                                 }.to_json)
       log_request_and_response(response, true)
+      return response
     else
       return auth_response
     end


### PR DESCRIPTION
[#171334725](https://www.pivotaltracker.com/story/show/171334725)

This _does not_ solve the 404 error in -d when trying to push a protocol to OnCore. However, having a logger that does not expose authentication information is helpful for understanding why a protocol may not make it to OnCore when pushed, especially since there is a firewall preventing outside requests without authorization. I decided against using HTTParty's default logger because it exposes all headers and request bodies, and the fewer times a client secret is printed (even in log files), the better. The default is also verbose and not very readable.