### PR TITLE
GM - Fix 'Close' button in messages inbox

### DIFF
--- a/app/views/dashboard/messages/_index.html.haml
+++ b/app/views/dashboard/messages/_index.html.haml
@@ -57,4 +57,4 @@
       - else
         .text-right
           %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
-            = t('actions.close')
+            = link_to t('actions.close'), dashboard_notifications_path


### PR DESCRIPTION
This PR adds additional functionality to the individual message views that we added to notification emails. "Close" button or "X"-ing out of the container now takes user to their message inbox on their Dashboard.

[Pivotal Ticket](https://www.pivotaltracker.com/story/show/183986301)

[#183986301]