### PR TITLE
GM - Change language and default radio

### DIFF
--- a/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
+++ b/app/views/dashboard/protocol_filters/_filter_protocols_form.html.haml
@@ -65,7 +65,7 @@
         .form-group.row.mb-0
           = f.label "admin_filter_for_all", t('dashboard.protocol_filters.all_protocols'), class: 'col-6 col-form-label pr-0'
           .col-5.d-flex.align-items-center.justify-content-center
-            = f.radio_button :admin_filter, "for_all"
+            = f.radio_button :admin_filter, "for_all", checked: "checked"
       .card-footer.flex-wrap
         = f.submit t('actions.filter'), class: 'btn btn-block btn-primary mb-2'
         .col-lg-6.col-12.pl-0.pr-1

--- a/app/views/service_requests/add_service.js.coffee
+++ b/app/views/service_requests/add_service.js.coffee
@@ -22,7 +22,7 @@
 ConfirmSwal.fire(
   icon: 'question'
   title: I18n.t('proper.catalog.new_request.header')
-  text: I18n.t('proper.catalog.new_request.warning')
+  text: " ",
   confirmButtonText: I18n.t('proper.catalog.new_request.yes_button')
   cancelButtonText: I18n.t('proper.catalog.new_request.no_button')
 ).then (result) ->

--- a/config/locales/proper.en.yml
+++ b/config/locales/proper.en.yml
@@ -48,10 +48,10 @@ en:
         notice: "* You may only select services applicable to ONE Study or Project at a time"
         dashboard_link: "Visit Your Dashboard"
       new_request:
-        header: "Is this a new request?"
+        header: "Is this a request for a new SPARC Study or Project?"
         warning: "Would you like to start a new Study or Project in SPARCRequest?"
         yes_button: "<b>Yes</b> <br>Continue Shopping"
-        no_button: "<b>No</b> <br>Visit my Dashboard"
+        no_button: "<b>No or Unsure</b> <br>Search SPARCDashboard"
       locked_organization:
         header: "%{ssr_id} - %{organization} is Locked"
         text: "Please contact %{contact_name} at %{contact_info} to make changes to the existing request."


### PR DESCRIPTION
When users add services on the SPARCRequest homepage, they are presented a pop-up screen that asks 2 different questions:

- Is this a new request AND
- Is this for a new study

The answers to these 2 questions may be different where both don't match the response button about creating a new study or going to dashboard. This request is to rephrase so only one question is being asked, revise 'No' button and customize the SPARCDashboard default filter to 'All Protocols' for 'No or Unsure' routing.

[Pivotal Ticket](https://www.pivotaltracker.com/story/show/183251824)

[#183251824]