### PR TITLE
EPIC Q1 & notes display for non-EPIC studies

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -156,6 +156,12 @@ $(document).ready ->
   ### Study Type Questions Logic ###
   ##################################
 
+  if $("#protocol_selected_for_epic_false").is(":checked")
+    $('#studyTypeNote').hide()
+
+  $("#protocol_selected_for_epic_false").on "click", ->
+    $('#studyTypeNote').hide()
+
   $(document).on 'change', '[name="protocol[selected_for_epic]"]', ->
     $('[for=protocol_selected_for_epic]').addClass('required')
 

--- a/app/views/protocols/view_details/_protocol_information.html.haml
+++ b/app/views/protocols/view_details/_protocol_information.html.haml
@@ -60,23 +60,23 @@
                 = label :protocol, :selected_for_epic, class: 'mb-0'
               %td.d-inline-block.col-9
                 = protocol.selected_for_epic ? t('constants.yes_select') : t('constants.no_select')
+          - if protocol.selected_for_epic
+            - if display_readonly_study_type_questions?(protocol) && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
+              %tr.bg-light
+                %td{ colspan: 2 }
+                  %h6.mb-0{ title: t(:protocols)[:tooltips][:study_type_questions], data: { toggle: 'tooltip', placement: 'right' } }
+                    = Protocol.human_attribute_name(:study_type_questions)
+              - protocol.display_answers.each do |answer|
+                - if ((answer.study_type_question.study_type_question_group.active && protocol.active?) || (!answer.study_type_question.study_type_question_group.active && !protocol.active?)) && display_study_type_question?(protocol, answer, true)
+                  %tr
+                    %td{ colspan: 2 }
+                      .row
+                        %label.col-11.mb-0
+                          = answer.study_type_question.question.html_safe
+                        .col-1
+                          = answer.answer? ? t('constants.yes_select') : t('constants.no_select')
 
-          - if display_readonly_study_type_questions?(protocol) && protocol.display_answers.any?{ |as| display_study_type_question?(protocol, as) }
-            %tr.bg-light
-              %td{ colspan: 2 }
-                %h6.mb-0{ title: t(:protocols)[:tooltips][:study_type_questions], data: { toggle: 'tooltip', placement: 'right' } }
-                  = Protocol.human_attribute_name(:study_type_questions)
-            - protocol.display_answers.each do |answer|
-              - if ((answer.study_type_question.study_type_question_group.active && protocol.active?) || (!answer.study_type_question.study_type_question_group.active && !protocol.active?)) && display_study_type_question?(protocol, answer, true)
+              - if Setting.get_value('use_epic') && protocol.active? && note = protocol.determine_study_type_note
                 %tr
                   %td{ colspan: 2 }
-                    .row
-                      %label.col-11.mb-0
-                        = answer.study_type_question.question.html_safe
-                      .col-1
-                        = answer.answer? ? t('constants.yes_select') : t('constants.no_select')
-
-            - if Setting.get_value('use_epic') && protocol.active? && note = protocol.determine_study_type_note
-              %tr
-                %td{ colspan: 2 }
-                  = render 'protocols/form/study_type_note', protocol: protocol, note: note
+                    = render 'protocols/form/study_type_note', protocol: protocol, note: note


### PR DESCRIPTION
***Background***
When editing a study, Confidentiality and Epic Questions question 'Do you want to have your Study Published in Epic?' from Yes to No, Study Type Questions data is still appearing when it should not.

1) Q1 appears after saving the page and returning to it for edits. It's displaying the outdated Q1 text.
2) The Epic Note shows when changing to No, and when returning to the page for edits

***Acceptance Criteria***
- [x] When editing study responses in the Confidentiality and Epic Questions section, 'Do you want to have your Study Published in Epic?' responses change from Yes to No do not display the remaining section text - Q1 nor EPIC note.
- [x] When responses are 'Yes', the questions and notes accurately display
- [x] Also show/hide on 'Study Details' modal

https://www.pivotaltracker.com/story/show/185710775