### PR TITLE
JV - SRID Column Sorts Numerically and Appropriately Considers Dashes as Decimals

### DIFF
--- a/app/assets/javascripts/utilities.js.coffee
+++ b/app/assets/javascripts/utilities.js.coffee
@@ -76,6 +76,6 @@ VALID_MONETARY_KEYS = [
     return text
 
 (exports ? this).numericSort = (a, b) ->
-  aa = a.replace(/[^\d]/g, '')
-  bb = b.replace(/[^\d]/g, '')
+  aa = a.replace(/[^\d-]/g, '').replace(/-/g, ".")
+  bb = b.replace(/[^\d-]/g, '').replace(/-/g, ".")
   aa - bb


### PR DESCRIPTION
The original fix simply removed dashes from consideration in terms of sorting. This updated fix now treats the dashes as decimals, which allows the column to sort numerically as expected.

https://www.pivotaltracker.com/story/show/185371715

[#185371715]