### PR TITLE
JL - Fix bug with dashboard merged protocol search

### DIFF
--- a/app/controllers/dashboard/protocols_controller.rb
+++ b/app/controllers/dashboard/protocols_controller.rb
@@ -35,11 +35,13 @@ class Dashboard::ProtocolsController < Dashboard::BaseController
 
     # if we are performing a search, check if user is looking for an old protocol
     # that has been merged and return the most current master protocol
-    if params.has_key?(:filterrific) && params[:filterrific].has_key?(:search_query) && params[:filterrific][:search_query][:search_drop] == "Protocol ID"
+    if params.has_key?(:filterrific) && params[:filterrific].has_key?(:search_query)
       search_term = params[:filterrific][:search_query][:search_text].to_i
-      merge = search_protocol_merges(search_term)
-      if merge
-        params[:filterrific][:search_query][:search_text] = merge.master_protocol_id.to_s
+      if search_term > 0
+        merge = search_protocol_merges(search_term)
+        if merge
+          params[:filterrific][:search_query][:search_text] = merge.master_protocol_id.to_s
+        end
       end
     end
 


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/n/projects/1918597/stories/182847204)

Description: When searching for a protocol that has been previously merged by entering its ID, the result should be the master protocol that it was merged into. Currently this functionality is broken.

Solution: In order for the search to happen correctly, the check for `search_drop = 'Protocol ID'` had to pass. This only happens if the user selects the 'Protocol ID' search from the dropdown box. This was causing confusion because most users just search for 'All'. The fix was to check if the search term was an integer (if it is a string then calling `string.to_i` will be zero), and if so attempt to find any existing protocol merges. 