### PR TITLE
fix to script to allow date conversion

### DIFF
--- a/lib/tasks/move_service.rake
+++ b/lib/tasks/move_service.rake
@@ -32,6 +32,7 @@ task :move_service, [:service_id, :organization_id] => :environment do |t, args|
     puts "\nService requests and sub service requests affected:"
 
     service.service_requests.each do |sr|
+      puts "Working on SRID: #{sr.id}"
       # SSR's that contain LineItems that need to be moved
       ssrs = sr.sub_service_requests.
         where.not(organization: dest_org_process_ssrs).
@@ -39,6 +40,7 @@ task :move_service, [:service_id, :organization_id] => :environment do |t, args|
         where(line_items: { service_id: service.id })
 
       ssrs.each do |ssr|
+        puts "Working on SSRID: #{ssr.id}"
         if ssr_contains_just_this_service?(ssr, service)
           # Don't really need to move anything. Just move the SSR
           # to another Organization.
@@ -60,6 +62,11 @@ task :move_service, [:service_id, :organization_id] => :environment do |t, args|
             # ! needed, since only it will return the _other_ attributes.
             copy_over_attributes = old_attributes.
               slice!(*%w(id ssr_id organization_id org_tree_display status))
+            
+            # fix 2 dates so that they are in the correct format for custom setters in the SSR model
+            copy_over_attributes['requester_contacted_date'] = copy_over_attributes['requester_contacted_date'].blank? ? nil : copy_over_attributes['requester_contacted_date'].strftime('%m/%d/%Y')
+            copy_over_attributes['consult_arranged_date'] = copy_over_attributes['consult_arranged_date'].blank? ? nil : copy_over_attributes['consult_arranged_date'].strftime('%m/%d/%Y')
+
             dest_ssr.assign_attributes(copy_over_attributes)
             dest_ssr.save(validate: false)
             dest_ssr.update_org_tree


### PR DESCRIPTION
2 date fields were causing the script to fail.  They have custom setter methods in the SSR model.  This fix only changes what happens in the script and leaves the setter methods alone.  Some additional debugging statements will also stay in.