### PR TITLE
Close the Edit Authorized User modal window

### DIFF
--- a/app/views/dashboard/associated_users/update.js.coffee
+++ b/app/views/dashboard/associated_users/update.js.coffee
@@ -48,6 +48,7 @@ $("#documentsCard").replaceWith("<%= j render 'documents/table', protocol: @prot
 $('.service-request-card:not(:eq(0))').remove()
 $(".service-request-card:eq(0)").replaceWith("<%= j render 'dashboard/service_requests/service_requests', protocol: @protocol, permission_to_edit: @permission_to_edit %>")
 
+$("#modalContainer").modal('hide')
 $("#authorizedUsersTable").bootstrapTable('refresh')
 $("#documentsTable").bootstrapTable()
 $(".service-requests-table").bootstrapTable()


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/177581254

Currently, the 'Edit Authorized User' modal window won't close after submit when a  (non overlord) user edit him/herslef in SPARCDashboard.