### PR TITLE
SJ - Visit Group Validation

### DIFF
--- a/app/models/arm.rb
+++ b/app/models/arm.rb
@@ -51,13 +51,21 @@ class Arm < ApplicationRecord
   validates :subject_count, numericality: { greater_than: 0 }
 
   def visit_groups_valid?
-    self.errors.add(:visit_groups, :invalid) unless self.visit_groups.all?(&:valid?)
-    self.errors.add(:visit_groups, :out_of_order) unless self.visit_groups.all?(&:in_order?)
+    loaded_visit_groups = visit_groups.to_a.each{|vg| vg.skip_order_validation = true}
+    self.errors.add(:visit_groups, :invalid) if loaded_visit_groups.detect(&:invalid?)
+    self.errors.add(:visit_groups, :out_of_order) unless visit_groups_in_order?(loaded_visit_groups)
     self.errors.none?
   end
 
   # To add errors for moving a visit's position
   attr_accessor :visit_group_id
+
+  def visit_groups_in_order?(loaded_visit_groups = visit_groups)
+    vg_ids_by_position = loaded_visit_groups.sort{|a,b| a.position <=> b.position}.map(&:id)
+    vg_ids_by_day = loaded_visit_groups.sort{|a,b| a.day <=> b.day}.map(&:id)
+
+    vg_ids_by_position === vg_ids_by_day
+  end
 
   def display_line_items_visits(display_all_services)
     if Setting.get_value('use_epic')

--- a/app/models/visit_group.rb
+++ b/app/models/visit_group.rb
@@ -53,9 +53,10 @@ class VisitGroup < ApplicationRecord
 
   validates :day, numericality: { only_integer: true }, if: Proc.new{ |vg| vg.day.present? }
 
-  validate :day_must_be_in_order, if: Proc.new{ |vg| vg.day.present? }
+  validate :day_must_be_in_order, if: Proc.new{ |vg| vg.day.present? && !vg.skip_order_validation }
 
   attr_accessor :neighbor_moved
+  attr_accessor :skip_order_validation
 
   default_scope { order(:position) }
 


### PR DESCRIPTION
When service requests were validating their arms, the arms were using the "in_order?" method at the visit_group level, which was extremely wasteful, since every single visit group on every arm checked all of it's sibling VGs to see if it was in order. This new method loads the visit groups for an arm once, then uses sort comparisons to ensure position matches day.

Takes about 0.2 seconds for an arm with 135 visit groups, instead of 5 seconds.