### PR TITLE
Prevent users from deleting invoiced services

### DIFF
--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -45,10 +45,14 @@ module Shard
         if self.one_time_fee?
           self.fulfillments.any?
         else
-
+          touched = false
           self.visits.each do |v|
             procedures = Shard::Fulfillment::Procedure.where visit_id: v.id
-            return true if procedures.where(status: %w(complete incomplete follow_up)).any?
+            procedures.each do |p|
+              if p.status != 'unstarted'
+                touched = true
+              end
+            end
           end
         end
       end

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -40,16 +40,16 @@ module Shard
         self.sparc_line_item.service.one_time_fee?
       end
 
+      # Disable deletion of line items in cart if they have been fulfilled
       def fulfilled?
         if self.one_time_fee?
           self.fulfillments.any?
         else
-          started_procedures = false
+
           self.visits.each do |v|
             procedures = Shard::Fulfillment::Procedure.where visit_id: v.id
-            started_procedures = procedures.where(status: %w(complete incomplete follow_up)).any?
+            return true if procedures.where(status: %w(complete incomplete follow_up)).any?
           end
-          started_procedures
         end
       end
 


### PR DESCRIPTION
Background
Users are able to delete services that have fulfillments submitted in SPARCFulfillment. This orphans the data. Related to [#181758085](https://www.pivotaltracker.com/story/show/181758085) that removed ability for end users to delete last subservice within a service request via SPARC shopping cart.

Acceptance Criteria
- [x] From the cart, users can't delete any services that have fulfillments submitted to SPARCFulfillment.

[Story](https://www.pivotaltracker.com/story/show/183121135)