### PR TITLE
GM - 'No wkhtmltopdf executable found' error fix 

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -26,3 +26,4 @@ Rails.application.initialize!
 
 ActiveResource::Base.logger = ActiveRecord::Base.logger
 
+Mime::Type.register "application/pdf", :pdf


### PR DESCRIPTION
Registering pdf again in config/environment fixed this in my local. 
This is a bug that came up during testing for ActiveStorage migration story - https://www.pivotaltracker.com/story/show/170086933