### PR TITLE
SAW - Rake task to update hospital service abbreviations

### DIFF
--- a/lib/tasks/refresh_hospital_services_abbreviations.rake
+++ b/lib/tasks/refresh_hospital_services_abbreviations.rake
@@ -37,11 +37,16 @@ task :refresh_hospital_services_abbreviations => :environment do
     file
   end
 
-  # Update all hospital service abbreviations to be their service names
-  puts "Reading in file of services to escape..."
-  input_file = Rails.root.join("db", "imports", get_file)
-  escaped_service_ids = CSV.parse(File.read(input_file), headers: true).by_col['Service ID'].map(&:to_i)
-  hospital_services = Service.where(send_to_epic: 1).where.not(id: escaped_service_ids)
+  # Update all hospital service abbreviations to be their service names, minus any exceptions
+  has_exceptions = prompt("Are there any hospital services that should be excluded from the abbreviation refresh? (y/n): ")
+  if (has_exceptions == 'y') || (has_exceptions == 'Y')
+    puts "Reading in file of services to escape..."
+    input_file = Rails.root.join("db", "imports", get_file)
+    escaped_service_ids = CSV.parse(File.read(input_file), headers: true).by_col['Service ID'].map(&:to_i)
+    hospital_services = Service.where(send_to_epic: 1).where.not(id: escaped_service_ids)
+  else
+    hospital_services = Service.where(send_to_epic: 1)
+  end
 
   continue = prompt("Preparing to refresh #{hospital_services.count} hospital service abbreviations. Are you sure you want to continue? (y/n): ")
   if (continue == 'y') || (continue == 'Y')

--- a/lib/tasks/refresh_hospital_services_abbreviations.rake
+++ b/lib/tasks/refresh_hospital_services_abbreviations.rake
@@ -1,0 +1,56 @@
+# Copyright © 2011-2020 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+desc "Refreshing all abbreviations on hospital services"
+task :refresh_hospital_services_abbreviations => :environment do
+
+  def prompt(*args)
+    print(*args)
+    STDIN.gets.strip
+  end
+
+  def get_file(error=false)
+    puts "No import file specified or the file specified does not exist in db/imports" if error
+    file = prompt "Please specify the file name to import from db/imports (must be a CSV, see db/imports/example.csv for formatting): "
+
+    while file.blank? or not File.exists?(Rails.root.join("db", "imports", file))
+      file = get_file(true)
+    end
+
+    file
+  end
+
+  # Update all hospital service abbreviations to be their service names
+  puts "Reading in file of services to escape..."
+  input_file = Rails.root.join("db", "imports", get_file)
+  escaped_service_ids = CSV.parse(File.read(input_file), headers: true).by_col['Service ID'].map(&:to_i)
+  hospital_services = Service.where(send_to_epic: 1).where.not(id: escaped_service_ids)
+
+  continue = prompt("Preparing to refresh #{hospital_services.count} hospital service abbreviations. Are you sure you want to continue? (y/n): ")
+  if (continue == 'y') || (continue == 'Y')
+    ActiveRecord::Base.transaction do
+      hospital_services.update_all("abbreviation=name")
+      puts "#{hospital_services.count} hospital service abbreviations have been updated!"
+    end
+  else
+    puts "Exiting rake task..."
+  end
+
+end


### PR DESCRIPTION
[#174431817](https://www.pivotaltracker.com/story/show/174431817)

New rake task to update all hospital service abbreviations to their service names, allowing for exceptions from a csv file containing the service IDs to be excluded.