### PR TITLE
Fixing undefined method for NilClass bug- sparc settings

### DIFF
--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -34,7 +34,7 @@ module Admin::SettingsHelper
   end
 
   def display_setting_value(setting)
-    if setting[:value].length > 40
+    if setting[:value] && setting[:value].length > 40
       truncate(setting[:value], length: 40)
     else
       setting[:value]


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/184083786

An exception occurs caused by a nil value setting (key: epic_user_api_error_teams_webhook).