### PR TITLE
GM - Replace input with span to fix double checkbox bug

### DIFF
--- a/app/assets/javascripts/documents.js.coffee
+++ b/app/assets/javascripts/documents.js.coffee
@@ -25,6 +25,8 @@ $(document).ready ->
     else
       $('#doc-type-other-field').addClass('d-none')
 
+  $('div.dropdown-menu input[type="checkbox"][name="select-all"]').replaceWith( '<span>Multi-select Documents</span>')
+
   $(document).on 'change', '#document_document', ->
    fileName = $(this).val().split('\\').pop()
    $(this).next('.custom-file-label').addClass("selected").html(fileName)
@@ -67,7 +69,7 @@ $(document).ready ->
 
   $(document).on 'click', '.edit-documents', (event) ->
     event.preventDefault()
-    
+
     selections = $('#documentsTable input[type="checkbox"]:checked') # get all selected checkboxes
     document_ids = $.map(selections, (c) -> return c.value) # get ids of all selected documents
 
@@ -93,7 +95,7 @@ $(document).ready ->
     $.ajax
       url:    '/documents/bulk_update'
       method: 'PUT'
-      data: 
+      data:
         protocol_id : protocol_id
         document_ids: document_ids
         share_all   : share_all

--- a/app/views/documents/_table.html.haml
+++ b/app/views/documents/_table.html.haml
@@ -35,11 +35,12 @@
         = link_to icon('fas', 'edit mr-2') + t('documents.edit_selected'), bulk_edit_documents_path(protocol_id: protocol.id, format: :js), class: 'btn btn-success edit-documents disabled', title: t('documents.tooltips.new'), data: { protocol_id: protocol.id, toggle: 'tooltip'}
 
     - url = in_dashboard? ? dashboard_documents_path(format: :json, protocol_id: protocol.id) : documents_path(format: :json, srid: service_request.id)
-    %table#documentsTable{ data: { "checkbox-header" => "true", "click-to-select" => "true", toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', url: url, toolbar: "#documentsTableToolbar" } }
+    %table#documentsTable{ data: { toggle: 'table', search: 'true', 'show-columns' => 'true', 'show-refresh' => 'true', url: url, toolbar: "#documentsTableToolbar" } }
       %thead.bg-light
         %tr
           - if !in_review?
-            %th{ data: { field: 'state', checkbox: 'true', id: "select-all" } }
+            %th{ data: { field: 'checkbox', align: 'left' } }
+              = check_box_tag 'select-all'
           %th{ data: { field: 'document', align: "left", sortable: "true" } }
             = Document.human_attribute_name(:document)
           %th{ data: { field: 'type', align: "left", sortable: "true" } }


### PR DESCRIPTION
Currently the dropdown column display menu in dashboard/documents table is showing a second checkbox in place of a text label on the first line. 
This changes that element on page load to name the first checkbox and match the rest of the menu. 

[Pivotal Story](https://www.pivotaltracker.com/story/show/183429075)

[#183429075]