### PR TITLE
ML- (SPARCDashboard) Fee Agreement Report Refinements [#180199840]

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -115,7 +115,7 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
   end
 
   def fee_agreement
-    session[:breadcrumbs].clear.add_crumbs(protocol_id: @protocol.id)
+    session[:breadcrumbs].clear.add_crumbs(protocol_id: @protocol.id, path_name: I18n.t('dashboard.fee_agreement.short_title'))
     params[:column_count] ||= 5
     visit_columns = params[:column_count].to_i
     filters = params[:filters] || {}

--- a/app/lib/dashboard/breadcrumber.rb
+++ b/app/lib/dashboard/breadcrumber.rb
@@ -58,7 +58,8 @@ class Dashboard::Breadcrumber
         protocol_label_and_url,
         edit_protocol_label_and_url,
         ssr_label_and_url,
-        notifications_label_and_url
+        notifications_label_and_url,
+        path_name_label_and_url
     ].compact!
 
     crumbs = [content_tag(:li, content_tag(:a, 'Dashboard', href: dashboard_protocols_path(@filters)))]
@@ -95,5 +96,10 @@ class Dashboard::Breadcrumber
   def edit_protocol_label_and_url
     protocol_id = @crumbs[:edit_protocol]
     protocol_id ? ["Edit", "/dashboard/protocols/#{protocol_id}/edit"] : nil
+  end
+
+  def path_name_label_and_url
+    name = @crumbs[:path_name]
+    name ? [name, nil] : nil
   end
 end

--- a/app/lib/fee_agreement.rb
+++ b/app/lib/fee_agreement.rb
@@ -231,6 +231,14 @@ module FeeAgreement
       @grand_total = @clinical_total + @non_clinical_service_table.total
     end
 
+    def clinical_services_displayed?
+      @clinical_service_tables.any? {|table| !table.rows.empty? }
+    end
+
+    def non_clinical_services_displayed?
+      !@non_clinical_service_table.rows.empty?
+    end
+
     # @returns Hash of options to use for filtering data.
     def filter_options
       unless @filter_options

--- a/app/views/dashboard/protocols/fee_agreement.html.haml
+++ b/app/views/dashboard/protocols/fee_agreement.html.haml
@@ -23,6 +23,8 @@
 = render 'dashboard/protocols/fee_agreement/study_information', protocol: @protocol
 = render 'dashboard/protocols/fee_agreement/arms', protocol: @protocol
 = render 'dashboard/protocols/fee_agreement/totals'
-= render 'dashboard/protocols/fee_agreement/non_clinical_services', protocol: @protocol
-= render 'dashboard/protocols/fee_agreement/clinical_services_wrapped', protocol: @protocol, clinical_service_tables: @fee_agreement.clinical_service_tables
+- if @fee_agreement.non_clinical_services_displayed?
+    = render 'dashboard/protocols/fee_agreement/non_clinical_services', protocol: @protocol
+- if @fee_agreement.clinical_services_displayed?
+    = render 'dashboard/protocols/fee_agreement/clinical_services_wrapped', protocol: @protocol, clinical_service_tables: @fee_agreement.clinical_service_tables
 = render 'dashboard/protocols/fee_agreement/terms'

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -100,10 +100,10 @@ en:
         arm_total: "Arm Total: %{total}"
       terms:
         header: "Terms and Conditions"
-        content: "<li>This fee covers the administrative and regulatory review for all protocols using CTRC services.</li>
-          <li>Prices are subject to change due to hospital and institution rate adjustments.</li>
-          <li>Cost estimates are subject to revision periodically and with any change in services requested. If this is a cost estimate for a grant please request an updated cost estimate for every resubmission as rates may change.</li>
-          <li>When budgeting for your project, please include a rate increase each calendar year. Also note that institution costs are subject to F&A.</li>"
+        content: "<li>Prices are subject to change due to hospital and institution rate adjustments.</li>
+        <li>Cost estimates are subject to revision periodically.</li>
+        <li>When budgeting for your protocol remember to consider adding a rate increase each calendar year.</li>
+        <li>In addition, research costs may be subject to F&A; refer to institutional F&A guidelines.</li>"
 
     #########
     # FORMS #

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -55,6 +55,7 @@ en:
     ###################
     fee_agreement:
       title: "Consolidated Fee Agreement"
+      short_title: "Fee Agreement"
       settings:
         header: "Settings"
         report_configuration: "Report Configuration"
@@ -79,7 +80,7 @@ en:
         total_clinical_services_cost: "Total Clinical Services Cost"
         total_study_budget: "Total Study Budget"
       non_clinical_services:
-        header: "Non-Clinical Services and Initiation Fees"
+        header: "Non-Clinical Services"
         program: "Program"
         service_name: "Service Name"
         your_cost: "Your Cost"

--- a/spec/lib/dashboard/breadcrumber_spec.rb
+++ b/spec/lib/dashboard/breadcrumber_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe Dashboard::Breadcrumber do
         expect(breadcrumbs).to have_tag('li', text: "Edit")
         expect(breadcrumbs).to match(/Dashboard.*My Protocol.*Edit/) # expect correct order
       end
+
+      it 'should allow a custom path name option' do
+        @breadcrumber.add_crumbs(protocol_id: protocol.id, path_name: "Test")
+
+        breadcrumbs = @breadcrumber.breadcrumbs
+
+        expect(breadcrumbs).to have_tag('a', count: 2) # expect correct number of links, so the following is exhaustive
+        expect(breadcrumbs).to have_tag('a', with: { href: "/dashboard/protocols" }, text: "Dashboard")
+        expect(breadcrumbs).to have_tag('a', with: { href: "/dashboard/protocols/#{protocol.id}" }, text: "(#{protocol.id}) My Protocol")
+        expect(breadcrumbs).to have_tag('li', text: "Test")
+        expect(breadcrumbs).to match(/Dashboard.*My Protocol.*Test/) # expect correct order
+      end
     end
   end
 end

--- a/spec/lib/fee_agreement/report_spec.rb
+++ b/spec/lib/fee_agreement/report_spec.rb
@@ -126,12 +126,14 @@ RSpec.describe FeeAgreement::Report do
 
     it 'should create a table for non-clinical services' do
       expect(report.non_clinical_service_table.class).to eq(FeeAgreement::NonClinicalServiceTable)
+      expect(report.non_clinical_services_displayed?).to be(true)
     end
     it 'should create a row in the non-clinical service table for every active otf line item' do
       expect(report.non_clinical_service_table.rows.count).to eq(2)
     end
     it 'should create a clinical service table for each arm' do
       expect(report.clinical_service_tables.size).to eq(2)
+      expect(report.clinical_services_displayed?).to be(true)
     end
 
     it 'computes a clinical service total' do
@@ -200,6 +202,8 @@ RSpec.describe FeeAgreement::Report do
         expect(report.non_clinical_service_table.rows.count).to eq(0)
         expect(report.clinical_service_tables[0].rows.count).to eq(0)
         expect(report.clinical_service_tables[1].rows.count).to eq(1)
+        expect(report.non_clinical_services_displayed?).to be(false)
+        expect(report.clinical_services_displayed?).to be(true)
       end
 
       it 'should only include selected program data in computed totals' do


### PR DESCRIPTION
# Overview

Refinements to the Fee Agreement report based on testing.

## Contributions

- Hide report sections when empty (Clinical Services and Non-Clinical Services).
- Rename "Non-clinical Services and Initiation fees" to "Non-Clinical Services" for consistency. 
- Modify the breadcrumb at the top of the report to allow users to go back to the protocol.
- Added a function to the Breadcrumber lib to allow an arbitrary path name.
- Updated the Terms to use more widely applicable language.

## Ticket

https://www.pivotaltracker.com/story/show/180199840

octri_contribution