### PR TITLE
Jl - Duplicate Protocol Bug

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -40,6 +40,12 @@ class ProtocolsController < ApplicationController
 
       @protocol.service_requests << @service_request
       @service_request.sub_service_requests.each{ |ssr| @protocol.sub_service_requests << ssr }
+      recent_protocol = Protocol.last
+      # We have a duplicate situation and must delete (need to save the service request) 
+      # the most recent protocol for the new one
+      if recent_protocol.service_requests.first.id == @protocol.service_requests.first.id
+        recent_protocol.delete
+      end
       @protocol.save
       @service_request.update_status('draft', current_user)
 

--- a/app/views/protocols/create.js.coffee
+++ b/app/views/protocols/create.js.coffee
@@ -60,4 +60,6 @@ if $('.is-invalid').length
   $('html, body').animate({ scrollTop: $('.is-invalid').first().offset().top }, 'slow')
 <% else %>
 window.location = "<%= protocol_service_request_path(srid: @service_request.id) %>"
+$('.protocol-save-btn').removeAttr('data-disable-with')
+$('.protocol-save-btn').prop('disabled', true)
 <% end %>

--- a/app/views/protocols/form/_footer.html.haml
+++ b/app/views/protocols/form/_footer.html.haml
@@ -28,6 +28,6 @@
       = link_to back_url, class: 'btn btn-lg btn-link px-0' do
         - succeed t('actions.cancel') do
           = icon('fas', 'arrow-left mr-2')
-      = f.button type: 'submit', class: 'btn btn-lg btn-outline-success float-right', data: { disable_with: t(:proper)[:navigation][:bottom][:saving] } do
+      = f.button type: 'submit', class: 'btn btn-lg btn-outline-success float-right protocol-save-btn', data: { disable_with: t(:proper)[:navigation][:bottom][:saving] } do
         - succeed icon('fas', 'arrow-right ml-2') do
           = t('actions.save')

--- a/spec/features/proper/protocol/protocols/user_adds_irb_records_spec.rb
+++ b/spec/features/proper/protocol/protocols/user_adds_irb_records_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'User wants to make a new Study with IRB Records', js: true do
   build_study_type_questions
 
   before :each do
+    protocol  = create(:protocol_federally_funded, primary_pi: jug2)
+    create(:service_request_without_validations, protocol: protocol)
     org     = create(:organization, name: "Program", process_ssrs: true, pricing_setup_count: 1)
     service = create(:service, name: "Service", abbreviation: "Service", organization: org, pricing_map_count: 1)
     @sr     = create(:service_request_without_validations, status: 'first_draft')

--- a/spec/features/proper/protocol/protocols/user_creates_project_spec.rb
+++ b/spec/features/proper/protocol/protocols/user_creates_project_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'User creates project', js: true do
   stub_config("use_epic", true)
 
   before :each do
+    protocol  = create(:protocol_federally_funded, primary_pi: jug2)
+    create(:service_request_without_validations, protocol: protocol)
     org     = create(:organization, name: "Program", process_ssrs: true, pricing_setup_count: 1)
     service = create(:service, name: "Service", abbreviation: "Service", organization: org, pricing_map_count: 1)
     @sr     = create(:service_request_without_validations, status: 'first_draft')

--- a/spec/features/proper/protocol/protocols/user_creates_study_spec.rb
+++ b/spec/features/proper/protocol/protocols/user_creates_study_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'User creates study', js: true do
   stub_config("use_epic", true)
 
   before :each do
+    protocol  = create(:protocol_federally_funded, primary_pi: jug2)
+    create(:service_request_without_validations, protocol: protocol)
     org     = create(:organization, name: "Program", process_ssrs: true, pricing_setup_count: 1)
     service = create(:service, name: "Service", abbreviation: "Service", organization: org, pricing_map_count: 1)
     @sr     = create(:service_request_without_validations, status: 'first_draft')


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/174973408

This bug was happening in two ways:

1) After saving a protocol, the user can use the browser back button to return to the protocol form. After saving again, a new protocol is created with the service request and sub service request being transferred to the new one, leaving the original protocol as an empty one. This was solved by deleting the original and keeping the new, because the user could have entered new or different information on the protocol form.

2) After saving the protocol form, there is a redirect which goes to the protocol's service request path which re-enables the save button, allowing the user to click again which was creating another protocol in a similar manner to bullet point #1. This was solved by disabling the button again after the redirect.