### PR TITLE
Fix visit group popover bug

### DIFF
--- a/app/views/visit_groups/edit.js.coffee
+++ b/app/views/visit_groups/edit.js.coffee
@@ -50,15 +50,27 @@ else
   )
 
   # This is a hack to fix https://www.pivotaltracker.com/story/show/185417863
-  $vg.on 'shown.bs.popover', ->
+  $vg.on 'inserted.bs.popover', ->
     if $('.popover').length > 1
-      $('.popover').first().attr('title', title).find('.popover-body').html($content)
-      $('.popover').last().remove()
+      $p1 = $('.popover').first()
+      $p2 = $('.popover').last()
+      if $('#templateTabLink').hasClass('active')
+        $p1.attr('title', title).find('.popover-body').html($content)
+        $p2.remove()
+        fixPopoverPosition($p1)
+      else
+        $p2.attr('title', title).find('.popover-body').html($content)
+        $p1.remove()
+        fixPopoverPosition($p2)
+
+  fixPopoverPosition = (misbehavingPopover) ->
+    misbehavingPopover.hide().on('hidden.bs.popover', ->
       y = $(window).scrollTop()
       $(window).scrollTop(y+1).scrollTop(y-1)
+    ).show()
 
-  # Logic for smoother closing of visit group popovers
   $vg.on 'shown.bs.popover', ->
+
     $(document).one 'hide.bs.popover', 'body', ->
       $vg.removeClass('active').trigger('focus')
   $vg.addClass('active').trigger('focus').popover('show')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185417863

When clicking from Quantity/Billing to Template tab in Service Calendar, then clicking on a Visit to edit, two popover instances get created and displayed. This PR adds some javascript to remove the extra popover and re-position the remaining popover correctly next to its reference element.
