### PR TITLE
Prevent users from deleting invoiced services

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -150,8 +150,8 @@ class LineItem < ApplicationRecord
   end
 
   def has_fulfillments?
-    line_item_in_cwf = Shard::Fulfillment::LineItem.find_by sparc_id: self.id
-    line_item_in_cwf.try(:fulfilled?)
+    fulfillment_line_item = Shard::Fulfillment::LineItem.find_by sparc_id: self.id
+    fulfillment_line_item.try(:fulfilled?)
   end
 
   def has_admin_rates?

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -36,13 +36,13 @@ module Shard
       belongs_to :sparc_line_item, class_name: '::LineItem', foreign_key: :sparc_id
       belongs_to :sparc_service, class_name: '::Service', foreign_key: :service_id
 
-      def one_time_fee?
+      def non_clinical?
         self.sparc_line_item.service.one_time_fee?
       end
 
       # Disable deletion of line items in cart if they have been fulfilled
       def fulfilled?
-        if self.one_time_fee?
+        if self.non_clinical?
           self.fulfillments.any?
         else
           touched = false

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -45,10 +45,14 @@ module Shard
         if self.one_time_fee?
           self.fulfillments.any?
         else
-
+          touched = false
           self.visits.each do |v|
             procedures = Shard::Fulfillment::Procedure.where visit_id: v.id
-            return true if procedures.where(status: %w(complete incomplete follow_up)).any?
+            procedures.each do |p|
+              if p.status != 'unstarted'
+                touched = true
+              end
+            end
           end
         end
       end

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -46,14 +46,15 @@ module Shard
           self.fulfillments.any?
         else
           touched = false
-          self.visits.each do |v|
-            procedures = Shard::Fulfillment::Procedure.where visit_id: v.id
+          self.visits.each do |visit|
+            procedures = Shard::Fulfillment::Procedure.where(visit_id: visit.id)
             procedures.each do |p|
               if p.status != 'unstarted'
                 touched = true
               end
             end
           end
+          touched
         end
       end
 

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -40,16 +40,16 @@ module Shard
         self.sparc_line_item.service.one_time_fee?
       end
 
+      # Disable deletion of line items in cart if they have been fulfilled
       def fulfilled?
         if self.one_time_fee?
           self.fulfillments.any?
         else
-          started_procedures = false
+
           self.visits.each do |v|
             procedures = Shard::Fulfillment::Procedure.where visit_id: v.id
-            started_procedures = procedures.where(status: %w(complete incomplete follow_up)).any?
+            return true if procedures.where(status: %w(complete incomplete follow_up)).any?
           end
-          started_procedures
         end
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,7 +385,7 @@ en:
               blank: "You must create Arms before proceeding to the Service Calendar"
             line_items:
               blank: "You must add services to your cart before continuing"
-              pushed_to_fulfillment: "Requests that have already been pushed to Fulfillment cannot be deleted"
+              pushed_to_fulfillment: "Services in fulfillment cannot be deleted"
             protocol:
               blank: "You must create a Protocol before continuing"
         system_survey:

--- a/spec/models/shard/fulfillment/line_item_spec.rb
+++ b/spec/models/shard/fulfillment/line_item_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Shard::Fulfillment::LineItem, type: :model do
+  describe 'associations' do
+    it 'belongs to :sparc_line_item' do
+      should belong_to(:sparc_line_item)
+    end
+    it 'belongs to :sparc_service' do
+      should belong_to(:sparc_service)
+    end
+  end
+
+  describe 'instance methods' do
+    describe '#fulfilled?' do
+      context 'when the line item is a one time fee' do
+        it 'returns true' do
+          allow(subject).to receive(:non_clinical?).and_return(true)
+          allow(subject).to receive_message_chain(:fulfillments, :any?).and_return(true)
+          expect(subject.fulfilled?).to eq(true)
+        end
+      end
+    end
+
+    describe '#non_clinical?' do
+      context 'when the line item is a one time fee' do
+        it 'returns true' do
+          allow(subject).to receive_message_chain(:sparc_line_item, :service, :one_time_fee?).and_return(true)
+          expect(subject.non_clinical?).to eq(true)
+        end
+      end
+    end
+
+    describe '#deleted?' do
+      context 'when the line item has been deleted' do
+        it 'returns true' do
+          allow(subject).to receive(:deleted_at).and_return(true)
+          expect(subject.deleted?).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
__Background__
Users are able to delete services that have fulfillments submitted in SPARCFulfillment. This orphans the data. Related to [#181758085](https://www.pivotaltracker.com/story/show/181758085) that removed ability for end users to delete last subservice within a service request via SPARC shopping cart.

__Acceptance Criteria__
- [x] From the cart, users can't delete any services that have fulfillments submitted to SPARCFulfillment.

[Story](https://www.pivotaltracker.com/story/show/183121135)