### PR TITLE
GM - Fix multiple documents download error 

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -22,13 +22,6 @@ class Document < ApplicationRecord
 
   audited
 
-  SUPPORTED_FILE_TYPES = [
-    /\.pdf$/i,  /\.docx?$/i, /\.xlsx?$/i, /\.txt$/i,
-    /\.csv$/i,  /\.ppt?$/i,  /\.msg$/i,   /\.eml$/i,
-    /\.jpg$/i,  /\.gif$/i,   /\.png$/i,   /\.tiff$/i,
-    /\.jpeg$/i
-  ]
-
   belongs_to :protocol
 
   has_and_belongs_to_many :sub_service_requests
@@ -36,18 +29,11 @@ class Document < ApplicationRecord
 
   has_one_attached :document, dependent: :destroy
 
-
   validates :doc_type, :document, presence: true
 
   validates :doc_type_other, presence: true, if: Proc.new { |doc| doc.doc_type == 'other' }
 
   validate :supported_file_types
-
-  before_create :remove_parenthesis_from_filename
-
-  def remove_parenthesis_from_filename
-    document.filename.to_s =  document.filename.to_s.gsub(/[()]/,"")
-  end
 
   def display_document_type
     self.doc_type == "other" ? self.doc_type_other : PermissibleValue.get_value('document_type', self.doc_type)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -22,6 +22,13 @@ class Document < ApplicationRecord
 
   audited
 
+  SUPPORTED_FILE_TYPES = [
+    #/\.pdf$/i,  /\.docx?$/i, /\.xlsx?$/i, /\.txt$/i,
+    #/\.csv$/i,  /\.ppt?$/i,  /\.msg$/i,   /\.eml$/i,
+    #/\.jpg$/i,  /\.gif$/i,   /\.png$/i,   /\.tiff$/i,
+    #/\.jpeg$/i
+  ]
+
   belongs_to :protocol
 
   has_and_belongs_to_many :sub_service_requests

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,7 +46,7 @@ class Document < ApplicationRecord
   before_create :remove_parenthesis_from_filename
 
   def remove_parenthesis_from_filename
-    self.document.blob = self.document.blob.gsub(/[()]/,"")
+    document.filename.to_s =  document.filename.to_s.gsub(/[()]/,"")
   end
 
   def display_document_type

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,7 +33,7 @@ class Document < ApplicationRecord
 
   has_and_belongs_to_many :sub_service_requests
   has_many :organizations, through: :sub_service_requests
-  
+
   has_one_attached :document, dependent: :destroy
 
 
@@ -46,7 +46,7 @@ class Document < ApplicationRecord
   before_create :remove_parenthesis_from_filename
 
   def remove_parenthesis_from_filename
-    self.document_file_name = self.document_file_name.gsub(/[()]/,"")
+    self.document.document.filename = self.document.document.filename.gsub(/[()]/,"")
   end
 
   def display_document_type

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -36,10 +36,18 @@ class Document < ApplicationRecord
   
   has_one_attached :document, dependent: :destroy
 
+
   validates :doc_type, :document, presence: true
+
   validates :doc_type_other, presence: true, if: Proc.new { |doc| doc.doc_type == 'other' }
 
   validate :supported_file_types
+
+  before_create :remove_parenthesis_from_filename
+
+  def remove_parenthesis_from_filename
+    self.document_file_name = self.document_file_name.gsub(/[()]/,"")
+  end
 
   def display_document_type
     self.doc_type == "other" ? self.doc_type_other : PermissibleValue.get_value('document_type', self.doc_type)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,7 +46,7 @@ class Document < ApplicationRecord
   before_create :remove_parenthesis_from_filename
 
   def remove_parenthesis_from_filename
-    self.document.document.filename = self.document.document.filename.gsub(/[()]/,"")
+    self.document.blob = self.document.blob.gsub(/[()]/,"")
   end
 
   def display_document_type

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -26,3 +26,5 @@ Rails.application.initialize!
 
 ActiveResource::Base.logger = ActiveRecord::Base.logger
 
+Mime::Type.register "application/pdf", :pdf
+


### PR DESCRIPTION
Parenthesis in document file name causing error in zip file creation. This PR adds a callback that removes parenthesis from filename before creating the object.

[Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/183946663)

[#183946663]