### PR TITLE
RMID update visual cues not appearing

### DIFF
--- a/lib/tasks/update_protocol_with_validated_rm.rake
+++ b/lib/tasks/update_protocol_with_validated_rm.rake
@@ -123,15 +123,16 @@ namespace :data do
     puts("Research Master ID removed from: #{former_rmid_protocols.size} Protocols")
     puts("IDs: #{former_rmid_protocols}")
 
-    slack_webhook = Setting.get_value("epic_user_api_error_slack_webhook")
-    if slack_webhook.present?
-      notifier = Slack::Notifier.new(slack_webhook)
+    teams_webhook = Setting.get_value("epic_user_api_error_teams_webhook")
+    if teams_webhook.present?
       message =  "RMID update has been performed for SPARC in: #{Rails.env}"
+
       message += "\nrmid_validated flags removed: #{former_validated_protocols.size}\n"
       message += "\nProtocol IDs: #{former_validated_protocols}\n"
       message += "\nresearch_master_ids removed: #{former_rmid_protocols.size}\n"
       message += "\nProtocol IDs: #{former_rmid_protocols}\n"
-      notifier.ping(message)
+      notifier = Teams.new(teams_webhook)
+      notifier.post(message)
     end
 
   end


### PR DESCRIPTION
Received report 2/28/23 from OCR that the RMID green text visual cues are missing from SPARC ID 21921. The study was IRB approved 2/12/2023 and the IRB approval data appears to be updated in SPARC. However, the visual cues do not appear in SPARCDashboard. They are present in RMID.

Update - at least another study SPARC ID 20235 recently released an approval and the cues are showing in SPARC. The approval date is Sept 2022 although its final approval was just released. Previously reported SPARC ID 21921 was approved and released Feb 2023.

Related, completed stories about SPARC-RMID API:

RMID verification label [#170383881](https://www.pivotaltracker.com/story/show/170383881)
Refresh SPARC protocol with validated RMID [#148336773](https://www.pivotaltracker.com/story/show/148336773)
Cronjob broken [#160358796](https://www.pivotaltracker.com/story/show/160358796)
RMID validation inconsistency [#153217206](https://www.pivotaltracker.com/story/show/153217206

[Story](https://www.pivotaltracker.com/story/show/184606389)