### PR TITLE
Edit visit bug caused by default billing function

### DIFF
--- a/app/views/visit_groups/edit.js.coffee
+++ b/app/views/visit_groups/edit.js.coffee
@@ -46,7 +46,16 @@ else
     html:       true
     trigger:    'manual'
     placement:  'left'
+    container:  'body'
   )
+
+  # This is a hack to fix https://www.pivotaltracker.com/story/show/185417863
+  $vg.on 'shown.bs.popover', ->
+    if $('.popover').length > 1
+      $('.popover').first().attr('title', title).find('.popover-body').html($content)
+      $('.popover').last().remove()
+      y = $(window).scrollTop()
+      $(window).scrollTop(y+1).scrollTop(y-1)
 
   # Logic for smoother closing of visit group popovers
   $vg.on 'shown.bs.popover', ->


### PR DESCRIPTION
When clicking from Quantity/Billing to Template tab in Service Calendar, then clicking on a Visit to edit, two popover instances get created and displayed. This PR adds some javascript to remove the extra popover and re-position the remaining popover correctly next to its reference element. 

https://www.pivotaltracker.com/story/show/185417863
