### PR TITLE
Fixed missing credential other error message bug

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -77,6 +77,8 @@ class Identity < ApplicationRecord
 
   validates_presence_of :first_name, :last_name, :email
 
+  validates_presence_of :credentials_other, if: Proc.new{ |i| i.credentials == 'other' }
+
   validates_format_of :email, with: DataTypeValidator::EMAIL_REGEXP, allow_blank: true, if: :email_changed?
   validates_format_of :phone, with: DataTypeValidator::PHONE_REGEXP, allow_blank: true, if: :phone_changed?
 

--- a/app/models/project_role.rb
+++ b/app/models/project_role.rb
@@ -74,7 +74,6 @@ class ProjectRole < ApplicationRecord
 
   def validate_other_selections
     role_other_filled = true
-    credentials_other_filled = true
 
     if self.role == 'other'
       if self.role_other.nil? || (!self.role_other.nil? && self.role_other.blank?)
@@ -82,15 +81,7 @@ class ProjectRole < ApplicationRecord
         errors.add(:must, "specify this User's Role.")
       end
     end
-
-    if self.identity.credentials == 'other'
-      if self.identity.credentials_other.nil? || (!self.identity.credentials_other.nil? && self.identity.credentials_other.blank?)
-        credentials_other_filled = false
-        errors.add(:must, "specify this User's Credentials.")
-      end
-    end
-
-    return role_other_filled && credentials_other_filled
+    return role_other_filled
   end
 
   def validate_one_primary_pi


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/182377612

Fixed the following 2 issues:

1. Unable to save a (Create/Edit) Authorized User Form, if 'Other' is selected for Credentials without entering anything in the 'Please Specify' textbox.
2. Need conditional validation on credentials_other on Profile form.

