### PR TITLE
JL - Human subjects driven logic for epic questions bug

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -74,10 +74,6 @@ $(document).ready ->
       $('#protocol_research_master_id').siblings('label').addClass('required')
       $('#protocol_human_subjects_info_attributes_approval_pending').bootstrapToggle('enable')
       $('[name="protocol[human_subjects_info_attributes][approval_pending]"').attr('disabled', false)
-      if $('#protocol_selected_for_epic_false').prop('checked')
-        $('#studyTypeQuestionsContainer').removeClass('d-none')
-        hideStudyTypeQuestion($(certificateOfConfidence))
-        showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
     else
       $('#protocol_research_master_id').siblings('label').removeClass('required')
       $('#protocol_human_subjects_info_attributes_approval_pending').bootstrapToggle('disable')
@@ -156,13 +152,6 @@ $(document).ready ->
       setRequiredFields()
       hideStudyTypeQuestion($(certificateOfConfidenceNoEpic))
       showStudyTypeQuestion($(certificateOfConfidence))
-    else if $('#protocol_research_types_info_attributes_human_subjects').prop('checked')
-      if $('#studyTypeQuestionsContainer').hasClass('d-none')
-        $('#studyTypeQuestionsContainer').removeClass('d-none')
-      $('label[for=protocol_study_type_questions]').removeClass('required')
-      setRequiredFields()
-      hideStudyTypeQuestion($(certificateOfConfidence))
-      showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
     else
       $('#studyTypeQuestionsContainer').addClass('d-none')
 

--- a/spec/features/dashboard/protocols/new/user_selects_publish_in_epic_spec.rb
+++ b/spec/features/dashboard/protocols/new/user_selects_publish_in_epic_spec.rb
@@ -55,25 +55,6 @@ RSpec.describe 'User edits study type questions', js: true do
           expect(page).to have_content('Full Epic Functionality: no notification, no yellow advisory, no MyChart access.')
         end
       end
-
-      context 'selects "No" to "Publish Study in Epic"' do
-        context 'Human Subjects is checked' do
-          it 'should show certificate of confidentiality questions without Epic language' do
-            find("[for='protocol_selected_for_epic_false']").click
-            wait_for_javascript_to_finish
-
-            find('#protocol_research_types_info_attributes_human_subjects + label').click
-            wait_for_javascript_to_finish
-
-            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
-
-            bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-            wait_for_javascript_to_finish
-
-            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
-          end
-        end
-      end
     end
 
     context 'Not Using Epic' do

--- a/spec/features/proper/protocol/protocols/user_selects_publish_in_epic_spec.rb
+++ b/spec/features/proper/protocol/protocols/user_selects_publish_in_epic_spec.rb
@@ -63,25 +63,6 @@ RSpec.describe 'User edits study type questions', js: true do
           expect(page).to have_content('Full Epic Functionality: no notification, no yellow advisory, no MyChart access.')
         end
       end
-
-      context 'selects "No" to "Publish Study in Epic"' do
-        context 'Human Subjects is checked' do
-          it 'should show certificate of confidentiality questions without Epic language' do
-            find("[for='protocol_selected_for_epic_false']").click
-            wait_for_javascript_to_finish
-
-            find('#protocol_research_types_info_attributes_human_subjects + label').click
-            wait_for_javascript_to_finish
-
-            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[5], normalize_ws: true)
-
-            bootstrap_select '#study_type_answer_certificate_of_conf_no_epic_answer', 'No'
-            wait_for_javascript_to_finish
-
-            expect(page).to have_content(STUDY_TYPE_QUESTIONS_VERSION_3[6], normalize_ws: true)
-          end
-        end
-      end
     end
 
     context 'Not Using Epic' do


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/n/projects/1918597/stories/183444254)

This fixes a bug where clicking the human subjects info box on the protocols form was changing epic questions to the old text.

[#183444254]