### PR TITLE
SJ - Admin Rate History

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ services:
 before_install:
   - "export TZ=America/New_York"
   - nvm install node 12.10.0
-  - sudo apt-get install -y shared-mime-info
 before_script:
   - "export DISPLAY=:99.0"
   - cp config/database.yml.example config/database.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,11 +339,11 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.9)
+    mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -367,8 +367,11 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.5)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-darwin)
+      racc (~> 1.4)
     nori (2.6.0)
     nprogress-rails (0.2.0.2)
     omniauth (1.9.1)
@@ -425,6 +428,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)
+    racc (1.5.2)
     rack (2.2.3)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -748,4 +752,4 @@ DEPENDENCIES
   x-editable-rails
 
 BUNDLED WITH
-   2.2.2
+   2.2.15

--- a/app/api/v1/entities/full.rb
+++ b/app/api/v1/entities/full.rb
@@ -206,8 +206,7 @@ module V1
     root 'service_requests', 'service_request'
 
     expose  :protocol_id,
-            :status,
-            :approved
+            :status
 
     with_options(format_with: :iso_timestamp) do
       expose :submitted_at

--- a/app/controllers/dashboard/sub_service_requests_controller.rb
+++ b/app/controllers/dashboard/sub_service_requests_controller.rb
@@ -168,6 +168,11 @@ class Dashboard::SubServiceRequestsController < Dashboard::BaseController
     #For Subsidy History Bootstrap Table
     @subsidies = PastSubsidy.where(sub_service_request_id: @sub_service_request.id)
   end
+
+  def rate_history
+    #For admin_rate history
+    @rates = @sub_service_request.admin_rates
+  end
   #History Table Methods End
 
   def refresh_tab

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -33,6 +33,10 @@ class LineItemsController < ApplicationController
     @line_item  = LineItem.find(params[:id])
     @field      = params[:field]
 
+    if @field == 'displayed_cost'
+      @line_item.current_user_id = current_user.id
+    end
+
     if @line_item.displayed_cost_valid?(line_item_params[:displayed_cost]) && @line_item.update_attributes(line_item_params)
       if @field != 'displayed_cost'
         @service_request.update_attribute(:status, 'draft') unless @service_request.previously_submitted?

--- a/app/models/admin_rate.rb
+++ b/app/models/admin_rate.rb
@@ -22,4 +22,5 @@ class AdminRate < ApplicationRecord
   audited
 
   belongs_to :line_item
+  belongs_to :identity
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -49,6 +49,7 @@ class Identity < ApplicationRecord
   has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all
 
   has_many :approvals, dependent: :destroy
+  has_many :admin_rates
   has_many :approved_subsidies, class_name: 'ApprovedSubsidy', foreign_key: 'approved_by'
   has_many :catalog_manager_rights, class_name: 'CatalogManager'
   has_many :catalog_managers, dependent: :destroy

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -44,6 +44,7 @@ class LineItem < ApplicationRecord
   has_many :fulfillment_line_items, -> { order(:arm_id) }, class_name: 'Shard::Fulfillment::LineItem', foreign_key: :sparc_id
 
   attr_accessor :pricing_scheme
+  attr_accessor :current_user_id
 
   accepts_nested_attributes_for :fulfillments, allow_destroy: true
 
@@ -99,7 +100,7 @@ class LineItem < ApplicationRecord
   end
 
   def displayed_cost=(dollars)
-    admin_rates.new( admin_cost: Service.dollars_to_cents(dollars) )
+    admin_rates.new( admin_cost: Service.dollars_to_cents(dollars), identity_id: current_user_id )
   end
 
   def pricing_scheme

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -49,6 +49,7 @@ class SubServiceRequest < ApplicationRecord
 
   has_many :line_items_visits, through: :line_items
   has_many :services, through: :line_items
+  has_many :admin_rates, through: :line_items
 
   has_many :service_forms, -> { active }, through: :services, source: :forms
   has_many :organization_forms, -> { active }, through: :organization, source: :forms
@@ -421,7 +422,7 @@ class SubServiceRequest < ApplicationRecord
       end
     end
   end
-  
+
   # send all available surveys at once
   def available_surveys
     self.line_items.map{|li| li.service.available_surveys}.flatten.compact.uniq

--- a/app/views/dashboard/sub_service_requests/_history.html.haml
+++ b/app/views/dashboard/sub_service_requests/_history.html.haml
@@ -31,6 +31,8 @@
             = link_to t(:dashboard)[:sub_service_requests][:history][:approval_history][:header], '#approvalHistoryTab', id: 'approvalHistoryLink', class: ['list-group-item list-group-item-action', tab == 'approval_history' ? 'active' : ''], role: 'tab', data: { toggle: 'tab' }, aria: { controls: 'approvalHistoryTab', selected: (tab == 'approval_history').to_s }
           - if sub_service_request.eligible_for_subsidy?
             = link_to t(:dashboard)[:sub_service_requests][:history][:subsidy_history][:header], '#subsidyHistoryTab', id: 'subsidyHistoryLink', class: ['list-group-item list-group-item-action', tab == 'subsidy_history' ? 'active' : ''], role: 'tab', data: { toggle: 'tab' }, aria: { controls: 'subsidyHistoryTab', selected: (tab == 'subsidy_history').to_s }
+          - if sub_service_request.admin_rates.any?
+            = link_to t(:dashboard)[:sub_service_requests][:history][:rate_history][:header], '#rateHistoryTab', id: 'rateHistoryLink', class: ['list-group-item list-group-item-action', tab == 'rate_history' ? 'active' : ''], role: 'tab', data: { toggle: 'tab' }, aria: { controls: 'rateHistoryTab', selected: (tab == 'rate_history').to_s }
       .tab-content.col-10.pl-0
         .tab-pane.fade#statusHistoryTab{ role: 'tabpanel', class: tab == 'status_history' ? 'show active' : '', aria: { labelledby: 'statusHistoryTabLink' } }
           = render 'dashboard/sub_service_requests/history/status_history', sub_service_request: sub_service_request
@@ -38,3 +40,5 @@
           = render 'dashboard/sub_service_requests/history/approval_history', sub_service_request: sub_service_request
         .tab-pane.fade#subsidyHistoryTab{ role: 'tabpanel', class: tab == 'subsidy_history' ? 'show active' : '', aria: { labelledby: 'subsidyHistoryTabLink' } }
           = render 'dashboard/sub_service_requests/history/subsidy_history', sub_service_request: sub_service_request
+        .tab-pane.fade#rateHistoryTab{ role: 'tabpanel', class: tab == 'rate_history' ? 'show active' : '', aria: { lablledby: 'rateHistoryLink' } }
+          = render 'dashboard/sub_service_requests/history/rate_history', sub_service_request: sub_service_request

--- a/app/views/dashboard/sub_service_requests/history/_rate_history.html.haml
+++ b/app/views/dashboard/sub_service_requests/history/_rate_history.html.haml
@@ -1,0 +1,34 @@
+-# Copyright © 2011-2020 MUSC Foundation for Research Development
+-# All rights reserved.
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+-# disclaimer in the documentation and/or other materials provided with the distribution.
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+-# derived from this software without specific prior written permission.
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+%table#rateHistoryTable{ data: { toggle: 'table', url: rate_history_dashboard_sub_service_request_path(id: sub_service_request.id, format: :json), search: "true", show_columns: 'true', show_refresh: 'true', sort_name: 'created_at', sort_order: 'desc' } }
+  %thead.bg-light
+    %tr
+      %th{ data: { class: 'service_name', align: "left", sortable: "true", field: "service_name" } }
+        = t(:dashboard)[:sub_service_requests][:history][:rate_history][:service_name]
+      %th{ data: { class: 'cpt_code', align: "left", sortable: "true", field: "cpt_code" } }
+        = t(:dashboard)[:sub_service_requests][:history][:rate_history][:cpt_code]
+      %th{ data: { class: 'modified_rate', align: "left", sortable: "true", field: "modified_rate" } }
+        = t(:dashboard)[:sub_service_requests][:history][:rate_history][:modified_rate]
+      %th{ data: { class: 'modified_by', align: "left", sortable: "true", field: "modified_by" } }
+        = t(:dashboard)[:sub_service_requests][:history][:rate_history][:modified_by]
+      %th{ data: { class: 'date_changed', align: "left", sortable: "true", field: "date_changed", sorter: "dateSorter" } }
+        = t(:dashboard)[:sub_service_requests][:history][:rate_history][:date_changed]
+

--- a/app/views/dashboard/sub_service_requests/rate_history.json.jbuilder
+++ b/app/views/dashboard/sub_service_requests/rate_history.json.jbuilder
@@ -1,0 +1,7 @@
+json.(@rates) do |rate|
+  json.service_name rate.line_item.service.name
+  json.cpt_code rate.line_item.service.cpt_code
+  json.modified_rate number_to_currency(Service.cents_to_dollars(rate.admin_cost))
+  json.modified_by rate.identity.try(:full_name)
+  json.date_changed format_datetime(rate.created_at)
+end

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -332,6 +332,13 @@ en:
           actions:
             overridden: "Overridden"
             deleted: "Deleted"
+        rate_history:
+          header: "Modified Rate History"
+          date_changed: "Date Changed"
+          service_name: "Service Name"
+          modified_by: "Modified By"
+          cpt_code: "CPT Code"
+          modified_rate: "Modified Rate"
         tooltips:
           status_history: "Status log of request"
           approval_history: "Time stamp log of approvals"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,6 +334,7 @@ SparcRails::Application.routes.draw do
         get :status_history
         get :approval_history
         get :subsidy_history
+        get :rate_history
         get :refresh_tab
       end
     end

--- a/db/migrate/20210323211018_add_identity_to_admin_rate.rb
+++ b/db/migrate/20210323211018_add_identity_to_admin_rate.rb
@@ -1,0 +1,14 @@
+class AddIdentityToAdminRate < ActiveRecord::Migration[5.2]
+  def change
+    add_column :admin_rates, :identity_id, :integer
+
+    puts "Populated Identity Column for Existing Admin Rates"
+    bar = ProgressBar.new(AdminRate.count)
+
+    AdminRate.find_each do |admin_rate|
+      audit = AuditRecovery.where(auditable_id: admin_rate.id, auditable_type: "AdminRate", action: "create").first
+      admin_rate.update_attributes(identity_id: audit.user_id)
+      bar.increment!
+    end
+  end
+end

--- a/spec/factories/service_request.rb
+++ b/spec/factories/service_request.rb
@@ -21,7 +21,6 @@
 FactoryBot.define do
   factory :service_request do
     status               { Faker::Lorem.sentence(word_count: 3) }
-    approved             { false }
 
     trait :without_validations do
       to_create { |instance| instance.save(validate: false) }
@@ -29,10 +28,6 @@ FactoryBot.define do
 
     trait :with_protocol do
       protocol factory: :protocol_federally_funded
-    end
-
-    trait :approved do
-      approved {true}
     end
 
     trait :submitted do


### PR DESCRIPTION
Adding admin rate history tab, migration to track who made the change (and populate from audit), and model changes to save the user for new admin rates going forward.

(This PR also includes some spec fixes for the approved column removal from a previous story, that showed up in this build)

[#159276083]

https://www.pivotaltracker.com/story/show/159276083