### PR TITLE
KG - Prevent Form Multi-Submission During Modal Hide Animation

### DIFF
--- a/app/assets/javascripts/custom/bootstrap-custom.es6
+++ b/app/assets/javascripts/custom/bootstrap-custom.es6
@@ -22,6 +22,16 @@
   $.extend($.fn.modal.Constructor.Default, { backdrop: 'static' });
 
   $(document).ready( function() {
+    // Prevent form multi-submit during a modal closing
+    // by stopping Rails remote requests during a modal transitioning
+    $(document).on('ajax:beforeSend', '.modal form', event => {
+      $modal = $(event.target).parents('.modal')
+      console.log($modal.data('bs.modal')._isTransitioning)
+      if ($modal.data('bs.modal')._isTransitioning)
+        event.preventDefault()
+        event.stopImmediatePropagation()
+    })
+
     // Allow popovers to be closed via an optional close button
     $(document).on('click', '.popover .close', event => {
       event.preventDefault();

--- a/app/assets/javascripts/custom/bootstrap-custom.es6
+++ b/app/assets/javascripts/custom/bootstrap-custom.es6
@@ -26,7 +26,6 @@
     // by stopping Rails remote requests during a modal transitioning
     $(document).on('ajax:beforeSend', '.modal form', event => {
       $modal = $(event.target).parents('.modal')
-      console.log($modal.data('bs.modal')._isTransitioning)
       if ($modal.data('bs.modal')._isTransitioning)
         event.preventDefault()
         event.stopImmediatePropagation()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174540082

### Context
When a form is submitted, Rails immediately disables the button used to submit, processes the request, then re-enables the button when the request is completed (`ajax:complete` event is fired). However in the case of modals, the `ajax:complete` event is fired while the modal is still transitioning from visible to hidden. This gives only the most insurmountably impatient of users a split second window of time where the submit button can be re-pressed during the animation by aggressively spam-clicking after the initial submission. To prevent this, I added a check that, when pre-sending a form submission from a form in a modal, if that modal is currently transitioning, stop the request. This seems to prevent the above scenario. This impacts all forms in SPARCRequest contained within a modal.