### PR TITLE
KG - Move Visit Bugs

### DIFF
--- a/app/models/visit_group.rb
+++ b/app/models/visit_group.rb
@@ -93,12 +93,11 @@ class VisitGroup < ApplicationRecord
     # Three Cases:
     # The Visit Group is new and is being inserted between two other consecutive-day visits
     # The Visit Group had a nil day but is between two consecutive-day visits and needs to move one
-    # The Visit Group has been moved in-between consecutive visits 
-    #   and now we need to move consecutive visits
+    # The Visit Group has been moved in-between consecutive visits and now we need to move
+    #   consecutive visits
     @moved_and_update ||= (self.new_record? && self.arm && self.day && self.day == self.arm.visit_groups.where(VisitGroup.arel_table[:position].gteq(self.position)).minimum(:day)) ||
                           ((self.persisted? && day_changed? && self.day == self.lower_items.where.not(id: self.id, day: nil).minimum(:day)) &&
-                          (self.persisted? && position_changed? && day_changed? && self.day == self.arm.visit_groups.find_by(position: self.position + 1).try(:day)))
-    @moved_and_update
+                          (self.persisted? && day_changed? && position_changed? && self.day == self.arm.visit_groups.find_by(position: self.position).try(:day)))
   end
 
   # Validate the day of the visit group based on surrounding visits

--- a/app/models/visit_group.rb
+++ b/app/models/visit_group.rb
@@ -55,19 +55,9 @@ class VisitGroup < ApplicationRecord
 
   validate :day_must_be_in_order, if: Proc.new{ |vg| vg.day.present? }
 
-  default_scope { order(:position) }
+  attr_accessor :neighbor_moved
 
-  # def position=(position)
-  #   if position.blank?
-  #     write_attribute(:position, nil)
-  #   elsif self.arm && position == self.arm.visit_count || self.position == position.to_i
-  #     write_attribute(:position, position)
-  #   else
-  #     # Because we have to insert before using position - 1,
-  #     # increment position when changed
-  #     write_attribute(:position, position.to_i + 1)
-  #   end
-  # end
+  default_scope { order(:position) }
 
   def identifier
     "#{self.name}" + (self.day.present? ? " (#{self.class.human_attribute_name(:day)} #{self.day})" : "")
@@ -95,9 +85,11 @@ class VisitGroup < ApplicationRecord
     # The Visit Group had a nil day but is between two consecutive-day visits and needs to move one
     # The Visit Group has been moved in-between consecutive visits and now we need to move
     #   consecutive visits
-    @moved_and_update ||= (self.new_record? && self.arm && self.day && self.day == self.arm.visit_groups.where(VisitGroup.arel_table[:position].gteq(self.position)).minimum(:day)) ||
+    @moved_and_update ||= neighbor_moved ||
+                          (self.new_record? && self.arm && self.day && self.day == self.arm.visit_groups.where(VisitGroup.arel_table[:position].gteq(self.position)).minimum(:day)) ||
                           ((self.persisted? && day_changed? && self.day == self.lower_items.where.not(id: self.id, day: nil).minimum(:day)) &&
                           (self.persisted? && day_changed? && position_changed? && self.day == self.arm.visit_groups.find_by(position: self.position).try(:day)))
+    @moved_and_update
   end
 
   # Validate the day of the visit group based on surrounding visits
@@ -145,10 +137,9 @@ class VisitGroup < ApplicationRecord
       end
     # The Visit Group was new or had a nil day but is between two
     # consecutive-day visits and needs to move one
-    else
-      if vg = self.arm.visit_groups.where(VisitGroup.arel_table[:position].gteq(self.position)).where.not(id: self.id, day: nil).first
-        vg.update_attributes(day: vg.day + 1, position: vg.position)
-      end
+    elsif vg = self.arm.visit_groups.where(VisitGroup.arel_table[:position].gteq(self.position)).where.not(id: self.id, day: nil).first
+      vg.neighbor_moved = true
+      vg.update_attributes(day: vg.day + 1)
     end
   end
 

--- a/app/views/visit_groups/_form.html.haml
+++ b/app/views/visit_groups/_form.html.haml
@@ -22,7 +22,7 @@
   - disable_left = visit_group.first?
   - disable_right = visit_group.last?
 
-= form_for visit_group, remote: true, html: { class: 'w-100 visit-group-form' } do |f|
+= form_for visit_group, remote: true, html: { class: 'w-100 visit-group-form d-flex flex-column' } do |f|
   = f.hidden_field :arm_id
   = hidden_field_tag :arm_id, visit_group.arm_id
   = hidden_field_tag :srid, service_request.try(:id)
@@ -31,6 +31,13 @@
   = hidden_field_tag :page, page
   - pages.each do |arm_id, page|
     = hidden_field_tag "pages[#{arm_id}]", page
+  .modal-footer.d-flex.row.border-top.pb-0.order-1{ class: action_name == 'edit' ? 'justify-content-between pt-2' : 'pt-3' }
+    - if action_name == 'edit'
+      = delete_visit_group_button(visit_group, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), tab: tab, page: page, pages: pages)
+    - else
+      %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+        = t('actions.close')
+    = f.submit t('actions.submit'), class: ['btn btn-primary', action_name == 'edit' ? 'btn' : '']
   .d-flex
     - if action_name == 'edit'
       %button.btn.btn-white.rounded-0.d-flex.align-items-center.change-visit-btn{ type: 'submit', title: disable_left ? '' : t('visit_groups.form.previous', name: visit_group.higher_item.name), disabled: disable_left, data: { toggle: 'tooltip', placement: 'left', new_visit: 'previous' } }
@@ -66,10 +73,3 @@
         .form-group.col-6{ class: action_name == 'edit' ? 'mb-2' : '' }
           = f.label :window_after, class: 'required'
           = f.number_field :window_after, class: ['form-control', action_name == 'edit' ? 'form-control' : ''], min: 0
-  .modal-footer.d-flex.row.border-top.pb-0{ class: action_name == 'edit' ? 'justify-content-between pt-2' : 'pt-3' }
-    - if action_name == 'edit'
-      = delete_visit_group_button(visit_group, srid: service_request.try(:id), ssrid: sub_service_request.try(:id), tab: tab, page: page, pages: pages)
-    - else
-      %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
-        = t('actions.close')
-    = f.submit t('actions.submit'), class: ['btn btn-primary', action_name == 'edit' ? 'btn' : '']


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174729918

**Scenarios (Hopefully) Fixed**
1) hitting enter when editing the visit goes backwards in sequence. This doesn't work on the first visit because it cant move left any further. Not sure if this is a browser issue or not.
**Note: This was caused by the ordering of the HTML elements. I reorganized them to put the Submit button before the two arrows**
2) Inserting a visit works, however when squeezing in a new visit (i.e. between 29 and 30) it says the visits will be moved to accommodate the new visit, but in reality it just added another visit with the same day I.e. 29 2x)
3) Task/scenario 12 resulted in the visits to move forward BUT there are now two day 2's instead of incrementing to day 3, 4