### PR TITLE
bug fix for has_fulfillments? method

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -152,7 +152,7 @@ class LineItem < ApplicationRecord
 
   # If a service in cart is in fulfillment, disable its delete button
   def has_fulfillments?
-    fulfillment_line_items.any?(&:fulfilled?)
+    Setting.get_value("fulfillment_contingent_on_catalog_manager") && fulfillment_line_items.any?(&:fulfilled?)
   end
 
   def has_admin_rates?


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/185707909
The following exception occurs when fulfillment module is not utilized.

An ActionView::Template::Error occurred in service_requests#catalog:

Mysql2::Error: Unknown column 'line_items.sparc_id' in 'where clause': SELECT line_items.* FROM line_items WHERE line_items.deleted_at IS NULL AND line_items.sparc_id = 332 ORDER BY arm_id ASC
app/models/line_item.rb:155:in `has_fulfillments?'

Trace of template inclusion: app/views/service_requests/cart/_cart.html.haml, app/views/service_requests/catalog.html.haml

Rails.root: /home/ying/rails/sparc-request
Application Trace | Framework Trace | Full Trace

app/models/line_item.rb:155:in has_fulfillments?' app/views/service_requests/cart/_cart_sub_service_requests.html.haml:40:inblock (2 levels) in _app_views_service_requests_cartcart_sub_service_requests_html_haml3815628468113393978_156200'
app/views/service_requests/cart/_cart_sub_service_requests.html.haml:28:in block in _app_views_service_requests_cart__cart_sub_service_requests_html_haml__3815628468113393978_156200' app/views/service_requests/cart/_cart_sub_service_requests.html.haml:21:ineach'
app/views/service_requests/cart/_cart_sub_service_requests.html.haml:21:in _app_views_service_requests_cart__cart_sub_service_requests_html_haml__3815628468113393978_156200' app/views/service_requests/cart/_cart.html.haml:37:in_app_views_service_requests_cartcart_html_haml4226547272169157865_156180'
app/views/service_requests/catalog.html.haml:27:in block in _app_views_service_requests_catalog_html_haml__2413247179448054277_155660' app/views/service_requests/catalog.html.haml:21:in_app_views_service_requests_catalog_html_haml__2413247179448054277_155660'