### PR TITLE
JV - Make Protocol Merge Modal Fields Searchable

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -123,6 +123,19 @@ class SearchController < ApplicationController
     render json: results.to_json
   end
 
+  def protocol_merge_search
+    term = params[:term].strip
+    results = Protocol.protocol_merge_search_query(term).map{ |p|
+      {
+        protocol_id: p.id,
+        protocol_title: p.title,
+        protocol_short_title: p.short_title,
+        protocol_rmid: p.research_master_id,
+      }
+    }
+    render json: results.to_json
+  end
+
   private
 
   def inactive_text(item)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -131,6 +131,7 @@ class SearchController < ApplicationController
         protocol_title: p.title,
         protocol_short_title: p.short_title,
         protocol_rmid: p.research_master_id,
+        protocol_pi: p.primary_pi.full_name
       }
     }
     render json: results.to_json

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -335,6 +335,12 @@ class Protocol < ApplicationRecord
       where.not(sub_service_requests: {status: 'first_draft'})
   }
 
+  scope :protocol_merge_search_query, -> (term) {
+    return if term.blank?
+
+    where (Protocol.arel_table[:short_title].matches("%#{term}%"))
+  }
+
   def research_master_id=(rmid)
     self.rmid_validated = false if rmid.blank?
 

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -338,7 +338,7 @@ class Protocol < ApplicationRecord
   scope :protocol_merge_search_query, -> (term) {
     return if term.blank?
 
-    where (Protocol.arel_table[:short_title].matches("%#{term}%"))
+    where (Protocol.arel_table[:id].eq(term))
   }
 
   def research_master_id=(rmid)

--- a/app/views/dashboard/protocol_merges/new.js.coffee
+++ b/app/views/dashboard/protocol_merges/new.js.coffee
@@ -60,3 +60,33 @@ $('#master_protocol_id').typeahead(
     }
   }
 )
+
+$('#merged_protocol_id').typeahead(
+  {
+    minLength: 1,
+    highlight: true
+  }, {
+    source: mergesBloodhound.ttAdapter(),
+    displayKey: 'protocol_id',
+    templates: {
+      notFound: "<div class='tt-suggestion'>#{I18n.t('constants.search.no_results')}</div>",
+      pending: "<div class='tt-suggestion'>#{I18n.t('constants.search.loading')}</div>",
+      suggestion: (s) -> [
+        "<div class='tt-suggestion'>"
+          "<div class='w-100'>"
+            "<h5>#{s.protocol_id}</h5>"
+          "</div>",
+          "<div class='w-100'>"
+            "<strong>Title: </strong>#{s.protocol_title}"
+          "<div>",
+          "<div class='w-100'>"
+            "<strong>Short Title: </strong>#{s.protocol_short_title}"
+          "<div>",
+          "<div class='w-100'>"
+            "<strong>RMID: </strong>#{s.protocol_rmid}"
+          "<div>",
+        "</div>"
+      ].join('')
+    }
+  }
+)

--- a/app/views/dashboard/protocol_merges/new.js.coffee
+++ b/app/views/dashboard/protocol_merges/new.js.coffee
@@ -20,3 +20,61 @@
 
 $('#modalContainer').html("<%= j render 'dashboard/protocol_merges/merge_tool_modal.html.haml', protocol_merge: @protocol_merge, current_user: @current_user %>")
 $('#modalContainer').modal('show')
+
+#$('#master_protocol_id').on 'keyup', ->
+  #alert 'Handler for keyup called.'
+  #return
+
+#keyupTimer = undefined
+#$('#master_protocol_id').keyup ->
+  #clearTimeout keyupTimer
+  #keyupTimer = setTimeout((->
+    #alert 'Handler for keyup called.'
+    #return
+  #), 800)
+  #return
+
+mergesBloodhound = new Bloodhound(
+  datumTokenizer: Bloodhound.tokenizers.whitespace
+  queryTokenizer: Bloodhound.tokenizers.whitespace
+  #local: [
+    #'222'
+    #'221'
+    #'220'
+  #]
+  remote:
+    url: "/search/protocol_merge_search?term=%TERM",
+    wildcard: '%TERM'
+)
+
+mergesBloodhound.initialize()
+
+$('#master_protocol_id').typeahead(
+  {
+    minLength: 1,
+    highlight: true
+  }, {
+    source: mergesBloodhound.ttAdapter(),
+    displayKey: 'protocol_id',
+    templates: {
+      notFound: "<div class='tt-suggestion'>#{I18n.t('constants.search.no_results')}</div>",
+      pending: "<div class='tt-suggestion'>#{I18n.t('constants.search.loading')}</div>",
+      suggestion: (s) -> [
+        "<div class='tt-suggestion'>"
+          "<div class='w-100'>"
+            "<h5>#{s.protocol_id}</h5>"
+          "</div>",
+          "<div class='w-100'>"
+            "<strong>Title: </strong>#{s.protocol_title}"
+          "<div>",
+          "<div class='w-100'>"
+            "<strong>Short Title: </strong>#{s.protocol_short_title}"
+          "<div>",
+          "<div class='w-100'>"
+            "<strong>RMID: </strong>#{s.protocol_rmid}"
+          "<div>",
+        "</div>"
+      ].join('')
+    }
+  }
+)

--- a/app/views/dashboard/protocol_merges/new.js.coffee
+++ b/app/views/dashboard/protocol_merges/new.js.coffee
@@ -21,27 +21,9 @@
 $('#modalContainer').html("<%= j render 'dashboard/protocol_merges/merge_tool_modal.html.haml', protocol_merge: @protocol_merge, current_user: @current_user %>")
 $('#modalContainer').modal('show')
 
-#$('#master_protocol_id').on 'keyup', ->
-  #alert 'Handler for keyup called.'
-  #return
-
-#keyupTimer = undefined
-#$('#master_protocol_id').keyup ->
-  #clearTimeout keyupTimer
-  #keyupTimer = setTimeout((->
-    #alert 'Handler for keyup called.'
-    #return
-  #), 800)
-  #return
-
 mergesBloodhound = new Bloodhound(
   datumTokenizer: Bloodhound.tokenizers.whitespace
   queryTokenizer: Bloodhound.tokenizers.whitespace
-  #local: [
-    #'222'
-    #'221'
-    #'220'
-  #]
   remote:
     url: "/search/protocol_merge_search?term=%TERM",
     wildcard: '%TERM'

--- a/app/views/dashboard/protocol_merges/new.js.coffee
+++ b/app/views/dashboard/protocol_merges/new.js.coffee
@@ -55,6 +55,9 @@ $('#master_protocol_id').typeahead(
           "<div class='w-100'>"
             "<strong>RMID: </strong>#{s.protocol_rmid}"
           "<div>",
+          "<div class='w-100'>"
+            "<strong>Primary PI: </strong>#{s.protocol_pi}"
+          "<div>",
         "</div>"
       ].join('')
     }
@@ -84,6 +87,9 @@ $('#merged_protocol_id').typeahead(
           "<div>",
           "<div class='w-100'>"
             "<strong>RMID: </strong>#{s.protocol_rmid}"
+          "<div>",
+          "<div class='w-100'>"
+            "<strong>Primary PI: </strong>#{s.protocol_pi}"
           "<div>",
         "</div>"
       ].join('')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ SparcRails::Application.routes.draw do
       get :services
       get :organizations
       get :identities
+      get :protocol_merge_search
     end
   end
 


### PR DESCRIPTION
This story adds dynamic search capability to the existing form fields in the protocol merge modal on SPARC Dashboard. Dynamic search grabs search input and looks for an exact protocol ID match in the database, and the search suggestions display the following to assist users in confirming they are selecting the correct protocols for merge:

1) Protocol ID
2) Title
3) Short Title
4) RMID (if applicable)
5) Primary PI

https://www.pivotaltracker.com/story/show/168029003

[#168029003]