### PR TITLE
Quick fixes for reports

### DIFF
--- a/app/lib/reports/admin_time_report.rb
+++ b/app/lib/reports/admin_time_report.rb
@@ -136,7 +136,7 @@ class AdminTimeReport < ReportingModule
     ssr_organization_ids = Organization.all.map(&:id) if ssr_organization_ids.compact.empty? # use all if none are selected
 
     # submitted_at ||= self.default_options["Date Range"][:from]..self.default_options["Date Range"][:to]
-    submitted_at = "2012-03-01".to_date..Date.today
+    submitted_at = "2012-03-01".to_date..Time.current
     statuses = args[:status] || PermissibleValue.get_key_list('status') # use all if none are selected
 
     return :sub_service_requests => {:organization_id => ssr_organization_ids, :status => statuses}, :service_requests => {:submitted_at => submitted_at}, :services => {:id => args[:service_id]}

--- a/app/lib/reports/service_pricing_report.rb
+++ b/app/lib/reports/service_pricing_report.rb
@@ -114,7 +114,7 @@ class ServicePricingReport < ReportingModule
     end
 
     if params[:rate_types]
-      service_pricing_date = Date.strptime(params[:services_pricing_date], "%m/%d/%Y")
+      service_pricing_date = params[:services_pricing_date] ? Date.strptime(params[:services_pricing_date], "%m/%d/%Y") : Date.today
 
       if params[:rate_types].include?("full_rate")
         attrs["Full Rate"] = "report_pricing(pricing_map_for_date(\"#{service_pricing_date}\").full_rate.to_f) rescue 'N/A'"

--- a/app/lib/reports/service_requests.rb
+++ b/app/lib/reports/service_requests.rb
@@ -30,7 +30,7 @@ class ServiceRequestsReport < ReportingModule
   # see app/reports/test_report.rb for all options
   def default_options
     {
-      "Submission Date Range" => {:field_type => :date_range, :for => "submitted_at", :from => "2012-03-01".to_date, :to => Date.today},
+      "Submission Date Range" => {:field_type => :date_range, :for => "submitted_at", :from => "2012-03-01".to_date, :to => Time.current},
       Institution => {:field_type => :select_tag, :has_dependencies => "true"},
       Provider => {:field_type => :select_tag, :dependency => '#institution_id', :dependency_id => 'parent_id'},
       Program => {:field_type => :select_tag, :dependency => '#provider_id', :dependency_id => 'parent_id'},

--- a/app/lib/reports/short_interactions.rb
+++ b/app/lib/reports/short_interactions.rb
@@ -30,7 +30,7 @@ class ShortInteractionsReport < ReportingModule
   # see app/reports/test_report.rb for all options
   def default_options
     {
-      "Created Date Range" => {:field_type => :date_range, :for => "short_interaction_created_at", :from => "2012-03-01".to_date, :to => Date.today},
+      "Created Date Range" => {:field_type => :date_range, :for => "short_interaction_created_at", :from => "2012-03-01".to_date, :to => Time.current},
       Institution => {:field_type => :select_tag, :has_dependencies => "true"},
       Provider => {:field_type => :select_tag, :dependency => '#institution_id', :dependency_id => 'parent_id'},
       Program => {:field_type => :select_tag, :dependency => '#provider_id', :dependency_id => 'parent_id'},

--- a/app/lib/reports/test_report.rb
+++ b/app/lib/reports/test_report.rb
@@ -49,7 +49,7 @@ class TestReport < ReportingModule
   # :selectpicker => this adds the class of 'selectpicker' onto the item, for usage by the selectpicker dropdown js.
   def default_options
     {
-      "Date Range" => {:field_type => :date_range, :for => "service_requests_submitted_at", :from => "2012-03-01".to_date, :to => Date.today, :required => true},
+      "Date Range" => {:field_type => :date_range, :for => "service_requests_submitted_at", :from => "2012-03-01".to_date, :to => Time.current, :required => true},
       Institution => {:field_type => :select_tag, :required => true, :has_dependencies => "true"},
       Provider => {:field_type => :select_tag, :dependency => '#institution_id', :dependency_id => 'parent_id'},
       Program => {:field_type => :select_tag, :dependency => '#provider_id', :dependency_id => 'parent_id'},

--- a/app/lib/reports/unique_pi.rb
+++ b/app/lib/reports/unique_pi.rb
@@ -30,7 +30,7 @@ class UniquePiReport < ReportingModule
   # see app/reports/test_report.rb for all options
   def default_options
     {
-      "Date Range" => {:field_type => :date_range, :for => "service_requests_submitted_at", :from => "2012-03-01".to_date, :to => Date.today},
+      "Date Range" => {:field_type => :date_range, :for => "service_requests_submitted_at", :from => "2012-03-01".to_date, :to => Time.current},
       Institution => {:field_type => :select_tag, :has_dependencies => "true"},
       Provider => {:field_type => :select_tag, :dependency => '#institution_id', :dependency_id => 'parent_id'},
       Program => {:field_type => :select_tag, :dependency => '#provider_id', :dependency_id => 'parent_id'},


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/180256122

Bugfixes for the following issues:

1. When the date range is not selected, records created or submitted on same day as the report run date are not included in the report. Affected reports are: Admin Time, Service Requests, Short Interactions, and Unique PI.
2. Service Pricing Report bug: exception occurs when Pricing Date is not selected.


