### PR TITLE
SJ - Small Fixes

### DIFF
--- a/db/migrate/20211122165334_add_institution_to_identities.rb
+++ b/db/migrate/20211122165334_add_institution_to_identities.rb
@@ -5,9 +5,11 @@ class AddInstitutionToIdentities < ActiveRecord::Migration[5.2]
 
     Identity.reset_column_information
 
-    Identity.all.each do |identity|
+    progress_bar = ProgressBar.new(Identity.count)
+    Identity.find_each do |identity|
       identity.institution = identity.professional_org_lookup('institution')
       identity.save(validate: false)
+      progress_bar.increment!
     end
 
   end


### PR DESCRIPTION
A recently added migration edits every single identity (82,000+ records!) without any sort of progress bar, and without any batch loading. This causes deploys to hang for a LONG time, with no indication of progress, and could possibly fail when deploying to production. I've added a progress bar, and change the "Identity.each" to "Identity.find_each" which has automatic batch sizing.

Also, I think an extra folder was committed by mistake, we had an empty "sparc-request" file folder... inside the application. I've removed it.