### PR TITLE
GM - Prevent deletion of sub_service_requests record if already pushed to Fulfillment

### DIFF
--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -72,15 +72,6 @@ class SubServiceRequest < ApplicationRecord
   after_save :update_org_tree
   after_save :update_past_status
 
-  # Users should not be able to delete a request that has been pushed
-  # to Fulfillment
-  before_destroy do
-    if self.in_work_fulfillment?
-      errors[:base] << "This request has been pushed to SPARC Fulfillment and cannot be deleted."
-      throw(:abort)
-    end
-  end
-
   scope :in_work_fulfillment, -> { where(in_work_fulfillment: true) }
   scope :imported_to_fulfillment, -> { where(imported_to_fulfillment: true) }
 

--- a/app/models/sub_service_request.rb
+++ b/app/models/sub_service_request.rb
@@ -72,6 +72,15 @@ class SubServiceRequest < ApplicationRecord
   after_save :update_org_tree
   after_save :update_past_status
 
+  # Users should not be able to delete a request that has been pushed
+  # to Fulfillment
+  before_destroy do
+    if self.in_work_fulfillment?
+      errors[:base] << "This request has been pushed to SPARC Fulfillment and cannot be deleted."
+      throw(:abort)
+    end
+  end
+
   scope :in_work_fulfillment, -> { where(in_work_fulfillment: true) }
   scope :imported_to_fulfillment, -> { where(imported_to_fulfillment: true) }
 

--- a/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
+++ b/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
@@ -29,13 +29,17 @@
         .list-group-item.line-item
           .row
             .col-10.d-flex.align-items-center.pr-0
-              %h6.mb-0{ class: ssr.is_complete? ? 'text-success' : ssr.is_locked? ? 'text-danger' : '' }<
+              %h6.mb-0{ class: ssr.is_complete? ? 'text-success' : ssr.is_locked? ? 'text-danger' : '' }
                 = li.service.abbreviation
                 - if li.service.cpt_code.present?
                   %strong
                     = "(#{li.service.cpt_code})"
                 - unless li.service.is_available
                   = inactive_tag
-            - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name)
+            - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name) && li != ssr.line_items.last && !ssr.in_work_fulfillment
               .col-2.pl-0.text-right
                 = link_to icon('fas', 'trash-alt'), remove_service_service_request_path(srid: service_request.id, line_item_id: li.id), remote: true, method: :delete, class: 'btn btn-sm btn-sq btn-danger remove-service', title: t('proper.cart.remove_service'), data: { toggle: 'tooltip', disable: true }
+            - else
+              .col-2.pl-0.text-right
+                = button_tag(icon('fas', 'trash-alt'), type: 'button',
+                title: t(:activerecord)[:errors][:models][:service_request] [:attributes][:line_items][:pushed_to_fulfillment], class: "btn btn-danger btn-sm btn-sq disabled", data: { toggle: 'tooltip', disable: true })

--- a/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
+++ b/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
@@ -36,6 +36,10 @@
                     = "(#{li.service.cpt_code})"
                 - unless li.service.is_available
                   = inactive_tag
-            - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name)
+            - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name) && !ssr.in_work_fulfillment?
               .col-2.pl-0.text-right
                 = link_to icon('fas', 'trash-alt'), remove_service_service_request_path(srid: service_request.id, line_item_id: li.id), remote: true, method: :delete, class: 'btn btn-sm btn-sq btn-danger remove-service', title: t('proper.cart.remove_service'), data: { toggle: 'tooltip', disable: true }
+            - else
+              .col-2.pl-0.text-right
+                = button_tag(icon('fas', 'trash-alt'), type: 'button',
+                title: t(:activerecord)[:errors][:models][:service_request] [:attributes][:line_items][:pushed_to_fulfillment], class: "btn btn-danger actions-button delete-authorized-user disabled", data: { toggle: 'tooltip', disable: true })

--- a/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
+++ b/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
@@ -29,7 +29,7 @@
         .list-group-item.line-item
           .row
             .col-10.d-flex.align-items-center.pr-0
-              %h6.mb-0{ class: ssr.is_complete? ? 'text-success' : ssr.is_locked? ? 'text-danger' : '' }
+              %h6.mb-0{ class: ssr.is_complete? ? 'text-success' : ssr.is_locked? ? 'text-danger' : '' }<
                 = li.service.abbreviation
                 - if li.service.cpt_code.present?
                   %strong
@@ -37,7 +37,7 @@
                 - unless li.service.is_available
                   = inactive_tag
             - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name)
-              - unless ssr.in_work_fulfillment && (li == ssr.line_items.last)
+              - unless ssr.in_work_fulfillment && (ssr.line_items.count == 1)
                 .col-2.pl-0.text-right
                   = link_to icon('fas', 'trash-alt'), remove_service_service_request_path(srid: service_request.id, line_item_id: li.id), remote: true, method: :delete, class: 'btn btn-sm btn-sq btn-danger remove-service', title: t('proper.cart.remove_service'), data: { toggle: 'tooltip', disable: true }
               - else

--- a/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
+++ b/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
@@ -36,10 +36,11 @@
                     = "(#{li.service.cpt_code})"
                 - unless li.service.is_available
                   = inactive_tag
-            - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name) && li != ssr.line_items.last && !ssr.in_work_fulfillment
-              .col-2.pl-0.text-right
-                = link_to icon('fas', 'trash-alt'), remove_service_service_request_path(srid: service_request.id, line_item_id: li.id), remote: true, method: :delete, class: 'btn btn-sm btn-sq btn-danger remove-service', title: t('proper.cart.remove_service'), data: { toggle: 'tooltip', disable: true }
-            - else
-              .col-2.pl-0.text-right
-                = button_tag(icon('fas', 'trash-alt'), type: 'button',
-                title: t(:activerecord)[:errors][:models][:service_request] [:attributes][:line_items][:pushed_to_fulfillment], class: "btn btn-danger btn-sm btn-sq disabled", data: { toggle: 'tooltip', disable: true })
+            - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name)
+              - unless ssr.in_work_fulfillment && (li == ssr.line_items.last)
+                .col-2.pl-0.text-right
+                  = link_to icon('fas', 'trash-alt'), remove_service_service_request_path(srid: service_request.id, line_item_id: li.id), remote: true, method: :delete, class: 'btn btn-sm btn-sq btn-danger remove-service', title: t('proper.cart.remove_service'), data: { toggle: 'tooltip', disable: true }
+              - else
+                .col-2.pl-0.text-right
+                  = button_tag(icon('fas', 'trash-alt'), type: 'button',
+                  title: t(:activerecord)[:errors][:models][:service_request] [:attributes][:line_items][:pushed_to_fulfillment], class: "btn btn-danger btn-sm btn-sq disabled", data: { toggle: 'tooltip', disable: true })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,6 +373,7 @@ en:
               blank: "You must create Arms before proceeding to the Service Calendar"
             line_items:
               blank: "You must add services to your cart before continuing"
+              pushed_to_fulfillment: "Requests that have already been pushed to Fulfillment cannot be deleted"
             protocol:
               blank: "You must create a Protocol before continuing"
         system_survey:


### PR DESCRIPTION
Users shouldn't be able to Delete a Request that has been pushed to SPARCFulfillment. The way users accomplish this is to use "Add Modify Request" and then on the dashboard screen delete the services from the cart. When the last service is deleted it triggers the SubServiceRequest to also be destroyed.
If this happens the VisitReport (and possibly other things) in SPARC Fulfillment will fail because the protocol row is storing the ID of a sub service request that will no longer exist.

[Pivotal Ticket](https://www.pivotaltracker.com/story/show/181758085)

[#181758085]

