### PR TITLE
SJ - Duplicate Dropdown Bug

### DIFF
--- a/app/views/catalog_manager/services/_general_info_form.html.haml
+++ b/app/views/catalog_manager/services/_general_info_form.html.haml
@@ -30,7 +30,7 @@
 
   .form-group
     = f.label :core, t(:catalog_manager)[:organization_form][:core], class: 'col-sm-3 control-label'
-    .col-sm-9
+    .col-sm-9.core_wrapper
       = render 'catalog_manager/services/core_dropdown', cores: @cores, service: service
   .form-group
     = f.label :name, t(:catalog_manager)[:organization_form][:name], class: 'col-sm-3 control-label'

--- a/app/views/catalog_manager/services/reload_core_dropdown.js.coffee
+++ b/app/views/catalog_manager/services/reload_core_dropdown.js.coffee
@@ -17,6 +17,6 @@
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-$('#service_core').replaceWith("<%= j render 'catalog_manager/services/core_dropdown', cores: @cores, service: @service %>")
-$('#service_core + .bootstrap-select').remove()
-$('#service_core').selectpicker()
+
+$('.core_wrapper').html("<%= j render 'catalog_manager/services/core_dropdown', cores: @cores, service: @service %>")
+$('.core_wrapper .selectpicker').selectpicker()


### PR DESCRIPTION
The way the JS was written before, the selector to remove the old dropdown was too specific, and it looks like changes to bootstrap select changed broke it.

It's fixed now, and a bit more generic.

[#175478103]

https://www.pivotaltracker.com/story/show/175478103