### PR TITLE
SJ - Protocol Merge Bug

### DIFF
--- a/app/lib/dashboard/merge_srs.rb
+++ b/app/lib/dashboard/merge_srs.rb
@@ -23,7 +23,7 @@ module Dashboard
   class MergeSrs
 
     def perform_sr_merge
-      ServiceRequest.skip_callback(:save, :after, :set_original_submitted_date)
+      ServiceRequest.skip_callback(:save, :after, :set_original_submitted_date, raise: false)
 
       protocols = Protocol.joins(:service_requests).group('protocols.id').having('count(protocol_id) >= 2').to_a
       protocols.each do |protocol|


### PR DESCRIPTION
fixing bug where after the first call to skip callbacks, it would throw an exception, this is a known issue with skip_callbacks, and adding the raise: false is the accepted solution.

[#174823479]

https://www.pivotaltracker.com/story/show/174823479