### PR TITLE
Only open SPARCCatalog module in new tab

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -214,7 +214,7 @@ module ApplicationHelper
 
     if accessible
       content_tag :li, class: 'nav-item' do
-        link_to name, path, target: :_blank, class: ['nav-link', active ? 'active' : '']
+        link_to name, path, target: identifier == 'sparc_catalog' ?  '_blank' : '', class: ['nav-link', active ? 'active' : '']
       end
     end
   end


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/n/projects/1918597/stories/181893059

All SPARC modules in top menu will open in the same tab when clicked, except for SPARCCatalog that will open in a new tab. 