### PR TITLE
KG - Move Visit Bugs again and again and again and again and again and...

### DIFF
--- a/app/views/visit_groups/_form.html.haml
+++ b/app/views/visit_groups/_form.html.haml
@@ -60,7 +60,10 @@
                 = t('constants.min', min: min)
               - if max
                 = t('constants.max', max: max)
-            - if min == max && (visit_group_clone.new_record? || visit_group_clone.position_changed?)
+            - # Because the visit group here actually has a position 1 less than it's true position would be, we can't use the built-in lower_item_with_day method
+            - higher_item_with_day  = visit_group_clone.higher_item_with_day
+            - lower_item_with_day   = visit_group_clone.lower_items.where(VisitGroup.arel_table[:position].gteq(visit_group_clone.position + 1)).where.not(id: visit_group_clone.id, day: nil).first
+            - if (visit_group_clone.new_record? || visit_group_clone.position_changed?) && higher_item_with_day.try(:day) == lower_item_with_day.try(:day).try(:-, 1)
               %small.form-text.text-warning
                 = t('visit_groups.form.move_note')
         .form-group.col-6{ class: action_name == 'edit' ? 'mb-1' : '' }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174729918

### Issues Fixed
According to Kyle and Wenjun scenario 7 was not working:
> 7. Inserting a new visit in a scenario such as [1, ?, 2, 3, 4] before the ? visit should set the day to “2" and visits 2, 3, and 4 should all increment by 1

but per my testing it seemed to be working even prior to these changes. I think it might be just due to bad data on the arm they tested with because of the multiple iterations of bugs.

This appears to be fixed now
> 12. Moving an existing visit in a scenario such as [1, ?, 2, 3, 4] and you’re moving visit 4 before visit ?, it should set the day to “2” and visits 2 and 3 should increment by 1

For scenario 6, the functionality is working, but the warning note was showing up even when I didn't have consecutive visits days for the position I was trying to insert into.
> 6. Inserting a new visit in-between two consecutive visits works as intended and increments the consecutive visits properly

![image](https://user-images.githubusercontent.com/12898988/97731212-3d977d00-1aab-11eb-89f2-77857820017d.png)
This wasn't working because we actually need to look at the previous and next visits with days to see if they're consecutive, not just the min/max