### PR TITLE
SJ - Admin Rate Reset Tweaks

### DIFF
--- a/app/views/line_items/_form.html.haml
+++ b/app/views/line_items/_form.html.haml
@@ -55,8 +55,8 @@
               = t('constants.max', max: max)
         - if params[:field] == 'displayed_cost'
           - disabled = line_item.admin_rates.none?
-          - reset_title = disabled ? "No modified rate in use" : "Reset cost to current service rate"
-          %button#admin_rate_reset_button.btn.btn-danger.mt-2{ title: reset_title, type: 'button', disabled: disabled, data: {toggle: "tooltip", placement: "bottom"}}
+          - translation_title = disabled ? "tooltip_disabled" : "tooltip"
+          %button#admin_rate_reset_button.btn.btn-danger.mt-2{ title: t("dashboard.sub_service_requests.history.rate_history.#{translation_title}"), type: 'button', disabled: disabled, data: {toggle: "tooltip", placement: "bottom"}}
             = t('dashboard.sub_service_requests.history.rate_history.reset_rate')
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }

--- a/app/views/line_items/_form.html.haml
+++ b/app/views/line_items/_form.html.haml
@@ -54,7 +54,9 @@
               = t('constants.min', min: min)
               = t('constants.max', max: max)
         - if params[:field] == 'displayed_cost'
-          %button#admin_rate_reset_button.btn.btn-danger.mt-2{ type: 'button'}
+          - disabled = line_item.admin_rates.none?
+          - reset_title = disabled ? "No modified rate in use" : "Reset cost to current service rate"
+          %button#admin_rate_reset_button.btn.btn-danger.mt-2{ title: reset_title, type: 'button', disabled: disabled, data: {toggle: "tooltip", placement: "bottom"}}
             = t('dashboard.sub_service_requests.history.rate_history.reset_rate')
       .modal-footer
         %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -399,6 +399,8 @@ en:
           cpt_code: "CPT Code"
           modified_rate: "Modified Rate"
           reset_rate: "Reset rate"
+          tooltip: "Reset cost to current service rate"
+          tooltip_disabled: "No modified rate in use"
         tooltips:
           status_history: "Status log of request"
           approval_history: "Time stamp log of approvals"


### PR DESCRIPTION
Adding tooltip, and disabling button if no admin rate is set.