### PR TITLE
SAW - OnCore REST API changes

### DIFF
--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -30,7 +30,7 @@ class OncoreProtocol
     self.title               = study.title
     self.short_title         = study.short_title
     self.library             = Setting.get_value("oncore_default_library")
-    self.department          = study.primary_pi.professional_organization.try(:department) || Setting.get_value("oncore_default_department")
+    self.department          = study.primary_pi.professional_organization.try(:department_name) || Setting.get_value("oncore_default_department")
     self.organizational_unit = Setting.get_value("oncore_default_organizational_unit")
     self.protocol_type       = Setting.get_value("oncore_default_protocol_type")
   end

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -39,21 +39,22 @@ class OncoreProtocol
     auth_response = self.authenticate
     if auth_response.success?
     # Assumes that the push will fail if it already exists in OnCore, need to confirm
-      response = self.class.post('/oncore-api/rest/protocols.json',
+      response = self.class.post('/oncore-api/rest/protocols',
                                 headers: {
+                                  'Accept' => 'application/json',
                                   'Content-Type' => 'application/json',
                                   'Authorization' => self.auth
                                 },
                                 body: {
                                   protocolNo: self.protocol_no,
                                   title: self.title,
-                                  short_title: self.short_title,
+                                  shortTitle: self.short_title,
                                   library: self.library,
                                   department: self.department,
                                   organizationalUnit: self.organizational_unit,
                                   protocolType: self.protocol_type
                                 }.to_json)
-      log_request_and_response(response, true)
+      log_request_and_response(response)
       return response
     else
       return auth_response
@@ -61,24 +62,23 @@ class OncoreProtocol
   end
 
   def authenticate
-    response = self.class.post('/forte-platform-web/api/oauth/token.json',
+    response = self.class.post('/forte-platform-web/api/oauth/token',
                               headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' },
                               body: {
                                 client_id: ENV.fetch('oncore_client_id'),
                                 client_secret: ENV.fetch('oncore_client_secret'),
                                 grant_type: 'client_credentials'
                               }.to_json)
-    log_request_and_response(response)
 
     if response.success?
-      self.auth = "Bearer " + JSON.parse(response)['access_token']
+      self.auth = "Bearer " + JSON.parse(response.body)['access_token']
     end
 
     return response
   end
 
-  # Log requests and responses without exposing any authentication information
-  def log_request_and_response(response, show_request_body=false)
+  # Log requests and responses without exposing any authentication information in headers
+  def log_request_and_response(response)
     request = response.request
 
     # Use the OnCore logger, it's easier than digging through the Rails logger
@@ -89,9 +89,7 @@ class OncoreProtocol
     logger.info "OnCore REST request ---------- Timestamp: #{DateTime.now.to_formatted_s(:long)}"
     logger.info "URI: " + request.uri.to_s
     logger.info "HTTP method: " + request.http_method.to_s
-    if show_request_body
-      logger.info "Request Body:\n" + request.raw_body
-    end
-    logger.info "Response: " + response.to_s
+    logger.info "Request Body:\n" + request.raw_body
+    logger.info "Response:\n" + response.to_s
   end
 end

--- a/app/models/professional_organization.rb
+++ b/app/models/professional_organization.rb
@@ -61,7 +61,7 @@ class ProfessionalOrganization < ApplicationRecord
     ProfessionalOrganization.where(parent_id: parent_id)
   end
 
-  def department
+  def department_name
     return self.parent.name if self.org_type == 'division'
     return self.name if self.org_type == 'department'
     return nil

--- a/app/models/professional_organization.rb
+++ b/app/models/professional_organization.rb
@@ -62,8 +62,8 @@ class ProfessionalOrganization < ApplicationRecord
   end
 
   def department
-    return self.parent if self.org_type == 'division'
-    return self if self.org_type == 'department'
+    return self.parent.name if self.org_type == 'division'
+    return self.name if self.org_type == 'department'
     return nil
   end
 end

--- a/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
+++ b/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'User pushes a study to OnCore', js: true do
   stub_config("use_oncore", true)
   stub_config("oncore_endpoint_access", ['jug2'])
 
-  let(:auth_path) { "/forte-platform-web/api/oauth/token.json" }
-  let(:create_protocol_path) { "/oncore-api/rest/protocols.json" }
+  let(:auth_path) { "/forte-platform-web/api/oauth/token" }
+  let(:create_protocol_path) { "/oncore-api/rest/protocols" }
 
   before :each do
     study = create(:study_federally_funded, primary_pi: jug2)

--- a/spec/lib/oncore_protocol_spec.rb
+++ b/spec/lib/oncore_protocol_spec.rb
@@ -22,8 +22,8 @@ require "rails_helper"
 
 RSpec.describe OncoreProtocol do
 
-  let(:auth_path) { "/forte-platform-web/api/oauth/token.json" }
-  let(:create_protocol_path) { "/oncore-api/rest/protocols.json" }
+  let(:auth_path) { "/forte-platform-web/api/oauth/token" }
+  let(:create_protocol_path) { "/oncore-api/rest/protocols" }
 
   before :each do
     pi = create(:identity)

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -31,10 +31,10 @@ RSpec.configure do |config|
     stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
       to_return(status: 201)
 
-    stub_request(:post, "#{Setting.get_value("oncore_api")}/oncore-api/rest/protocols.json").
+    stub_request(:post, "#{Setting.get_value("oncore_api")}/oncore-api/rest/protocols").
       to_return(status: 201)
 
-    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token.json").
+    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token").
       to_return(status: 200, body: { access_token: "some_token_value", expires_in: "300", token_type: "Bearer" }.to_json)
   end
 
@@ -42,7 +42,7 @@ RSpec.configure do |config|
     stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
       to_return(status: 500)
 
-    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token.json").
+    stub_request(:post, "#{Setting.get_value("oncore_api")}/forte-platform-web/api/oauth/token").
       to_return(status: 500)
   end
 end


### PR DESCRIPTION
[#171334725](https://www.pivotaltracker.com/story/show/171334725)

- Changed the logger to no longer log authentication requests in any environment, mainly to avoid additional bloat in the OnCore log
- Removed `.json` from paths in requests, those seemed to cause errors.
- Changed `short_title` in body to `shortTitle` to be consistent with documentation
- ProfessionalOrganization#department(_name) now returns department name instead of a department object. OnCore needs a string of the department name, not an object.
- Updated specs to reflect changes.

These changes resulted in a 403: Forbidden error with message "User does not have access to the requested resource." I believe this is due to me attempting to push a protocol to OnCore from my localhost server instead of from -d. 