### PR TITLE
Fix a Funding Document Download table export button bug

### DIFF
--- a/app/controllers/funding/services_controller.rb
+++ b/app/controllers/funding/services_controller.rb
@@ -68,7 +68,7 @@ class Funding::ServicesController < ApplicationController
       csv << ["SRID", "Primary PI", "Institution", "Protocol Short Title", "Document Name", "Uploaded", "SSR Status"]
       ##Insert table row for each document
       documents.each do |d|
-        ssr = d.share_all ? d.protocol.sub_service_requests.where(organization_id: Setting.get_value("funding_org_ids")).first : d.sub_service_requests.where(organization_id: Setting.get_value("funding_org_ids")).first
+        ssr = d.protocol.sub_service_requests.where(organization_id: Setting.get_value("funding_org_ids")).first
         p = ssr.protocol
         csv << [ssr.display_id, p.primary_pi.last_name_first, p.primary_pi.try(:professional_org_lookup, 'institution'), p.short_title, d.document.filename, d.updated_at.strftime('%D %l:%M %p'), PermissibleValue.get_value('status', ssr.status)]
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/184217264/comments/235217056

Fix a bug where an undefined method for nil:NilClass exception occurs if an uploaded document with either a 'LOI' or 'Application' document type does not assign access to the funding entity service providers.  Supposedly, this scenario should not happen, unfortunately, it does happen for whatever reasons... anyway, it is fixed now.