### PR TITLE
SAW - Silent Error when PI not in OnCore

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -195,16 +195,8 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
   def push_to_oncore
     if @protocol.is_a?(Study)
       oncore_protocol = OncoreProtocol.new(@protocol)
-      response = oncore_protocol.create_oncore_protocol
-      if response.success?
-        flash[:success] = I18n.t('protocols.summary.oncore.pushed_to_oncore')
-      else
-        if response['message'].try(:include?, ('already exists'))
-          @error = t('protocols.summary.oncore.already_exists', protocol_id: @protocol.id)
-        else
-          @error = "#{response.code}: #{response.message}"
-        end
-      end
+      @successful_oncore_push = oncore_protocol.create_oncore_protocol
+      @errors = oncore_protocol.errors.empty? ? nil : oncore_protocol.errors
     end
 
     respond_to :js

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -21,6 +21,7 @@
 class OncoreProtocol
   # Required dependency for ActiveModel::Errors
   extend ActiveModel::Naming
+  extend ActiveModel::Translation
 
   include HTTParty
   base_uri Setting.get_value('oncore_api')
@@ -204,19 +205,6 @@ class OncoreProtocol
       raise OncorePushError
     end
     @auth = "Bearer " + JSON.parse(response.body)['access_token']
-  end
-
-  # Methods needed for implementing ActiveModel::Errors
-  def read_attribute_for_validation(attr)
-    send(attr)
-  end
-
-  def self.human_attribute_name(attr, options = {})
-    attr
-  end
-
-  def self.lookup_ancestors
-    [self]
   end
 
   private

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -99,7 +99,7 @@ class OncoreProtocol
     if !response.success? && response['message'].try(:include?, ('already exists'))
       @errors.add(:base, :already_exists)
       raise OncorePushError
-    elsif !response.success
+    elsif !response.success?
       @errors.add(:base, :post_protocols_failed, message: "#{response.code}: #{response.message}")
       raise OncorePushError
     end
@@ -171,19 +171,19 @@ class OncoreProtocol
   end
 
   def add_primary_pi
-    staff_response = self.class.post('/oncore-api/rest/protocolStaff',
+    response = self.class.post('/oncore-api/rest/protocolStaff',
                               headers: {
                                 'Accept' => 'application/json',
                                 'Content-Type' => 'application/json',
-                                'Authorization' => self.auth
+                                'Authorization' => @auth
                               },
                               body: {
-                                protocolId: self.protocol_id,
-                                contactId: contact_id,
-                                role: self.primary_pi_role
+                                protocolId: @protocol_id,
+                                contactId: @primary_pi_contact_id,
+                                role: @primary_pi_role
                               }.to_json)
 
-    log_request_and_response(staff_response)
+    log_request_and_response(response)
     unless response.success?
       @errors.add(:base, :post_protocol_staff_failed, message: "#{response.code}: #{response.message}")
       raise OncorePushError

--- a/app/lib/oncore_protocol.rb
+++ b/app/lib/oncore_protocol.rb
@@ -19,44 +19,63 @@
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class OncoreProtocol
+  # Required dependency for ActiveModel::Errors
+  extend ActiveModel::Naming
+
   include HTTParty
   base_uri Setting.get_value('oncore_api')
 
-  attr_accessor :auth, :protocol_no, :protocol_id, :title, :short_title, :library, :department, :organizational_unit, :protocol_type, :institution, :primary_pi, :primary_pi_role
+  class OncorePushError < StandardError; end
+
+  attr_accessor :auth,
+                :protocol_no,
+                :protocol_id,
+                :title,
+                :short_title,
+                :library,
+                :department,
+                :organizational_unit,
+                :protocol_type,
+                :institution,
+                :primary_pi,
+                :primary_pi_contact_id,
+                :primary_pi_role
+  attr_reader   :errors
 
   def initialize(study)
     # Use default values for fields that do not correlate to SPARC values
-    self.protocol_no         = "STUDY#{study.id}"
-    self.title               = study.title
-    self.short_title         = "#{study.short_title} - #{study.title}"
-    self.library             = Setting.get_value("oncore_default_library")
-    self.department          = (study.primary_pi.professional_organization.try(:department_name) || Setting.get_value("oncore_default_department")).upcase
-    self.organizational_unit = Setting.get_value("oncore_default_organizational_unit")
-    self.protocol_type       = Setting.get_value("oncore_default_protocol_type")
+    @protocol_no         = "STUDY#{study.id}"
+    @title               = study.title
+    @short_title         = "#{study.short_title} - #{study.title}"
+    @library             = Setting.get_value("oncore_default_library")
+    @department          = (study.primary_pi.professional_organization.try(:department_name) || Setting.get_value("oncore_default_department")).upcase
+    @organizational_unit = Setting.get_value("oncore_default_organizational_unit")
+    @protocol_type       = Setting.get_value("oncore_default_protocol_type")
 
-    self.institution         = Setting.get_value("oncore_default_institution")
-    self.primary_pi          = study.primary_pi
-    self.primary_pi_role     = Setting.get_value("oncore_default_pi_role")
+    @institution         = Setting.get_value("oncore_default_institution")
+    @primary_pi          = study.primary_pi
+    @primary_pi_role     = Setting.get_value("oncore_default_pi_role")
+
+    @errors = ActiveModel::Errors.new(self)
   end
 
   def create_oncore_protocol
-    auth_response = authenticate
-    if auth_response.success?
-      push_base_response = push_base_oncore_protocol
-      return push_base_response if !push_base_response.success?
+    protocol_push_successful = false
+    begin
+      authenticate
+      push_base_oncore_protocol
+      oncore_protocol_id_search
+      add_insitution
 
-      id_search_response = oncore_protocol_id_search
-      return id_search_response if !id_search_response.success?
+      protocol_push_successful = true
 
-      add_institution_response = add_insitution
-      return add_institution_response if !add_institution_response.success?
-
-      primary_pi_response = add_primary_pi
-
-      return primary_pi_response
-    else
-      return auth_response
+      get_primary_pi_contact_id
+      add_primary_pi
+    rescue OncorePushError
+      # Don't need to do anything special if this is raised, errors are already assigned in HTTP call method
     end
+
+    return protocol_push_successful
   end
 
   def push_base_oncore_protocol
@@ -64,19 +83,26 @@ class OncoreProtocol
                               headers: {
                                 'Accept' => 'application/json',
                                 'Content-Type' => 'application/json',
-                                'Authorization' => self.auth
+                                'Authorization' => @auth
                               },
                               body: {
-                                protocolNo: self.protocol_no,
-                                title: self.title,
-                                shortTitle: self.short_title,
-                                library: self.library,
-                                department: self.department,
-                                organizationalUnit: self.organizational_unit,
-                                protocolType: self.protocol_type
+                                protocolNo: @protocol_no,
+                                title: @title,
+                                shortTitle: @short_title,
+                                library: @library,
+                                department: @department,
+                                organizationalUnit: @organizational_unit,
+                                protocolType: @protocol_type
                               }.to_json)
+
     log_request_and_response(response)
-    return response
+    if !response.success? && response['message'].try(:include?, ('already exists'))
+      @errors.add(:base, :already_exists)
+      raise OncorePushError
+    elsif !response.success
+      @errors.add(:base, :post_protocols_failed, message: "#{response.code}: #{response.message}")
+      raise OncorePushError
+    end
   end
 
   # Get the OnCore protocolId, like SPARC's ids but specific to OnCore
@@ -86,14 +112,18 @@ class OncoreProtocol
                               headers: {
                                 'Accept' => 'application/json',
                                 'Content-Type' => 'application/json',
-                                'Authorization' => self.auth
+                                'Authorization' => @auth
                               },
                               query: {
-                                protocolNo: self.protocol_no
+                                protocolNo: @protocol_no
                               })
+
     log_request_and_response(response)
-    self.protocol_id = response.success? ? response.first['protocolId'] : nil
-    return response
+    unless response.success?
+      @errors.add(:base, :get_protocols_failed, message: "#{response.code}: #{response.message}")
+      raise OncorePushError
+    end
+    @protocol_id = response.first['protocolId']
   end
 
   def add_insitution
@@ -101,33 +131,46 @@ class OncoreProtocol
                               headers: {
                                 'Accept' => 'application/json',
                                 'Content-Type' => 'application/json',
-                                'Authorization' => self.auth
+                                'Authorization' => @auth
                               },
                               body: {
-                                protocolId: self.protocol_id,
-                                institution: self.institution
+                                protocolId: @protocol_id,
+                                institution: @institution
                               }.to_json)
+
     log_request_and_response(response)
-    return response
+    unless response.success?
+      @errors.add(:base, :post_protocols_institutions_failed, message: "#{response.code}: #{response.message}")
+      raise OncorePushError
+    end
   end
 
-  def add_primary_pi
-    contact_response = response = self.class.get('/oncore-api/rest/contacts',
+  def get_primary_pi_contact_id
+    response = self.class.get('/oncore-api/rest/contacts',
                               headers: {
                                 'Accept' => 'application/json',
                                 'Content-Type' => 'application/json',
-                                'Authorization' => self.auth
+                                'Authorization' => @auth
                               },
                               query: {
-                                email: self.primary_pi.email,
-                                firstName: self.primary_pi.first_name,
-                                lastName: self.primary_pi.last_name
+                                email: @primary_pi.email,
+                                firstName: @primary_pi.first_name,
+                                lastName: @primary_pi.last_name
                               })
-    log_request_and_response(contact_response)
-    return contact_response if !contact_response.success?
 
-    contact_id = response.first['contactId']
+    log_request_and_response(response)
+    if !response.success?
+      @errors.add(:base, :get_contacts_failed, message: "#{response.code}: #{response.message}")
+      raise OncorePushError
+    elsif response.success? && response.empty?
+      @errors.add(:base, :pi_not_in_oncore)
+      raise OncorePushError
+    end
 
+    @primary_pi_contact_id = response.first['contactId']
+  end
+
+  def add_primary_pi
     staff_response = self.class.post('/oncore-api/rest/protocolStaff',
                               headers: {
                                 'Accept' => 'application/json',
@@ -139,8 +182,12 @@ class OncoreProtocol
                                 contactId: contact_id,
                                 role: self.primary_pi_role
                               }.to_json)
+
     log_request_and_response(staff_response)
-    return staff_response
+    unless response.success?
+      @errors.add(:base, :post_protocol_staff_failed, message: "#{response.code}: #{response.message}")
+      raise OncorePushError
+    end
   end
 
   def authenticate
@@ -152,12 +199,27 @@ class OncoreProtocol
                                 grant_type: 'client_credentials'
                               }.to_json)
 
-    if response.success?
-      self.auth = "Bearer " + JSON.parse(response.body)['access_token']
+    unless response.success?
+      @errors.add(:base, :auth_failed, message: "#{response.code}: #{response.message}")
+      raise OncorePushError
     end
-
-    return response
+    @auth = "Bearer " + JSON.parse(response.body)['access_token']
   end
+
+  # Methods needed for implementing ActiveModel::Errors
+  def read_attribute_for_validation(attr)
+    send(attr)
+  end
+
+  def self.human_attribute_name(attr, options = {})
+    attr
+  end
+
+  def self.lookup_ancestors
+    [self]
+  end
+
+  private
 
   # Log requests and responses without exposing any authentication information in headers
   def log_request_and_response(response)

--- a/app/views/dashboard/protocols/push_to_oncore.js.coffee
+++ b/app/views/dashboard/protocols/push_to_oncore.js.coffee
@@ -18,12 +18,27 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-<% if @error %>
-AlertSwal.fire(
-  type: 'error'
-  title: I18n.t('protocols.summary.oncore.error')
-  text: "<%= @error %>"
-)
+<% if @errors && !@successful_oncore_push %>
+icon = 'error'
+title = I18n.t('protocols.summary.oncore.error')
+text = "<%= @errors[:base].first %>"
+
+<% elsif @errors && @successful_oncore_push %>
+icon = 'info'
+title = I18n.t('protocols.summary.oncore.pushed_to_oncore')
+text = "<%= @errors[:base].first %>"
+
 <% else %>
-$("#flashContainer").replaceWith("<%= j render 'layouts/flash' %>")
+icon = 'success'
+title = I18n.t('protocols.summary.oncore.pushed_to_oncore')
+text = ""
 <% end %>
+
+AlertSwal.fire(
+  icon: icon
+  title: title
+  text: text
+  showCloseButton: true
+  showConfirmButton: false
+  cancelButtonText: I18n.t('actions.close')
+)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,6 +378,11 @@ en:
       system_survey: "Survey"
       sub_service_request: "Request"
 
+  errors:
+    attributes:
+      base:
+        already_exists: "Study already exists in OnCore."
+        pi_not_in_oncore: "PI does not exist in OnCore. Study still pushed to OnCore."
   ########
   # ARMS #
   ########
@@ -825,7 +830,6 @@ en:
         push_to_oncore: "Push to OnCore"
         pushed_to_oncore: "Study Pushed to OnCore!"
         error: "Unable to push Study to OnCore"
-        already_exists: "Study %{protocol_id} already exists in OnCore."
       tooltips:
         notes: "Protocol notes viewable to Administrators and Authorized Users"
         details: "Quick access to protocol information"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,13 @@ en:
       feedback:
         typeofrequest: "Type of Request"
         sparc_request_id: "SRID"
+    errors:
+      models:
+        oncore_protocol:
+          attributes:
+            base:
+              already_exists: "Study already exists in OnCore."
+              pi_not_in_oncore: "PI does not exist in OnCore. Study still pushed to OnCore."
 
   ################
   # ACTIVERECORD #
@@ -378,11 +385,6 @@ en:
       system_survey: "Survey"
       sub_service_request: "Request"
 
-  errors:
-    attributes:
-      base:
-        already_exists: "Study already exists in OnCore."
-        pi_not_in_oncore: "PI does not exist in OnCore. Study still pushed to OnCore."
   ########
   # ARMS #
   ########

--- a/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
+++ b/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe 'User pushes a study to OnCore', js: true do
         expect(a_request(:post, Setting.get_value("oncore_api")+protocol_institutions_path)).to have_been_made.once
         expect(a_request(:post, Setting.get_value("oncore_api")+protocol_staff_path)).to have_been_made.once
       end
+
+      it 'should show success message' do
+        expect(page).to have_content(I18n.t('protocols.summary.oncore.pushed_to_oncore'))
+      end
     end
 
     context 'and the protocol has already been pushed to OnCore', oncore_protocol: :exists do
@@ -57,7 +61,19 @@ RSpec.describe 'User pushes a study to OnCore', js: true do
 
       it 'should display an error' do
         expect(page).to have_content(I18n.t('protocols.summary.oncore.error'))
-        expect(page).to have_content(I18n.t('protocols.summary.oncore.already_exists', protocol_id: @study.id))
+        expect(page).to have_content(I18n.t('errors.attributes.base.already_exists'))
+      end
+    end
+
+    context 'and the PI does not exist in OnCore', oncore_pi: :does_not_exist do
+      it 'should post a protocol to OnCore' do
+        expect(a_request(:post, Setting.get_value("oncore_api")+protocols_path)).to have_been_made.once
+        expect(a_request(:post, Setting.get_value("oncore_api")+protocol_institutions_path)).to have_been_made.once
+      end
+
+      it 'should show success message with notice' do
+        expect(page).to have_content(I18n.t('protocols.summary.oncore.pushed_to_oncore'))
+        expect(page).to have_content(I18n.t('errors.attributes.base.pi_not_in_oncore'))
       end
     end
   end

--- a/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
+++ b/spec/features/dashboard/protocols/show/user_pushes_protocol_to_oncore_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'User pushes a study to OnCore', js: true do
 
       it 'should display an error' do
         expect(page).to have_content(I18n.t('protocols.summary.oncore.error'))
-        expect(page).to have_content(I18n.t('errors.attributes.base.already_exists'))
+        expect(page).to have_content(I18n.t('activemodel.errors.models.oncore_protocol.attributes.base.already_exists'))
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe 'User pushes a study to OnCore', js: true do
 
       it 'should show success message with notice' do
         expect(page).to have_content(I18n.t('protocols.summary.oncore.pushed_to_oncore'))
-        expect(page).to have_content(I18n.t('errors.attributes.base.pi_not_in_oncore'))
+        expect(page).to have_content(I18n.t('activemodel.errors.models.oncore_protocol.attributes.base.pi_not_in_oncore'))
       end
     end
   end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -59,6 +59,11 @@ RSpec.configure do |config|
       )
   end
 
+  config.before(:each, oncore_pi: :does_not_exist) do
+    stub_request(:get, /#{Regexp.quote(Setting.get_value("oncore_api"))}\/oncore-api\/rest\/contacts\?email=(.+)&firstName=(.+)&lastName=(.+)/).
+      to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+
   config.before(:each, remote_service: :unavailable) do
     stub_request(:post, /#{Setting.get_value("remote_service_notifier_host")}/).
       to_return(status: 500)


### PR DESCRIPTION
[#177916113](https://www.pivotaltracker.com/story/show/177916113)

Refactored the OnCore REST API to better handle different errors and cases that may arise when pushing a protocol to OnCore. This refactor best handles the case where a protocol is successfully pushed to OnCore, but the primary PI isn't a contact in OnCore. We still want to allow that protocol to be pushed to OnCore, but we want to warn the user that the primary PI isn't in OnCore. Now there's an info SweetAlert for this case:

![image](https://user-images.githubusercontent.com/19152930/134991129-12d4074e-84db-4935-b6e0-677384e12814.png)
