### PR TITLE
Prevent users from deleting services from cart if service is in fulfillment

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -149,9 +149,9 @@ class LineItem < ApplicationRecord
     self.service.one_time_fee?
   end
 
+  # If a service in cart is in fulfillment, disable its delete button
   def has_fulfillments?
-    fulfillment_line_item = Shard::Fulfillment::LineItem.find_by sparc_id: self.id
-    fulfillment_line_item.try(:fulfilled?)
+    fulfillment_line_items.any?(&:fulfilled?)
   end
 
   def has_admin_rates?

--- a/app/models/shard/fulfillment/appointment.rb
+++ b/app/models/shard/fulfillment/appointment.rb
@@ -1,0 +1,31 @@
+# Copyright © 2011-2023 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module Shard
+  module Fulfillment
+    class Appointment < Shard::Fulfillment::Base
+      self.table_name = 'appointments'
+      self.inheritance_column = :_type_disabled
+
+      has_many :procedures
+      belongs_to :arm
+    end
+  end
+end

--- a/app/models/shard/fulfillment/arm.rb
+++ b/app/models/shard/fulfillment/arm.rb
@@ -24,15 +24,15 @@ module Shard
       self.table_name = 'arms'
 
       belongs_to :protocol
-
+      has_many :appointments
       has_many :line_items
-      has_many :visit_groups
 
       ##########################
       ### SPARC Associations ###
       ##########################
 
       belongs_to :sparc_arm, class_name: '::Arm', foreign_key: :sparc_id
+
     end
   end
 end

--- a/app/models/shard/fulfillment/line_item.rb
+++ b/app/models/shard/fulfillment/line_item.rb
@@ -40,21 +40,12 @@ module Shard
         self.sparc_line_item.service.one_time_fee?
       end
 
-      # Disable deletion of line items in cart if they have been fulfilled
+      # Disable deletion of service in cart if in fulfillment
       def fulfilled?
-        if self.non_clinical?
-          self.fulfillments.any?
+        if non_clinical?
+          fulfillments.exists?
         else
-          touched = false
-          self.visits.each do |visit|
-            procedures = Shard::Fulfillment::Procedure.where(visit_id: visit.id)
-            procedures.each do |p|
-              if p.status != 'unstarted'
-                touched = true
-              end
-            end
-          end
-          touched
+          arm.appointments.joins(:procedures).where(procedures: { service_id: service_id, status: %w[incomplete complete follow_up] }).exists?
         end
       end
 

--- a/spec/models/shard/fulfillment/appointment_spec.rb
+++ b/spec/models/shard/fulfillment/appointment_spec.rb
@@ -1,3 +1,23 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
 require 'rails_helper'
 
 RSpec.describe Shard::Fulfillment::Appointment, type: :model do

--- a/spec/models/shard/fulfillment/appointment_spec.rb
+++ b/spec/models/shard/fulfillment/appointment_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Shard::Fulfillment::Appointment, type: :model do
+  describe 'associations' do
+    it { should have_many(:procedures) }
+    it { should belong_to(:arm) }
+  end
+
+  describe 'table_name' do
+    it { expect(described_class.table_name).to eq('appointments') }
+  end
+end

--- a/spec/models/shard/fulfillment/line_item_spec.rb
+++ b/spec/models/shard/fulfillment/line_item_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe Shard::Fulfillment::LineItem, type: :model do
 
   describe 'instance methods' do
     describe '#fulfilled?' do
-      context 'when the line item is a one time fee' do
+      let(:service_id) { 1 }
+      let(:procedure ) {{ status: 'incomplete' }}
+       context 'if service is non-clinical' do
         it 'returns true' do
           allow(subject).to receive(:non_clinical?).and_return(true)
-          allow(subject).to receive_message_chain(:fulfillments, :any?).and_return(true)
+          allow(subject).to receive_message_chain(:fulfillments, :exists?).and_return(true)
           expect(subject.fulfilled?).to eq(true)
         end
       end

--- a/spec/models/shard/fulfillment/line_item_spec.rb
+++ b/spec/models/shard/fulfillment/line_item_spec.rb
@@ -1,3 +1,23 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development~
+# All rights reserved.~
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+# derived from this software without specific prior written permission.~
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
 require 'rails_helper'
 
 RSpec.describe Shard::Fulfillment::LineItem, type: :model do


### PR DESCRIPTION
Background
Users are able to delete services that have fulfillments submitted in SPARCFulfillment. This orphans the data. Related to [#181758085](https://www.pivotaltracker.com/story/show/181758085) that removed ability for end users to delete last subservice within a service request via SPARC shopping cart.

Acceptance Criteria
From the cart, users can't delete any services that have fulfillments submitted to SPARCFulfillment.
[Story](https://www.pivotaltracker.com/story/show/183121135)