### PR TITLE
YW-Added Funding Status to protocol summary

### DIFF
--- a/app/views/protocols/_summary.html.haml
+++ b/app/views/protocols/_summary.html.haml
@@ -77,6 +77,12 @@
               = Protocol.human_attribute_name(:sponsor_name)
           %td.d-inline-block.col-10
             = protocol.sponsor_name
+      %tr.d-flex
+        %td.d-inline-block.col-2
+          %label.mb-0
+            = Protocol.human_attribute_name(:funding_status)
+        %td.d-inline-block.col-10
+          = PermissibleValue.get_value('funding_status', protocol.funding_status)
       - if protocol.funded? || protocol.pending_funding?
         %tr.d-flex
           %td.d-inline-block.col-2
@@ -84,10 +90,3 @@
               = Protocol.human_attribute_name(:funding_source)
           %td.d-inline-block.col-10
             = protocol.display_funding_source_value
-      - else
-        %tr.d-flex
-          %td.d-inline-block.col-2
-            %label.mb-0
-              = Protocol.human_attribute_name(:funding_status)
-          %td.d-inline-block.col-10
-            = PermissibleValue.get_value('funding_status', protocol.funding_status)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/184082536

Background:  Prior to v3.10.0, when you select a funding status of “Pending”, the funding source row in the study/project summary shows “Potential Funding Source”. In v.3.10.x, the funding source simply reads “Funding Source” regardless of the status (Not Funded/Pending or Funded). After brief email discussions among Op Committee, it is agreed that we add funding status to the protocol summary.