### PR TITLE
Add Regional Health Network (RHN) Organization options for user profiles at MUSC

### DIFF
--- a/app/controllers/associated_users_controller.rb
+++ b/app/controllers/associated_users_controller.rb
@@ -1,23 +1,4 @@
 # Copyright © 2011-2022 MUSC Foundation for Research Development~
-# All rights reserved.~
-
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
-
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
-
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
-# disclaimer in the documentation and/or other materials provided with the distribution.~
-
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
-# derived from this software without specific prior written permission.~
-
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
-
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -40,7 +21,7 @@
 class AssociatedUsersController < ApplicationController
   before_action :initialize_service_request,  except: [:update_professional_organizations]
   before_action :authorize_identity,          except: [:update_professional_organizations]
-  
+
   include AssociatedUsersControllerShared
 
   def update_professional_organizations

--- a/app/models/professional_organization.rb
+++ b/app/models/professional_organization.rb
@@ -20,7 +20,7 @@
 
 class ProfessionalOrganization < ApplicationRecord
   # In order from most general to least.
-  ORG_TYPES = ['institution', 'college', 'department', 'division'].freeze
+  ORG_TYPES = ['institution', 'college', 'department', 'division', 'location'].freeze
   audited
 
   belongs_to :parent, class_name: "ProfessionalOrganization"
@@ -39,6 +39,10 @@ class ProfessionalOrganization < ApplicationRecord
 
   scope :divisions, -> {
     where(org_type: 'division')
+  }
+
+  scope :locations, -> {
+    where(org_type: 'location')
   }
 
   # Returns collection like [greatgrandparent, grandparent, parent].
@@ -66,4 +70,11 @@ class ProfessionalOrganization < ApplicationRecord
     return self.name if self.org_type == 'department'
     return nil
   end
+
+  def division_name
+    return self.parentl.name if self.org_type == "location"
+    return self.name if self.org_type == "division"
+    return nil
+  end
+
 end

--- a/lib/tasks/add_rhn_to_professional_organizations.rake
+++ b/lib/tasks/add_rhn_to_professional_organizations.rake
@@ -1,0 +1,42 @@
+task :add_rhn_to_professional_organizations => :environment do
+  begin
+    # Add top level Institution
+    rhn = ProfessionalOrganization.find_or_create_by name: "Regional Health Network (RHN)"
+    rhn.update(org_type: "institution")
+    puts "Created or updated Institution: #{rhn.name}"
+
+    # Add Divisions as children of Institution
+    divisions_count = 0
+    divisions = ["RHN-MUSC Health Florence", "RHN-MUSC Health Midlands/Columbia", "RHN-MUSC Health Lancaster"]
+    parent_id = rhn.id
+    divisions.each do |name|
+      division = ProfessionalOrganization.find_or_create_by name: name
+      division.update(org_type: "division", parent_id: parent_id)
+      divisions_count += 1 unless division.new_record?
+    end
+    puts "Created or updated #{divisions_count} Divisions as children of #{rhn.name}"
+
+    # Add Locations as children of Divisions
+    florence = ["MUSC Health Florence", "MUSC Health Marion"]
+    columbia = ["MUSC Health Kershaw Medical Center", "MUSC Health Columbia Medical Center", "MUSC Heart and Vascular Institute"]
+    lancaster = ["MUSC Health Lancaster", "MUSC Health Chester", "MUSC Health Indian Land"]
+    locations = [florence, columbia, lancaster]
+
+    florence_id = ProfessionalOrganization.find_by(name: divisions[0]).id
+    columbia_id = ProfessionalOrganization.find_by(name: divisions[1]).id
+    lancaster_id = ProfessionalOrganization.find_by(name: divisions[-1]).id
+    parents = [florence_id, columbia_id, lancaster_id]
+
+    locations_count = 0
+    locations.each_with_index do |location, index|
+      location.each do |name|
+        place = ProfessionalOrganization.find_or_create_by name: name
+        place.update(org_type: "location", parent_id: parents[index])
+        locations_count += 1 unless place.new_record?
+      end
+    end
+    puts "Created or updated #{locations_count} Locations as children of Divisions"
+  rescue => e
+    puts "Error occurred: #{e.message}"
+  end
+end


### PR DESCRIPTION
**Background**
MUSC Regional Health Network sites conducting research need to capture study team RHN institutional information on their profiles.  

**Acceptance Criteria**

- [x]  Add 'Regional Health Network (RHN) as an option in the Institution drop down on user profiles
- [x]  When RHN selected, new field 'Division' displays with the divisions named in the attached spreadsheet
- [x] When Division selected, new field 'Location' displays with the division's locations in the attached spreadsheet
- [x] Changes display in all user profile spaces:
     * SPARCRequest Step 2 & SPARCDashboard - Add Authorized User
     * SPARCAdmin-->Users-->Edit Profile
     * User-->Edit Profile Add
 
[Story](https://www.pivotaltracker.com/story/show/183545433)