### PR TITLE
GM - Multi-select documents checkbox issue fix

### DIFF
--- a/app/views/documents/_table.html.haml
+++ b/app/views/documents/_table.html.haml
@@ -35,7 +35,7 @@
         = link_to icon('fas', 'edit mr-2') + t('documents.edit_selected'), bulk_edit_documents_path(protocol_id: protocol.id, format: :js), class: 'btn btn-success edit-documents disabled', title: t('documents.tooltips.new'), data: { protocol_id: protocol.id, toggle: 'tooltip'}
 
     - url = in_dashboard? ? dashboard_documents_path(format: :json, protocol_id: protocol.id) : documents_path(format: :json, srid: service_request.id)
-    %table#documentsTable{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', url: url, toolbar: "#documentsTableToolbar" } }
+    %table#documentsTable{ data: { toggle: 'table', search: 'true', 'show-columns' => 'false', 'show-refresh' => 'true', url: url, toolbar: "#documentsTableToolbar" } }
       %thead.bg-light
         %tr
           - if !in_review?

--- a/app/views/documents/_table.html.haml
+++ b/app/views/documents/_table.html.haml
@@ -35,12 +35,11 @@
         = link_to icon('fas', 'edit mr-2') + t('documents.edit_selected'), bulk_edit_documents_path(protocol_id: protocol.id, format: :js), class: 'btn btn-success edit-documents disabled', title: t('documents.tooltips.new'), data: { protocol_id: protocol.id, toggle: 'tooltip'}
 
     - url = in_dashboard? ? dashboard_documents_path(format: :json, protocol_id: protocol.id) : documents_path(format: :json, srid: service_request.id)
-    %table#documentsTable{ data: { toggle: 'table', search: 'true', 'show-columns' => 'false', 'show-refresh' => 'true', url: url, toolbar: "#documentsTableToolbar" } }
+    %table#documentsTable{ data: { "checkbox-header" => "true", "click-to-select" => "true", toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', url: url, toolbar: "#documentsTableToolbar" } }
       %thead.bg-light
         %tr
           - if !in_review?
-            %th{ data: { field: 'checkbox', align: 'left'} }
-              = check_box_tag "select-all"
+            %th{ data: { field: 'state', checkbox: 'true', id: "select-all" } }
           %th{ data: { field: 'document', align: "left", sortable: "true" } }
             = Document.human_attribute_name(:document)
           %th{ data: { field: 'type', align: "left", sortable: "true" } }

--- a/spec/helpers/documents_helper_spec.rb
+++ b/spec/helpers/documents_helper_spec.rb
@@ -49,9 +49,22 @@ RSpec.describe DocumentsHelper, type: :helper do
     end
   end
 
+  describe 'set select-all attributes on checkbox column' do
+    let(:document) { create(:document) }
 
+    context 'in dashboard' do
+      before(:each) { allow(helper).to receive(:in_dashboard?).and_return(true) }
 
-  describe '#display_document_title' do
+      context 'with permission' do
+        it 'should render checkbox with name^="select-document" id' do
+          expect(helper).to receive(:check_box_tag).with("select-document-#{document.id}", "#{document.id}")
+          helper.display_check_box(document)
+        end
+      end
+    end
+  end
+
+ describe '#display_document_title' do
     let(:document) { create(:document) }
 
     context 'in dashboard' do


### PR DESCRIPTION
There is a double checkbox showing in the select/deselect columns dropdown of the documents table. This change removes the checkbox colulmn from that menu.

[Pivotal Story](https://www.pivotaltracker.com/story/show/183429075)

[#183429075]