### PR TITLE
Import guarantor information into EPIC

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -920,7 +920,7 @@ en:
         header: "Involved External Organizations"
       financial_information:
         header: "Financial Information"
-        guarantor_header: "Guarantor Information"
+        guarantor_header: "Send Bills To..."
       grant_information:
         header: "Federal Grant Information"
         sponsor_separator: "- OR -"

--- a/lib/epic_interface.rb
+++ b/lib/epic_interface.rb
@@ -162,6 +162,8 @@ class EpicInterface
         emit_cofc(xml, study)
         emit_visits(xml, study)
         emit_procedures_and_encounters(xml, study)
+        emit_guarantor_contact(xml, study)
+        emit_guarantor_phone(xml, study)
       }
     }
 
@@ -189,10 +191,35 @@ class EpicInterface
         emit_ide_number(xml, study)
         emit_cofc(xml, study)
         emit_rmid(xml, study)
-
+        emit_guarantor_contact(xml, study)
+        emit_guarantor_phone(xml, study)
       }
     }
     return xml.target!
+  end
+
+  def emit_guarantor_contact(xml, study) # 'Send bills to...' contact field
+    guarantor_contact = study.try(:guarantor_contact)
+    if !guarantor_contact.blank?
+      xml.subject_of(typeCode: 'SUBJ') {
+        xml.studyCharacteristic(classCode: 'OBS', moodCode: 'EVN') {
+          xml.code(code: 'GUARANTOR_CONTACT')
+          xml.value(value: guarantor_contact)
+        }
+      }
+    end
+  end
+
+  def emit_guarantor_phone(xml, study) # 'Send bills to...' phone field
+    guarantor_phone = study.try(:guarantor_phone)
+    if !guarantor_phone.blank?
+      xml.subject_of(typeCode: 'SUBJ') {
+        xml.studyCharactersitic(classCode: 'OBS', moodCode: 'EVN') {
+          xml.code(code: 'GUARANTOR_PHONE')
+          xml.value(value: guarantor_phone)
+        }
+      }
+    end
   end
 
   def emit_project_roles(xml, study)

--- a/lib/epic_interface.rb
+++ b/lib/epic_interface.rb
@@ -201,7 +201,7 @@ class EpicInterface
   def emit_guarantor_contact(xml, study) # 'Send bills to...' contact field
     guarantor_contact = study.try(:guarantor_contact)
     if !guarantor_contact.blank?
-      xml.subject_of(typeCode: 'SUBJ') {
+      xml.subjectOf(typeCode: 'SUBJ') {
         xml.studyCharacteristic(classCode: 'OBS', moodCode: 'EVN') {
           xml.code(code: 'GUARANTOR_CONTACT')
           xml.value(value: guarantor_contact)
@@ -213,8 +213,8 @@ class EpicInterface
   def emit_guarantor_phone(xml, study) # 'Send bills to...' phone field
     guarantor_phone = study.try(:guarantor_phone)
     if !guarantor_phone.blank?
-      xml.subject_of(typeCode: 'SUBJ') {
-        xml.studyCharactersitic(classCode: 'OBS', moodCode: 'EVN') {
+      xml.subjectOf(typeCode: 'SUBJ') {
+        xml.studyCharacteristic(classCode: 'OBS', moodCode: 'EVN') {
           xml.code(code: 'GUARANTOR_PHONE')
           xml.value(value: guarantor_phone)
         }

--- a/spec/extensions/epic_interface_spec.rb
+++ b/spec/extensions/epic_interface_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe EpicInterface do
   build_study_type_answers
   build_study_type_questions
 
-
   let!(:provider) {
     create(
       :provider,
@@ -387,6 +386,58 @@ RSpec.describe EpicInterface do
           'hl7' => 'urn:hl7-org:v3')
 
       expect(node[0]).to be_equivalent_to(expected.root)
+    end
+
+    it 'should emit a subjectOf for guarantor contact' do
+      epic_interface.send_study_creation(study)
+
+      xml = <<-END
+        <subjectOf typeCode="SUBJ"
+                   xmlns='urn:hl7-org:v3'
+                   xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+          <studyCharacteristic classCode="OBS" moodCode="EVN">
+            <code code="GUARANTOR_CONTACT" />
+            <value value="#{study.guarantor_contact}" />
+          </studyCharacteristic>
+        </subjectOf>
+      END
+
+      expected = Nokogiri::XML(xml)
+
+      node = epic_received[0].xpath(
+        '//env:Body/rpe:RetrieveProtocolDefResponse/rpe:protocolDef/
+        hl7:plannedStudy/hl7:subjectOf',
+        'env' => 'http://www.w3.org/2003/05/soap-envelope',
+        'rpe' => 'urn:ihe:qrph:rpe:2009',
+        'hl7' => 'urn:hl7-org:v3')
+
+      expect(node[5]).to be_equivalent_to(expected.root)
+    end
+
+    it 'should emit a subjectOf for guarantor phone' do
+      epic_interface.send_study_creation(study)
+
+      xml = <<-END
+        <subjectOf typeCode="SUBJ"
+                   xmlns='urn:hl7-org:v3'
+                   xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+          <studyCharacteristic classCode="OBS" moodCode="EVN">
+            <code code="GUARANTOR_PHONE" />
+            <value value="#{study.guarantor_phone}" />
+          </studyCharacteristic>
+        </subjectOf>
+      END
+
+      expected = Nokogiri::XML(xml)
+
+      node = epic_received[0].xpath(
+        '//env:Body/rpe:RetrieveProtocolDefResponse/rpe:protocolDef/
+        hl7:plannedStudy/hl7:subjectOf',
+        'env' => 'http://www.w3.org/2003/05/soap-envelope',
+        'rpe' => 'urn:ihe:qrph:rpe:2009',
+        'hl7' => 'urn:hl7-org:v3')
+
+      expect(node[6]).to be_equivalent_to(expected.root)
     end
 
     it 'should emit a subjectOf for an ide number' do

--- a/spec/factories/protocol.rb
+++ b/spec/factories/protocol.rb
@@ -38,6 +38,8 @@ FactoryBot.define do
     start_date                   { '2015-10-15' }
     end_date                     { '2015-10-15' }
     selected_for_epic            { false }
+    guarantor_contact            { "Benjamin Dover" }
+    guarantor_phone              { "8430000000" }
 
     trait :without_validations do
       to_create { |instance| instance.save(validate: false) }


### PR DESCRIPTION
**Background**
Continued efforts to synchronize data between EPIC and SPARC.
Original story [#157856473](https://www.pivotaltracker.com/story/show/157856473) added these fields.

**Acceptance Criteria**
The SPARC Study (SPARCRequest Step 2; SPARCDashboard Edit Study Information) page Guarantor Information fields are imported into EPIC Research Study Maintenance.

- [ ] The SPARC Study (SPARCRequest Step 2; SPARCDashboard Edit Study Information) page Guarantor Information fields 
         are imported into EPIC Research Study Maintenance.
- [x] The term 'Guarantor Information' updated to read 'Send Bills To..." to align with the new name in Epic.

[Story](https://www.pivotaltracker.com/story/show/184479538)