### PR TITLE
SAW - OnCore minimum footprint push

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -199,7 +199,11 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
       if response.success?
         flash[:success] = I18n.t('protocols.summary.oncore.pushed_to_oncore')
       else
-        @http_error = "#{response.code}: #{response.message}"
+        if response['message'].try(:include?, ('already exists'))
+          @error = t('protocols.summary.oncore.already_exists', protocol_id: @protocol.id)
+        else
+          @error = "#{response.code}: #{response.message}"
+        end
       end
     end
 

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -30,7 +30,7 @@ class OncoreProtocol
     self.title               = study.title
     self.short_title         = study.short_title
     self.library             = Setting.get_value("oncore_default_library")
-    self.department          = study.primary_pi.professional_organization.try(:department_name) || Setting.get_value("oncore_default_department")
+    self.department          = (study.primary_pi.professional_organization.try(:department_name) || Setting.get_value("oncore_default_department")).upcase
     self.organizational_unit = Setting.get_value("oncore_default_organizational_unit")
     self.protocol_type       = Setting.get_value("oncore_default_protocol_type")
   end

--- a/app/views/dashboard/protocols/push_to_oncore.js.coffee
+++ b/app/views/dashboard/protocols/push_to_oncore.js.coffee
@@ -18,11 +18,11 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-<% if @http_error %>
+<% if @error %>
 AlertSwal.fire(
   type: 'error'
   title: I18n.t('protocols.summary.oncore.error')
-  text: "<%= @http_error %>"
+  text: "<%= @error %>"
 )
 <% else %>
 $("#flashContainer").replaceWith("<%= j render 'layouts/flash' %>")

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -661,7 +661,7 @@
   },
   {
     "key":            "oncore_default_department",
-    "value":          "Other",
+    "value":          "OTHER",
     "friendly_name":  "OnCore Department Default Value",
     "description":    "Default value for Primary PI's Department field when pushing studies to OnCore.",
     "group":          "",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -803,6 +803,7 @@ en:
         push_to_oncore: "Push to OnCore"
         pushed_to_oncore: "Study Pushed to OnCore!"
         error: "Unable to push Study to OnCore"
+        already_exists: "Study %{protocol_id} already exists in OnCore."
       tooltips:
         notes: "Protocol notes viewable to Administrators and Authorized Users"
         details: "Quick access to protocol information"

--- a/spec/lib/oncore_protocol_spec.rb
+++ b/spec/lib/oncore_protocol_spec.rb
@@ -24,11 +24,18 @@ RSpec.describe OncoreProtocol do
 
   let(:auth_path) { "/forte-platform-web/api/oauth/token" }
   let(:create_protocol_path) { "/oncore-api/rest/protocols" }
+  stub_config 'oncore_default_department', 'Other' #force setting to not be all caps to make sure department is capitalized
 
   before :each do
     pi = create(:identity)
     study = create(:study_federally_funded, primary_pi: pi)
     @oncore_protocol = OncoreProtocol.new(study)
+  end
+
+  describe '#initialize' do
+    it 'should upcase the department to match OnCore' do
+      expect(@oncore_protocol.department).to eq("OTHER")
+    end
   end
 
   describe '#create_oncore_protocol' do


### PR DESCRIPTION
[#171334725](https://www.pivotaltracker.com/story/show/171334725)

Made it so the department name will be all uppercase letters to match OnCore's department list. It's a required field for pushing protocols to OnCore and it's case sensitive, if the department is "Medicine" and not "MEDICINE", the protocol will not be created in OnCore.

Also added better error parsing so that when a protocol has already been pushed to OnCore, a readable error is displayed:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/19152930/92785630-92edc280-f375-11ea-990d-3450fdf3b8cd.png">
