### PR TITLE
SAW - Prot. Request Access Tooltip Covering Dropdown

### DIFF
--- a/app/views/dashboard/protocols/_request_access_dropdown.html.haml
+++ b/app/views/dashboard/protocols/_request_access_dropdown.html.haml
@@ -18,10 +18,10 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-.dropdown.no-caret
-  %div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'left', title: t("dashboard.protocols.table.tooltips.request_access") } }
-    %button.btn.btn-primary.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' } }<
+%div.tooltip-wrapper{ data: { toggle: 'tooltip', placement: 'top', boundary: 'window', title: t("dashboard.protocols.table.tooltips.request_access") } }
+  .dropdown.no-caret  
+    %button.btn.btn-primary.dropdown-toggle{ type: 'button', data: { toggle: 'dropdown', placement: 'bottom', container: 'body', boundary: 'window' }, aria: { haspopup: 'true', expanded: 'false' } }<
       = t("dashboard.protocols.table.request_access")
-    .dropdown-menu{ aria: { labelledby: 'newProtocolButton' } }
+    .dropdown-menu.dropdown-menu-right{ aria: { labelledby: 'newProtocolButton' } }
       - protocol.project_roles.includes(:identity).order("identities.first_name", "identities.last_name").each do |pr|
         = link_to display_authorized_user(pr), request_access_dashboard_protocol_path(protocol, recipient_id: pr.identity.id), remote: true, class: 'dropdown-item'


### PR DESCRIPTION
[#171789989](https://www.pivotaltracker.com/story/show/171789989)

Fixed the issue of the tooltip covering dropdown options by making the tooltip always open above the button and dropdown always open below the button.