### PR TITLE
modify identity display_gender method  

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -196,7 +196,12 @@ class Identity < ApplicationRecord
   end
 
   def display_gender
-    gender.present? ?  PermissibleValue.get_value('gender', gender) : ""
+    gender_display = gender.present? ?  PermissibleValue.get_value('gender', gender) : ""
+    if gender == "other" && self.gender_other.present?
+      gender_display  += " (#{self.gender_other})"
+    end
+
+    return gender_display
   end
 
   def display_age_group


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/182491420
- Fixed bug where the 'gender_other' text entered by users ( 'Prefer to Self-Describe' is selected) did not show in Admin/Users view.