### PR TITLE
Make Fee Agreement Report Configurable

### DIFF
--- a/app/views/dashboard/service_requests/_service_requests.html.haml
+++ b/app/views/dashboard/service_requests/_service_requests.html.haml
@@ -52,8 +52,9 @@
         = link_to dashboard_protocol_path(protocol, format: :pdf), target: :_blank, class: 'btn btn-success cost-analysis mr-1' do
           = succeed t('dashboard.protocols.service_requests.cost_analysis_report') do
             = icon('fas', 'file-pdf mr-2')
-        = link_to fee_agreement_dashboard_protocol_path(protocol, format: :html), class: 'btn btn-success' do
-          = succeed t('dashboard.protocols.service_requests.fee_agreement') do
-            = icon('fas', 'eye mr-2')
+        - if Setting.get_value('use_fee_agreement')
+          = link_to fee_agreement_dashboard_protocol_path(protocol, format: :html), class: 'btn btn-success' do
+            = succeed t('dashboard.protocols.service_requests.fee_agreement') do
+              = icon('fas', 'eye mr-2')
     .collapse.show{ class: "service-request-#{sr.id}" }
       = render 'dashboard/service_requests/protocol_service_request_show', service_request: sr, protocol: protocol, permission_to_edit: permission_to_edit

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -940,6 +940,16 @@
     "parent_value":   ""
   },
   {
+    "key":            "use_fee_agreement",
+    "value":          "false",
+    "friendly_name":  "Use Fee Agreement Report",
+    "description":    "This determines whether the application will use the Fee Agreement Report. When turned off, there will be no Fee Agreement button.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "",
+    "parent_value":   ""
+  },
+  {
     "key":            "use_feedback_link",
     "value":          "false",
     "friendly_name":  "Use Feedback Link",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -727,7 +727,7 @@ ActiveRecord::Schema.define(version: 2022_03_09_210040) do
     t.string "guarantor_contact"
     t.string "guarantor_phone"
     t.string "guarantor_email"
-    t.boolean "all_research_billing", default: true
+    t.string "default_billing_type", default: "r"
     t.index ["next_ssr_id"], name: "index_protocols_on_next_ssr_id"
   end
 
@@ -983,10 +983,6 @@ ActiveRecord::Schema.define(version: 2022_03_09_210040) do
     t.datetime "deleted_at"
     t.datetime "consult_arranged_date"
     t.datetime "requester_contacted_date"
-    t.boolean "nursing_nutrition_approved", default: false
-    t.boolean "lab_approved", default: false
-    t.boolean "imaging_approved", default: false
-    t.boolean "committee_approved", default: false
     t.boolean "in_work_fulfillment", default: false
     t.string "routing"
     t.text "org_tree_display"

--- a/spec/lib/fee_agreement/clinical_service_row_spec.rb
+++ b/spec/lib/fee_agreement/clinical_service_row_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe FeeAgreement::ClinicalServiceRow do
   let(:visit2_pppv1) { create(:visit, line_items_visit: liv_pppv1, research_billing_qty: 2) }
 
   context('construction from a LineItemsVisit and list of Visits') do
+    stub_config("use_fee_agreement", true)
+
     context('without summary information') do
       let(:row) { FeeAgreement::ClinicalServiceRow.build(liv_pppv1, [visit1_pppv1, visit2_pppv1], show_summary = false) }
       it('sets the program name') do

--- a/spec/lib/fee_agreement/clinical_service_table_spec.rb
+++ b/spec/lib/fee_agreement/clinical_service_table_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe FeeAgreement::ClinicalServiceTable do
   end
 
   context('table initialization') do
+    stub_config("use_fee_agreement", true)
+
     let(:table) {
       FeeAgreement::ClinicalServiceTable.new(
         service_request: @service_request,

--- a/spec/lib/fee_agreement/non_clinical_service_row_spec.rb
+++ b/spec/lib/fee_agreement/non_clinical_service_row_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe FeeAgreement::NonClinicalServiceRow do
   let(:line_item) { create(:line_item_with_service, :one_time_fee, service: service, protocol: protocol) }
 
   context('initialization from a line item') do
+    stub_config("use_fee_agreement", true)
+
     let(:row) { FeeAgreement::NonClinicalServiceRow.new(line_item) }
 
     it('sets the program name') do

--- a/spec/lib/fee_agreement/non_clinical_service_table_spec.rb
+++ b/spec/lib/fee_agreement/non_clinical_service_table_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe FeeAgreement::NonClinicalServiceTable do
     @org_C.destroy
   end
 
+  stub_config("use_fee_agreement", true)
+
   it('constructs a row for every active otf line item') do
     table = FeeAgreement::NonClinicalServiceTable.new(@service_request)
     expect(table.rows.count).to eq(2)

--- a/spec/lib/fee_agreement/report_spec.rb
+++ b/spec/lib/fee_agreement/report_spec.rb
@@ -126,6 +126,8 @@ RSpec.describe FeeAgreement::Report do
     @program_admin.destroy
   end
 
+  stub_config("use_fee_agreement", true)
+
   context 'report creation' do
     let(:report) { FeeAgreement::Report.new(@sr) }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/181312573

1. Add a new 'use_fee_agreement' setting, run rake data:import_settings to add the new setting
2. When this configuration is turned on, the "Fee Agreement" button would show up on SPARCDashboard and triggers the generation of the report; when turned off, there should be no Fee Agreement button.