### PR TITLE
HH - Disable timestamp in Paperclip URLs

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,0 +1,4 @@
+# Disable timestamps added to Paperclip URLs. Prevents Chrome and Edge from altering
+# the file extension of downloads to match the Content-Type header, which can prevent
+# Word from opening older-format documents.
+Paperclip::Attachment.default_options[:use_timestamp] = false


### PR DESCRIPTION
Add an initializer that disables the timestamp appended to Paperclip URLs, which causes some browsers to alter the file extension on download. Fixes an issue where Word documents in Word 97 format could not be opened after download from SPARCRequest.

## Context

At OHSU, members of our Navigator team found that occasionally Word would display an error when opening documents downloaded from SPARCRequest.

![image (1)](https://user-images.githubusercontent.com/2746306/123319719-a2de2980-d4e5-11eb-8d62-8a2569f5140b.png)

On investigation, the documents in question were all in Word 97 compatible format (`.doc`), but the browser was altering the file extension to `.docx`.

![octri-request ohsu edu_dashboard_protocols_12693](https://user-images.githubusercontent.com/2746306/123320103-2b5cca00-d4e6-11eb-9c48-384f1cb1246d.png)

<img width="684" alt="Screen Shot 2021-06-04 at 2 47 08 PM" src="https://user-images.githubusercontent.com/2746306/123320158-3ca5d680-d4e6-11eb-9287-66b0aba316fb.png">

After trying various approaches, I finally found that the file timestamp Paperclip appends to download links seems to cause at least Chrome, Edge, and Internet Explorer 11 to alter the file extension of the download. Adding an initializer that disables this feature of Paperclip fixed the issue.
