### PR TITLE
SJ - Dashboard CWF Button Loop

### DIFF
--- a/app/helpers/dashboard/sub_service_requests_helper.rb
+++ b/app/helpers/dashboard/sub_service_requests_helper.rb
@@ -63,7 +63,7 @@ module Dashboard::SubServiceRequestsHelper
           end
         else
           # In fulfillment, but user has no rights to view in Fulfillment
-          content_tag :div, t('dashboard.sub_service_requests.header.fulfillment.in_fulfillment'), id: 'fulfillmentStatus', class: 'alert alert-sm alert-success mb-0'
+          content_tag :div, t('dashboard.sub_service_requests.header.fulfillment.in_fulfillment'), class: 'alert alert-sm alert-success mb-0'
         end
       elsif current_user.send_to_cwf_rights?(sub_service_request.organization)
         # Not in Fulfillment, and user has rights to send to Fulfillment


### PR DESCRIPTION
The "cwf button" in dashboard had a loophole in it's logic, where if you didn't have rights, and the ssr is in fulfillment, it will keep refreshing the button forever, thinking that it's waiting for the ssr to be in fulfillment, when you actually just don't have rights to see the "view in fulfillment" button.

Just needed to disable the JS that did the looping, for this particular scenario. Just needed to remove the ID that triggers it.