### PR TITLE
Remove email submission data when split/notify is disabled

### DIFF
--- a/app/controllers/catalog_manager/organizations_controller.rb
+++ b/app/controllers/catalog_manager/organizations_controller.rb
@@ -68,6 +68,10 @@ class CatalogManager::OrganizationsController < CatalogManager::AppController
   end
 
   def update
+    if params[:organization][:process_ssrs] == "0"
+      SubmissionEmail.where(organization_id: params[:id]).delete_all
+    end
+
     @organization = Organization.find(params[:id])
     set_registrar_enabled(@organization)
     @user_rights  = user_rights(@organization.id)
@@ -248,6 +252,8 @@ class CatalogManager::OrganizationsController < CatalogManager::AppController
     name_change = @attributes[:name] != @organization.name || @attributes[:abbreviation] != @organization.abbreviation
 
     if @organization.update_attributes(@attributes)
+      # If self.process_ssrs_changed? && self.process_ssrs == 0, self.submission_emails.destroy_all
+      @organization.submission_emails.destroy_all if (@organization.type != "Institution" && @organization.process_ssrs == 0)
       @organization.update_ssr_org_name if (@organization.type != "Institution" && name_change)
       update_services
       true

--- a/app/controllers/catalog_manager/organizations_controller.rb
+++ b/app/controllers/catalog_manager/organizations_controller.rb
@@ -252,8 +252,6 @@ class CatalogManager::OrganizationsController < CatalogManager::AppController
     name_change = @attributes[:name] != @organization.name || @attributes[:abbreviation] != @organization.abbreviation
 
     if @organization.update_attributes(@attributes)
-      # If self.process_ssrs_changed? && self.process_ssrs == 0, self.submission_emails.destroy_all
-      @organization.submission_emails.destroy_all if (@organization.type != "Institution" && @organization.process_ssrs == 0)
       @organization.update_ssr_org_name if (@organization.type != "Institution" && name_change)
       update_services
       true


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185178780

## Background
Validation needed that all submission emails have been disabled if the Split notify is disabled. This was related to a bug that left emails duplicating or going out when email was removed. Refer to story [#183876911](https://www.pivotaltracker.com/story/show/183876911).

Testing showed the email is remaining from when first put in there when there was a split/notify established at the (program) level. Whereas, the current split/notify is at the core level.

SPARC is requiring a certain sequence of events to remove the emails so it disassociates from the split/notify. Current story will add the feature for submission emails to follow the same action that removes the split/notify.

## Acceptance Criteria
- [x] Remove these submission email(s) when the split/notify is also removed in Catalog
- [x] Submission email(s) is only active when the split/notify is active in Catalog