### PR TITLE
KG - Remove limit on Visit Group popover

### DIFF
--- a/app/assets/stylesheets/service_calendar.scss
+++ b/app/assets/stylesheets/service_calendar.scss
@@ -136,6 +136,8 @@
 }
 
 .visit-group-popover {
+  max-width: unset;
+
   .change-visit-btn {
     margin-top: -0.5rem;
 


### PR DESCRIPTION
The main issue here is really really long visit group names. Selectpicker's overflow is really weird and doesn't seem to properly size via a percentage (ie fit to 100% of container for the popover). I tried other ways of messing with the CSS but so far this is the only solution I could come up with.
![image](https://user-images.githubusercontent.com/12898988/93911575-93b91980-fcd0-11ea-8983-2f584e047a98.png)
