### PR TITLE
SAW - Add Institution and Primary PI to OnCore Protocol

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -630,6 +630,16 @@
     "parent_value":   "true"
   },
   {
+    "key":            "oncore_default_institution",
+    "value":          "Medical University of South Carolina",
+    "friendly_name":  "OnCore Institution default value.",
+    "description":    "Default Institution to add to protocols pushed to OnCore.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
     "key":            "oncore_default_library",
     "value":          "Non-Oncology",
     "friendly_name":  "OnCore Library Default Value",
@@ -644,6 +654,16 @@
     "value":          "MUSC Enterprise",
     "friendly_name":  "OnCore Organizational Unit Default Value",
     "description":    "Default value for Organizational Unit when pushing studies to OnCore.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "use_oncore",
+    "parent_value":   "true"
+  },
+  {
+    "key":            "oncore_default_pi_role",
+    "value":          "Principal Investigator",
+    "friendly_name":  "OnCore role for principal investigators.",
+    "description":    "OnCore's role name for principal investigators from the Staff Role reference list.",
     "group":          "",
     "version":        "",
     "parent_key":     "use_oncore",


### PR DESCRIPTION
[#174429556](https://www.pivotaltracker.com/story/show/174429556)

Immediately after a protocol has been pushed to OnCore, add MUSC as the institution and the protocol's primary PI. MUSC has been added as a setting for the default institution because OnCore considers all protocols under MUSC, including MUHA and MUSCP, to be MUSC and this may vary depending on institution for potential OS implementations.