### PR TITLE
JL - Place ssr back into draft status if an arm is copied

### DIFF
--- a/app/services/arm_copier.rb
+++ b/app/services/arm_copier.rb
@@ -26,6 +26,7 @@ class ArmCopier < ApplicationService
   end
 
   def call
+    @copied_arm.line_items.first.sub_service_request.update(status: "draft")
     @new_arm.update_attributes(subject_count: @copied_arm.subject_count, new_with_draft: @copied_arm.new_with_draft,
                                minimum_visit_count: @copied_arm.minimum_visit_count, minimum_subject_count: @copied_arm.minimum_subject_count)
     visit_groups = @copied_arm.visit_groups


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/n/projects/1918597/stories/165837119)

- This is an enhancement to the copy arm story that reflects a change in the acceptance criteria. If an arm is copied, the request is place into draft status so that it goes through the full submission process.

[#165837119] 