### PR TITLE
KG - Fix Visit Group Changing Page / Tiny Calendar Style

### DIFF
--- a/app/assets/stylesheets/service_calendar.scss
+++ b/app/assets/stylesheets/service_calendar.scss
@@ -57,6 +57,10 @@
       }
     }
 
+    &> thead > tr:last-child> th::before {
+      bottom: -1px;
+    }
+
     tbody th:first-child, tbody td:first-child {
       border-left: 0;
     }

--- a/app/controllers/service_requests_controller.rb
+++ b/app/controllers/service_requests_controller.rb
@@ -103,7 +103,7 @@ class ServiceRequestsController < ApplicationController
     # step.
     @pages = {}
     @service_request.arms.each do |arm|
-      @pages[arm.id] = 1
+      @pages[arm.id.to_s] = 1
     end
   end
 

--- a/app/controllers/visit_groups_controller.rb
+++ b/app/controllers/visit_groups_controller.rb
@@ -79,7 +79,7 @@ class VisitGroupsController < ApplicationController
 
     setup_calendar_pages
 
-    @position_changed = @visit_group.position != visit_group_params[:position].to_i
+    @position_changed = @visit_group.position != visit_group_params[:position].to_i + 1
 
     if @visit_group.update_attributes(visit_group_params)
       flash[:success] = t('visit_groups.updated')

--- a/app/lib/dashboard/service_calendars.rb
+++ b/app/lib/dashboard/service_calendars.rb
@@ -27,7 +27,7 @@ module Dashboard
     extend ActionView::Helpers::NumberHelper
 
     def self.generate_visit_navigation(arm, service_request, pages, tab, portal=nil, ssr_id=nil)
-      page = pages[arm.id].to_i == 0 ? 1 : pages[arm.id].to_i
+      page = pages[arm.id.to_s].to_i == 0 ? 1 : pages[arm.id.to_s].to_i
 
       path_method = if @merged
         method(:merged_calendar_service_request_service_calendars_path)

--- a/app/views/dashboard/sub_service_requests/_view_modal.html.haml
+++ b/app/views/dashboard/sub_service_requests/_view_modal.html.haml
@@ -30,7 +30,7 @@
 
       - if sub_service_request.has_per_patient_per_visit_services?
         - service_request.arms.select{ |arm| arm.visit_groups.any? }.each do |arm|
-          = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, merged: merged, consolidated: consolidated
+          = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id.to_s, pages: pages, merged: merged, consolidated: consolidated
 
       - if sub_service_request.has_one_time_fee_services?
         = render 'service_calendars/master_calendar/otf/otf_calendar', service_request: service_request, sub_service_request: sub_service_request, merged: merged, consolidated: consolidated

--- a/app/views/dashboard/sub_service_requests/_view_modal.html.haml
+++ b/app/views/dashboard/sub_service_requests/_view_modal.html.haml
@@ -30,7 +30,7 @@
 
       - if sub_service_request.has_per_patient_per_visit_services?
         - service_request.arms.select{ |arm| arm.visit_groups.any? }.each do |arm|
-          = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id.to_s, pages: pages, merged: merged, consolidated: consolidated
+          = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id.to_s], pages: pages, merged: merged, consolidated: consolidated
 
       - if sub_service_request.has_one_time_fee_services?
         = render 'service_calendars/master_calendar/otf/otf_calendar', service_request: service_request, sub_service_request: sub_service_request, merged: merged, consolidated: consolidated

--- a/app/views/service_calendars/_view_full_calendar.html.haml
+++ b/app/views/service_calendars/_view_full_calendar.html.haml
@@ -36,7 +36,7 @@
 
       - if has_pppv = service_request.has_per_patient_per_visit_services?
         - service_request.arms.select{ |arm| arm.visit_groups.any? }.each do |arm|
-          = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id], pages: pages, merged: merged, consolidated: consolidated
+          = render 'service_calendars/master_calendar/pppv/pppv_calendar', tab: tab, arm: arm, service_request: service_request, sub_service_request: sub_service_request, page: pages[arm.id.to_s], pages: pages, merged: merged, consolidated: consolidated
 
       - if has_otf = service_request.has_one_time_fee_services? 
         = render 'service_calendars/master_calendar/otf/otf_calendar', service_request: service_request, sub_service_request: sub_service_request, merged: merged, consolidated: consolidated


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170546216

* Changing pages did not properly re-render the calendar and update the page because the position provided to the controller is always 1 less than the actual position (due to being a "insert **before**")
* Because the pages hash is passed with string keys instead of integer keys, the code assigning pages had to be rewritten to use the arm_id as a string. Some places were missed previously, causing 500 errors.
* Also fixed a tiny tiny bug where the bottom of the bottom-most header row on the service calendar was 1px off and created 1px of extra whitespace (See screenshot)

![image](https://user-images.githubusercontent.com/12898988/93522572-b083d480-f8ff-11ea-88a2-a5437b644f5e.png)
