### PR TITLE
SAW - Changed Epic Root for component4

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -160,10 +160,20 @@
     "parent_value":   "true"
   },
   {
-    "key":            "epic_study_root",
-    "value":          "1.2.3.4",
-    "friendly_name":  "Epic Study Root",
+    "key":            "epic_study_rsh_root",
+    "value":          "1.2.5.2.3.4",
+    "friendly_name":  "Epic RHS Study Root",
     "description":    "This is the root URL of your institution's Epic API.",
+    "group":          "epic_settings",
+    "version":        "",
+    "parent_key":     "use_epic",
+    "parent_value":   "true"
+  },
+  {
+    "key":            "epic_study_prl_root",
+    "value":          "3.2.4.4.5",
+    "friendly_name":  "Epic PRL Study Root",
+    "description":    "This is the root URL of your institution's Epic API used in Arm (component4) SOAP message segments.",
     "group":          "epic_settings",
     "version":        "",
     "parent_key":     "use_epic",

--- a/db/migrate/20200925173318_rename_epic_study_root_setting.rb
+++ b/db/migrate/20200925173318_rename_epic_study_root_setting.rb
@@ -1,0 +1,7 @@
+class RenameEpicStudyRootSetting < ActiveRecord::Migration[5.2]
+  def change
+    if epic_study_root = Setting.find_by_key('epic_study_root')
+      epic_study_root.update_attribute('key', 'epic_study_rsh_root')
+    end
+  end
+end

--- a/lib/epic_interface.rb
+++ b/lib/epic_interface.rb
@@ -59,7 +59,8 @@ class EpicInterface
     @errors = {}
 
     @namespace = @config['epic_namespace'] || 'urn:ihe:qrph:rpe:2009'
-    @study_root = @config['epic_study_root'] || 'UNCONFIGURED'
+    @study_rsh_root = @config['epic_study_rsh_root'] || 'UNCONFIGURED'
+    @study_prl_root = @config['epic_study_prl_root'] || 'UNCONFIGURED'
 
     # We must set namespace_identifier to nil here, in order to prevent
     # Savon from prepending a wsdl: prefix to the
@@ -143,11 +144,11 @@ class EpicInterface
   def full_study_message(study)
     xml = Builder::XmlMarkup.new(indent: 2)
 
-    xml.query(root: @study_root, extension: "STUDY#{study.id}")
+    xml.query(root: @study_rsh_root, extension: "STUDY#{study.id}")
 
     xml.protocolDef {
       xml.plannedStudy(xmlns: 'urn:hl7-org:v3', classCode: 'CLNTRL', moodCode: 'DEF') {
-        xml.id(root: @study_root, extension: "STUDY#{study.id}")
+        xml.id(root: @study_rsh_root, extension: "STUDY#{study.id}")
         xml.title study.epic_title
         xml.text study.brief_description
 
@@ -172,11 +173,11 @@ class EpicInterface
   def study_creation_message(study)
     xml = Builder::XmlMarkup.new(indent: 2)
 
-    xml.query(root: @study_root, extension: "STUDY#{study.id}")
+    xml.query(root: @study_rsh_root, extension: "STUDY#{study.id}")
 
     xml.protocolDef {
       xml.plannedStudy(xmlns: 'urn:hl7-org:v3', classCode: 'CLNTRL', moodCode: 'DEF') {
-        xml.id(root: @study_root, extension: "STUDY#{study.id}")
+        xml.id(root: @study_rsh_root, extension: "STUDY#{study.id}")
         xml.title study.epic_title
         xml.text study.brief_description
 
@@ -321,11 +322,11 @@ class EpicInterface
   def study_calendar_definition_message(study)
     xml = Builder::XmlMarkup.new(indent: 2)
 
-    xml.query(root: @study_root, extension: "STUDY#{study.id}")
+    xml.query(root: @study_rsh_root, extension: "STUDY#{study.id}")
 
     xml.protocolDef {
       xml.plannedStudy(xmlns: 'urn:hl7-org:v3', classCode: 'CLNTRL', moodCode: 'DEF') {
-        xml.id(root: @study_root, extension: "STUDY#{study.id}")
+        xml.id(root: @study_rsh_root, extension: "STUDY#{study.id}")
         xml.title study.epic_title
         xml.text study.brief_description
 
@@ -356,7 +357,7 @@ class EpicInterface
 
       xml.component4(typeCode: 'COMP') {
         xml.timePointEventDefinition(classCode: 'CTTEVENT', moodCode: 'DEF') {
-          xml.id(root: @study_root, extension: "STUDY#{study.id}.ARM#{arm.id}")
+          xml.id(root: @study_prl_root, extension: "STUDY#{study.id}.ARM#{arm.id}")
           xml.title(arm.name)
           xml.code(code: 'CELL', codeSystem: 'n/a')
 
@@ -366,7 +367,7 @@ class EpicInterface
             xml.sequenceNumber(value: seq)
 
             xml.timePointEventDefinition(classCode: 'CTTEVENT', moodCode: 'DEF') {
-              xml.id(root: @study_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}")
+              xml.id(root: @study_rsh_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}")
               xml.title("Cycle #{cycle}")
               xml.code(code: 'CYCLE', codeSystem: 'n/a')
 
@@ -382,7 +383,7 @@ class EpicInterface
                 xml.component1(typeCode: 'COMP') {
                   xml.sequenceNumber(value: visit_group.position)
                   xml.timePointEventDefinition(classCode: 'CTTEVENT', moodCode: 'DEF') {
-                    xml.id(root: @study_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}.DAY#{visit_group.position}")
+                    xml.id(root: @study_rsh_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}.DAY#{visit_group.position}")
                     xml.title(visit_group.name)
                   }
                 }
@@ -404,7 +405,7 @@ class EpicInterface
 
         xml.component4(typeCode: 'COMP') {
           xml.timePointEventDefinition(classCode: 'CTTEVENT', moodCode: 'DEF') {
-            xml.id(root: @study_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}.DAY#{visit_group.position}")
+            xml.id(root: @study_prl_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}.DAY#{visit_group.position}")
             xml.title(visit_group.name)
             xml.code(code: 'VISIT', codeSystem: 'n/a')
 
@@ -456,7 +457,7 @@ class EpicInterface
           # TODO: there's nowhere in this message to put the quantity
           xml.component1(typeCode: 'COMP') {
             xml.timePointEventDefinition(classCode: 'CTTEVENT', moodCode: 'DEF') {
-              xml.id(root: @study_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}.DAY#{visit_group.position}.PROC#{line_item.id}")
+              xml.id(root: @study_rsh_root, extension: "STUDY#{study.id}.ARM#{arm.id}.CYCLE#{cycle}.DAY#{visit_group.position}.PROC#{line_item.id}")
               xml.code(code: 'PROC', codeSystem: service_code_system)
 
               xml.component2(typeCode: 'COMP') {

--- a/spec/extensions/epic_interface_spec.rb
+++ b/spec/extensions/epic_interface_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe EpicInterface do
   let!(:epic_interface) {
     EpicInterface.new(
         'epic_wsdl' => "http://localhost:#{server.port}/wsdl",
-        'epic_study_root' => '1.2.3.4')
+        'epic_study_rsh_root' => '1.2.5.2.3.4',
+        'epic_study_prl_root' => '3.2.4.4.5')
   }
 
   build_study_type_question_groups
@@ -1072,10 +1073,10 @@ RSpec.describe EpicInterface do
       # base study creation message
       xml = <<-END
         <RetrieveProtocolDefResponse xmlns="urn:ihe:qrph:rpe:2009">
-          <query root="1.2.3.4" extension="STUDY#{study.id}"/>
+          <query root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
           <protocolDef>
             <plannedStudy xmlns="urn:hl7-org:v3" classCode="CLNTRL" moodCode="DEF">
-              <id root="1.2.3.4" extension="STUDY#{study.id}"/>
+              <id root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
               <title>#{study.epic_title}</title>
               <text>#{study.brief_description}</text>
             </plannedStudy>
@@ -1112,10 +1113,10 @@ RSpec.describe EpicInterface do
       # base study creation message
       xml = <<-END
         <RetrieveProtocolDefResponse xmlns="urn:ihe:qrph:rpe:2009">
-          <query root="1.2.3.4" extension="STUDY#{study.id}"/>
+          <query root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
           <protocolDef>
             <plannedStudy xmlns="urn:hl7-org:v3" classCode="CLNTRL" moodCode="DEF">
-              <id root="1.2.3.4" extension="STUDY#{study.id}"/>
+              <id root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
               <title>#{study.epic_title}</title>
               <text>#{study.brief_description}</text>
             </plannedStudy>
@@ -1151,21 +1152,21 @@ RSpec.describe EpicInterface do
 
       xml = <<-END
         <RetrieveProtocolDefResponse xmlns="urn:ihe:qrph:rpe:2009">
-          <query root="1.2.3.4" extension="STUDY#{study.id}"/>
+          <query root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
           <protocolDef>
             <plannedStudy xmlns="urn:hl7-org:v3" classCode="CLNTRL" moodCode="DEF">
-              <id root="1.2.3.4" extension="STUDY#{study.id}"/>
+              <id root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
               <title>#{study.epic_title}</title>
               <text>#{study.brief_description}</text>
               <component4 typeCode="COMP">
                 <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                  <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}" />
+                  <id root="3.2.4.4.5" extension="STUDY#{study.id}.ARM#{arm1.id}" />
                   <title>#{arm1.name}</title>
                   <code code="CELL" codeSystem="n/a" />
                   <component1 typeCode="COMP">
                     <sequenceNumber value="1" />
                     <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                      <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1" />
+                      <id root="1.2.5.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1" />
                       <title>Cycle 1</title>
                       <code code="CYCLE" codeSystem="n/a" />
                       <effectiveTime>
@@ -1175,7 +1176,7 @@ RSpec.describe EpicInterface do
                       <component1 typeCode="COMP">
                         <sequenceNumber value="1"/>
                         <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                          <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
+                          <id root="1.2.5.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
                           <title>#{arm1.visit_groups.first.name}</title>
                         </timePointEventDefinition>
                       </component1>
@@ -1185,7 +1186,7 @@ RSpec.describe EpicInterface do
               </component4>
               <component4 typeCode="COMP">
                 <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                  <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
+                  <id root="3.2.4.4.5" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
                   <title>#{arm1.visit_groups.first.name}</title>
                   <code code="VISIT" codeSystem="n/a"/>
                   <component2 typeCode="COMP">
@@ -1239,21 +1240,21 @@ RSpec.describe EpicInterface do
 
       xml = <<-END
         <RetrieveProtocolDefResponse xmlns="urn:ihe:qrph:rpe:2009">
-          <query root="1.2.3.4" extension="STUDY#{study.id}"/>
+          <query root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
           <protocolDef>
             <plannedStudy xmlns="urn:hl7-org:v3" classCode="CLNTRL" moodCode="DEF">
-              <id root="1.2.3.4" extension="STUDY#{study.id}"/>
+              <id root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
               <title>#{study.epic_title}</title>
               <text>#{study.brief_description}</text>
               <component4 typeCode="COMP">
                 <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                  <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}" />
+                  <id root="3.2.4.4.5" extension="STUDY#{study.id}.ARM#{arm1.id}" />
                   <title>#{arm1.name}</title>
                   <code code="CELL" codeSystem="n/a" />
                   <component1 typeCode="COMP">
                     <sequenceNumber value="1" />
                     <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                      <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1" />
+                      <id root="1.2.5.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1" />
                       <title>Cycle 1</title>
                       <code code="CYCLE" codeSystem="n/a" />
                       <effectiveTime>
@@ -1263,7 +1264,7 @@ RSpec.describe EpicInterface do
                       <component1 typeCode="COMP">
                         <sequenceNumber value="1"/>
                         <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                          <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
+                          <id root="1.2.5.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
                           <title>#{arm1.visit_groups.first.name}</title>
                         </timePointEventDefinition>
                       </component1>
@@ -1273,13 +1274,13 @@ RSpec.describe EpicInterface do
               </component4>
               <component4 typeCode="COMP">
                 <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                  <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm2.id}" />
+                  <id root="3.2.4.4.5" extension="STUDY#{study.id}.ARM#{arm2.id}" />
                   <title>#{arm2.name}</title>
                   <code code="CELL" codeSystem="n/a" />
                   <component1 typeCode="COMP">
                     <sequenceNumber value="2" />
                     <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                      <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm2.id}.CYCLE1" />
+                      <id root="1.2.5.2.3.4" extension="STUDY#{study.id}.ARM#{arm2.id}.CYCLE1" />
                       <title>Cycle 1</title>
                       <code code="CYCLE" codeSystem="n/a" />
                       <effectiveTime>
@@ -1289,7 +1290,7 @@ RSpec.describe EpicInterface do
                       <component1 typeCode="COMP">
                         <sequenceNumber value="1"/>
                         <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                          <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm2.id}.CYCLE1.DAY#{arm2.visit_groups.first.day}"/>
+                          <id root="1.2.5.2.3.4" extension="STUDY#{study.id}.ARM#{arm2.id}.CYCLE1.DAY#{arm2.visit_groups.first.day}"/>
                           <title>#{arm2.visit_groups.first.name}</title>
                         </timePointEventDefinition>
                       </component1>
@@ -1299,7 +1300,7 @@ RSpec.describe EpicInterface do
               </component4>
               <component4 typeCode="COMP">
                 <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                  <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
+                  <id root="3.2.4.4.5" extension="STUDY#{study.id}.ARM#{arm1.id}.CYCLE1.DAY#{arm1.visit_groups.first.day}"/>
                   <title>#{arm1.visit_groups.first.name}</title>
                   <code code="VISIT" codeSystem="n/a"/>
                   <component2 typeCode="COMP">
@@ -1315,7 +1316,7 @@ RSpec.describe EpicInterface do
               </component4>
               <component4 typeCode="COMP">
                 <timePointEventDefinition classCode="CTTEVENT" moodCode="DEF">
-                  <id root="1.2.3.4" extension="STUDY#{study.id}.ARM#{arm2.id}.CYCLE1.DAY#{arm2.visit_groups.first.day}"/>
+                  <id root="3.2.4.4.5" extension="STUDY#{study.id}.ARM#{arm2.id}.CYCLE1.DAY#{arm2.visit_groups.first.day}"/>
                   <title>#{arm2.visit_groups.first.name}</title>
                   <code code="VISIT" codeSystem="n/a"/>
                   <component2 typeCode="COMP">
@@ -1386,10 +1387,10 @@ RSpec.describe EpicInterface do
         # base study creation message
         xml = <<-END
           <RetrieveProtocolDefResponse xmlns="urn:ihe:qrph:rpe:2009">
-            <query root="1.2.3.4" extension="STUDY#{study.id}"/>
+            <query root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
             <protocolDef>
               <plannedStudy xmlns="urn:hl7-org:v3" classCode="CLNTRL" moodCode="DEF">
-                <id root="1.2.3.4" extension="STUDY#{study.id}"/>
+                <id root="1.2.5.2.3.4" extension="STUDY#{study.id}"/>
                 <title>#{study.epic_title}</title>
                 <text>#{study.brief_description}</text>
               </plannedStudy>


### PR DESCRIPTION
[#174910577](https://www.pivotaltracker.com/story/show/174910577)

Changed `epic_study_root` setting to `epic_study_rsh_root` with a value of 1.2.5.2.3.4. A migration was added to update this setting. This root is no longer used in component4 segments.

Also added a setting for `epic_study_prl_root` with a value of 3.2.4.4.5 used in component4 segments of the SOAP messages sent to Epic.