### PR TITLE
Prevent users from deleting fulfilled services

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -151,8 +151,7 @@ class LineItem < ApplicationRecord
 
   def has_fulfillments?
     line_item_in_cwf = Shard::Fulfillment::LineItem.find_by sparc_id: self.id
-    line_item_in_cwf.try(:fulfilled?) #|| line_item_in_cwf.try(:procedures).try(:where, status: %w(complete incomplete follow_up)).try(:any?)
-    #line_item_in_fulfillment.fulfillments.any? || line_item_in_fulfillment.procedures.where(status: %w(complete incomplete follow_up)).any?
+    line_item_in_cwf.try(:fulfilled?)
   end
 
   def has_admin_rates?

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -145,6 +145,16 @@ class LineItem < ApplicationRecord
     rate
   end
 
+  def one_time_fee?
+    self.service.one_time_fee?
+  end
+
+  def has_fulfillments?
+    line_item_in_cwf = Shard::Fulfillment::LineItem.find_by sparc_id: self.id
+    line_item_in_cwf.try(:fulfilled?) #|| line_item_in_cwf.try(:procedures).try(:where, status: %w(complete incomplete follow_up)).try(:any?)
+    #line_item_in_fulfillment.fulfillments.any? || line_item_in_fulfillment.procedures.where(status: %w(complete incomplete follow_up)).any?
+  end
+
   def has_admin_rates?
     self.admin_rates.present? && self.admin_rates.last.admin_cost.present?
   end

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -44,7 +44,12 @@ module Shard
         if self.one_time_fee?
           self.fulfillments.any?
         else
-          self.procedures.where(status: %w(complete incomplete follow_up)).any?
+          started_procedures = false
+          self.visits.each do |v|
+            procedures = Shard::Fulfillment::Procedure.where visit_id: v.id
+            started_procedures = procedures.where(status: %w(complete incomplete follow_up)).any?
+          end
+          started_procedures
         end
       end
 

--- a/app/models/shard/fulfillment/procedure.rb
+++ b/app/models/shard/fulfillment/procedure.rb
@@ -1,0 +1,28 @@
+# Copyright © 2011-2023 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module Shard
+  module Fulfillment
+    class Procedure < Shard::Fulfillment::Base
+      self.table_name = 'procedures'
+      belongs_to :visit
+    end
+  end
+end

--- a/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
+++ b/app/views/service_requests/cart/_cart_sub_service_requests.html.haml
@@ -37,7 +37,7 @@
                 - unless li.service.is_available
                   = inactive_tag
             - if li.optional? && ssr.can_be_edited? && ['document_management'].exclude?(action_name)
-              - unless ssr.in_work_fulfillment && (ssr.line_items.count == 1)
+              - unless (ssr.in_work_fulfillment && (ssr.line_items.count == 1)) || li.has_fulfillments?
                 .col-2.pl-0.text-right
                   = link_to icon('fas', 'trash-alt'), remove_service_service_request_path(srid: service_request.id, line_item_id: li.id), remote: true, method: :delete, class: 'btn btn-sm btn-sq btn-danger remove-service', title: t('proper.cart.remove_service'), data: { toggle: 'tooltip', disable: true }
               - else


### PR DESCRIPTION
__Background__
Users are able to delete services that have fulfillments submitted in SPARCFulfillment. This orphans the data. Related to [#181758085](https://www.pivotaltracker.com/story/show/181758085) that removed ability for end users to delete last subservice within a service request via SPARC shopping cart.

__Acceptance Criteria__
- [x] From the cart, users can't delete any services that have fulfillments submitted to SPARCFulfillment.

[Story](https://www.pivotaltracker.com/story/show/183121135)