### PR TITLE
SJ - Fixing Service Request Issue

### DIFF
--- a/app/controllers/line_items_visits_controller.rb
+++ b/app/controllers/line_items_visits_controller.rb
@@ -41,7 +41,7 @@ class LineItemsVisitsController < ApplicationController
     if @line_items_visit.update_attributes(line_items_visit_params)
       unless @in_admin
         @line_items_visit.sub_service_request.update_attribute(:status, 'draft')
-        @service_request.update_attribute(:status, 'draft')
+        @service_request.update_attribute(:status, 'draft') unless (@service_request.submitted? || @service_request.previously_submitted?)
       end
     else
       @errors = @line_items_visit.errors

--- a/app/controllers/service_calendars_controller.rb
+++ b/app/controllers/service_calendars_controller.rb
@@ -99,7 +99,7 @@ class ServiceCalendarsController < ApplicationController
     # Update the sub service request only if we are not in dashboard; admin's actions should not affect the status
     unless @in_admin
       @line_items_visit.sub_service_request.update_attribute(:status, "draft")
-      @service_request.update_attribute(:status, "draft")
+      @service_request.update_attribute(:status, "draft") unless (@service_request.submitted? || @service_request.previously_submitted?)
     end
 
     respond_to :js
@@ -138,7 +138,7 @@ class ServiceCalendarsController < ApplicationController
     # Update the sub service request only if we are not in dashboard; admin's actions should not affect the status
     unless @in_admin
       editable_ssrs.where.not(status: 'draft').update_all(status: 'draft')
-      @service_request.update_attribute(:status, "draft")
+      @service_request.update_attribute(:status, "draft") unless (@service_request.submitted? || @service_request.previously_submitted?)
     end
 
     respond_to :js


### PR DESCRIPTION
Service requests should never be changed from submitted to draft.

This is (one at least) the cause of the email bug that keeps cropping up. Service requests were being set back to draft when the calendar was edited. Now it will only change to draft if it's never been submitted (and isn't currently submitted status).

[#179691800]

https://www.pivotaltracker.com/story/show/179691800