### PR TITLE
HH - delete error without fulfillment [#175275687]

### DIFF
--- a/app/controllers/dashboard/study_level_activities_controller.rb
+++ b/app/controllers/dashboard/study_level_activities_controller.rb
@@ -125,11 +125,11 @@ class Dashboard::StudyLevelActivitiesController < Dashboard::BaseController
   end
 
   def has_cwf_fulfillments?(line_item)
-    cwf_line_item = Shard::Fulfillment::LineItem.where(sparc_id: line_item.id).first
-    if cwf_line_item
-      return (cwf_line_item.fulfillments.size > 0) ? true : false
+    if Setting.get_value("fulfillment_contingent_on_catalog_manager")
+      cwf_line_item = Shard::Fulfillment::LineItem.where(sparc_id: line_item.id).first
+      (cwf_line_item && cwf_line_item.fulfillments.size > 0) ? true : false
     else
-      return false
+      false
     end
   end
 end


### PR DESCRIPTION
Check `fulfillment_contingent_on_catalog_manager` setting before querying fulfillment database in `StudyLevelActivitiesController`. Prevents errors deleting items when SPARCFulfillment is not in use.

This impacts both 3.7 and 3.8.

Pivotal Tracker: https://www.pivotaltracker.com/story/show/175275687