### PR TITLE
JV - Max Length Validation Added to Protocol attribute 'short_title'

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -108,8 +108,10 @@ class Protocol < ApplicationRecord
 
   validates :indirect_cost_rate, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 1000 }, allow_blank: true, if: :indirect_cost_enabled
 
-  validates_presence_of :short_title,
-                        :title,
+  validates :short_title,
+            presence: true,
+            length: { maximum: 255 }
+  validates_presence_of :title,
                         :funding_status
   validates_presence_of :funding_source,            if: Proc.new{ |p| p.funded? || p.funding_status.blank? }
   validates_presence_of :potential_funding_source,  if: :pending_funding?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_19_141351) do
+ActiveRecord::Schema.define(version: 2022_09_07_153451) do
 
   create_table "admin_rates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "line_item_id"


### PR DESCRIPTION
When users previously attempted to add protocols, if the 'short_title' attribute was longer than the database-allowed 255 characters, the application would not save the new protocol record and would not indicate an error had occured. This simply adds a maximum length validation to the attribute that shows an error message if the form entry is longer than 255 characters.

https://www.pivotaltracker.com/story/show/183224023

[#183224023]