### PR TITLE
Add the 'By' and 'Date' columns to the Form Submissions table on SPAR…

### DIFF
--- a/app/views/forms/_table.html.haml
+++ b/app/views/forms/_table.html.haml
@@ -42,8 +42,14 @@
               = Form.human_attribute_name(:surveyable)
             %th{ data: { field: "title", align: "left", sortable: "true" } }
               = Form.human_attribute_name(:title)
-            %th{ data: { field: "completed", align: "center", sortable: "false" } }
-              = Form.human_attribute_name(:completed)
+            - if !in_dashboard?
+              %th{ data: { field: "completed", align: "center", sortable: "false" } }
+                = Form.human_attribute_name(:completed)
+            - if in_dashboard?
+              %th{ data: { field: "by", align: "left", sortable: "false" } }
+                = Form.human_attribute_name(:by)
+              %th{ data: { field: "completion_date", align: "center", sortable: "false" } }
+                = Form.human_attribute_name(:date)
             %th{ data: { field: "actions", align: "center", sortable: "false" } }
               = t('actions.actions')
     - else

--- a/app/views/forms/index.json.jbuilder
+++ b/app/views/forms/index.json.jbuilder
@@ -7,5 +7,9 @@ json.(@forms) do |form, respondable|
     json.title        form.title
     json.completed    form_completed_display(completed)
     json.actions      form_options(form, completed, respondable)
+    if response = Response.where(survey: form, respondable: respondable).first
+      json.by                response.identity.try(:full_name) || 'N/A'
+      json.completion_date   format_date(response.created_at)
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
         surveyable: "Association"
         title: "Title"
         completed: "Completed"
+        by: "By"
+        completion_date: "Date"
       fulfillment:
         date: "Date Fulfilled"
         time: "Quantity"


### PR DESCRIPTION
…CDashboard

https://www.pivotaltracker.com/n/projects/1918597/stories/181588054

**Background:**
Although admin users can see who submitted a form with the date of submission from SPARCForms module, there is no matching information from SPARCDashboard in the Form Submissions table. That is causing inconvenience for service providers when they are gathering versions and information.

**Acceptance Criteria:**
Please add the 'By' and 'Date' columns onto the Form Submissions table on SPARCDashboard.