### PR TITLE
Add `additional_funding_sources`

### DIFF
--- a/app/assets/javascripts/additional_funding_sources.js.coffee
+++ b/app/assets/javascripts/additional_funding_sources.js.coffee
@@ -1,0 +1,23 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/
+
+$ ->
+  $(document).on 'changed.bs.select', '#additional_funding_source_funding_source', '#protocol_additional_funding_source_attributes_funding_source', ->
+    if $(this).val() == 'federal'
+      $('#federalGrantFields').removeClass('d-none')
+    else
+      $('#federalGrantFields').addClass('d-none')
+
+    if $(this).val() == 'internal'
+      $('#additionalFundingSourceOtherContainer').removeClass('d-none')
+    else
+      $('#additionalFundingSourceOtherContainer').addClass('d-none')
+
+  $(document).on 'change', '#additional_funding_source_phs_sponsor', ->
+    if $('#additional_funding_source_non_phs_sponsor').val()
+      $('#additional_funding_source_non_phs_sponsor').selectpicker('val', '')
+
+  $(document).on 'change', '#additional_funding_source_non_phs_sponsor', ->
+    if $('#additional_funding_source_phs_sponsor').val()
+      $('#additional_funding_source_phs_sponsor').selectpicker('val', '')

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -88,6 +88,7 @@
 //= require documents
 //= require review
 //= require confirmation
+//= require additional_funding_sources
 
 //= require service_calendar
 

--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -38,6 +38,12 @@ $(document).ready ->
     clearTimeout(rmidTimer)
   )
 
+  $(document).on 'change', '#protocol_additional_funding_sources', ->
+    if $(this).prop('checked')
+      $('#additionalFundingSourcesContainer').removeClass('d-none')
+    else
+      $('#additionalFundingSourcesContainer').addClass('d-none')
+
   $(document).on 'change', '#protocol_funding_status', ->
     toggleFundingSource($(this).val())
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,65 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px; }
+
+body, p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px; }
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px; }
+
+a {
+  color: #000; }
+
+a:visited {
+  color: #666; }
+
+a:hover {
+  color: #fff;
+  background-color: #000; }
+
+th {
+  padding-bottom: 5px; }
+
+td {
+  padding: 0 5px 7px; }
+
+div.field,
+div.actions {
+  margin-bottom: 10px; }
+
+#notice {
+  color: green; }
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table; }
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0; }
+
+#error_explanation h2 {
+  text-align: left;
+  font-weight: bold;
+  padding: 5px 5px 5px 15px;
+  font-size: 12px;
+  margin: -7px -7px 0;
+  background-color: #c00;
+  color: #fff; }
+
+#error_explanation ul li {
+  font-size: 12px;
+  list-style: square; }
+
+label {
+  display: block; }

--- a/app/controllers/additional_funding_sources_controller.rb
+++ b/app/controllers/additional_funding_sources_controller.rb
@@ -3,28 +3,16 @@ class AdditionalFundingSourcesController < ApplicationController
 
   before_action :set_additional_funding_source, only: %i[ edit update destroy ]
 
-  # GET /additional_funding_sources or /additional_funding_sources.json
-  def index
-    @additional_funding_sources = AdditionalFundingSource.all
-  end
-
-  # GET /additional_funding_sources/1 or /additional_funding_sources/1.json
-  def show
-  end
-
-  # GET /additional_funding_sources/new
   def new
     @additional_funding_source = @protocol.additional_funding_sources.new
     respond_to :js, :html
   end
 
-  # GET /additional_funding_sources/1/edit
   def edit
     respond_to :js
     @additional_funding_source.assign_attributes(additional_funding_source_params) if params[:additional_funding_source]
   end
 
-  # POST /additional_funding_sources or /additional_funding_sources.json
   def create
     respond_to :js
     @additional_funding_source = @protocol.additional_funding_sources.new(additional_funding_source_params)
@@ -33,7 +21,6 @@ class AdditionalFundingSourcesController < ApplicationController
     end
   end
 
-  # PATCH/PUT /additional_funding_sources/1 or /additional_funding_sources/1.json
   def update
     respond_to :js
     @additional_funding_source.assign_attributes(additional_funding_source_params) if params[:additional_funding_source]
@@ -43,7 +30,6 @@ class AdditionalFundingSourcesController < ApplicationController
     end
   end
 
-    # DELETE /additional_funding_sources/1 or /additional_funding_sources/1.json
   def destroy
     @additional_funding_source.destroy
 
@@ -55,7 +41,6 @@ class AdditionalFundingSourcesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_additional_funding_source
       @additional_funding_source = params[:id].present? ? AdditionalFundingSource.find(params[:id]) : AdditionalFundingSource.new
     end
@@ -64,7 +49,6 @@ class AdditionalFundingSourcesController < ApplicationController
       @protocol = params[:protocol_id].present? ? Protocol.find(params[:protocol_id]) : Study.new
     end
 
-    # Only allow a list of trusted parameters through.
     def additional_funding_source_params
       params.require(:additional_funding_source).permit(:id, :funding_source, :funding_source_other, :sponsor_name, :comments, :federal_grant_code, :federal_grant_serial_number, :federal_grant_title, :phs_sponsor, :non_phs_sponsor, :protocol_id)
     end

--- a/app/controllers/additional_funding_sources_controller.rb
+++ b/app/controllers/additional_funding_sources_controller.rb
@@ -1,0 +1,72 @@
+class AdditionalFundingSourcesController < ApplicationController
+  before_action :set_protocol
+
+  before_action :set_additional_funding_source, only: %i[ edit update destroy ]
+
+  # GET /additional_funding_sources or /additional_funding_sources.json
+  def index
+    @additional_funding_sources = AdditionalFundingSource.all
+  end
+
+  # GET /additional_funding_sources/1 or /additional_funding_sources/1.json
+  def show
+  end
+
+  # GET /additional_funding_sources/new
+  def new
+    @additional_funding_source = @protocol.additional_funding_sources.new
+    respond_to :js, :html
+  end
+
+  # GET /additional_funding_sources/1/edit
+  def edit
+    respond_to :js
+    @additional_funding_source.assign_attributes(additional_funding_source_params) if params[:additional_funding_source]
+  end
+
+  # POST /additional_funding_sources or /additional_funding_sources.json
+  def create
+    respond_to :js
+    @additional_funding_source = @protocol.additional_funding_sources.new(additional_funding_source_params)
+    unless @additional_funding_source.valid?
+      @errors = @additional_funding_source.errors
+    end
+  end
+
+  # PATCH/PUT /additional_funding_sources/1 or /additional_funding_sources/1.json
+  def update
+    respond_to :js
+    @additional_funding_source.assign_attributes(additional_funding_source_params) if params[:additional_funding_source]
+
+    unless @additional_funding_source.valid?
+      @errors = @additional_funding_source.errors.full_messages
+    end
+  end
+
+    # DELETE /additional_funding_sources/1 or /additional_funding_sources/1.json
+  def destroy
+    @additional_funding_source.destroy
+
+    respond_to do |format|
+      format.js
+      format.html { redirect_to additional_funding_sources_url, notice: "Additional funding source was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_additional_funding_source
+      @additional_funding_source = params[:id].present? ? AdditionalFundingSource.find(params[:id]) : AdditionalFundingSource.new
+    end
+
+    def set_protocol
+      @protocol = params[:protocol_id].present? ? Protocol.find(params[:protocol_id]) : Study.new
+    end
+
+    # Only allow a list of trusted parameters through.
+    def additional_funding_source_params
+      params.require(:additional_funding_source).permit(:id, :funding_source, :funding_source_other, :sponsor_name, :comments, :federal_grant_code, :federal_grant_serial_number, :federal_grant_title, :phs_sponsor, :non_phs_sponsor, :protocol_id)
+    end
+
+end

--- a/app/controllers/concerns/protocols_controller_shared.rb
+++ b/app/controllers/concerns/protocols_controller_shared.rb
@@ -102,6 +102,7 @@ module ProtocolsControllerShared
       :title,
       :type,
       :udak_project_number,
+      additional_funding_sources_attributes: [:id, :funding_source, :funding_source_other, :sponsor_name, :comments, :federal_grant_code, :federal_grant_serial_number, :federal_grant_title, :phs_sponsor, :non_phs_sponsor, :protocol_id, :_destroy],
       affiliations_attributes: [:id, :name, :new, :position, :_destroy],
       external_organizations_attributes: [:id, :collaborating_org_name, :collaborating_org_type, :comments, :collaborating_org_name_other, :collaborating_org_type_other, :_destroy],
       human_subjects_info_attributes: [

--- a/app/models/additional_funding_source.rb
+++ b/app/models/additional_funding_source.rb
@@ -3,7 +3,7 @@ class AdditionalFundingSource < ApplicationRecord
 
   validates :fundig_source_other, presence: true, if: Proc.new { |a| a.funding_source == 'Internal Funded Pilot Project' }
 
-  # Validate federal grant details    
+  ## In case we decide to validate federal grant details ##
   # validates :federal_grant_code, :federal_grant_serial_number, :federal_grant_title, presence: true, if: Proc.new { |a| a.funding_source == 'Federal' }
 
   # validate :phs_or_non_phs_sponsor_present, if: Proc.new { |a| a.funding_source == 'Federal' }

--- a/app/models/additional_funding_source.rb
+++ b/app/models/additional_funding_source.rb
@@ -1,0 +1,18 @@
+class AdditionalFundingSource < ApplicationRecord
+  belongs_to :protocol
+
+  validates :fundig_source_other, presence: true, if: Proc.new { |a| a.funding_source == 'Internal Funded Pilot Project' }
+
+  # Validate federal grant details    
+  # validates :federal_grant_code, :federal_grant_serial_number, :federal_grant_title, presence: true, if: Proc.new { |a| a.funding_source == 'Federal' }
+
+  # validate :phs_or_non_phs_sponsor_present, if: Proc.new { |a| a.funding_source == 'Federal' }
+
+  # def phs_or_non_phs_sponsor_present
+  #   if phs_sponsor.blank? && non_phs_sponsor.blank?
+  #     errors.add(:base, "Either PHS Sponsor or Non-PHS Sponsor must be present")
+  #   elsif phs_sponsor.present? && non_phs_sponsor.present?
+  #     errors.add(:base, "PHS Sponsor and Non-PHS Sponsor cannot both be present")
+  #   end
+  # end
+end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -63,6 +63,7 @@ class Protocol < ApplicationRecord
   has_many :responses,                    through: :sub_service_requests
   has_many :irb_records,                  through: :human_subjects_info
   has_many :external_organizations,       dependent: :destroy
+  has_many :additional_funding_sources,   dependent: :destroy
 
   has_many :principal_investigator_roles, -> { where(role: ['pi', 'primary-pi']) }, class_name: "ProjectRole", dependent: :destroy
   has_many :principal_investigators, through: :principal_investigator_roles, source: :identity
@@ -101,6 +102,7 @@ class Protocol < ApplicationRecord
   accepts_nested_attributes_for :primary_pi_role,               allow_destroy: true
   accepts_nested_attributes_for :arms,                          allow_destroy: true
   accepts_nested_attributes_for :study_type_answers,            allow_destroy: true
+  accepts_nested_attributes_for :additional_funding_sources,   allow_destroy: true
 
   validates :research_master_id, numericality: { only_integer: true }, allow_blank: true
   validates :research_master_id, presence: true, if: :rmid_requires_validation?

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -70,6 +70,7 @@ class Study < Protocol
     self.build_vertebrate_animals_info          unless self.vertebrate_animals_info
     self.build_investigational_products_info    unless self.investigational_products_info
     self.build_ip_patents_info                  unless self.ip_patents_info
+    self.build_additional_funding_sources       unless self.additional_funding_sources
     self.setup_study_types
     self.setup_impact_areas
     self.setup_affiliations

--- a/app/views/additional_funding_sources/_additional_funding_source.html.haml
+++ b/app/views/additional_funding_sources/_additional_funding_source.html.haml
@@ -1,0 +1,65 @@
+.list-group-item.d-flex.border.flex-column.collapsed.mb-3.additional-funding-source{ class: 'list-group-item-success additional-funding-source', id: "additionalFundingSource#{index}", data: { toggle: 'collapse', target: "#additionalFundingSource#{index}Collapse" }}
+  - AdditionalFundingSource.attribute_names.each do |attr|
+    = hidden_field_tag "protocol[additional_funding_sources_attributes][#{index}][#{attr}]", additional_funding_source.send(attr)
+
+  .d-flex.justify-content-between
+    %h4.mb-0.collapsed
+      = icon('fas', 'caret-down mr-2')
+      = PermissibleValue.get_value('funding_source', additional_funding_source.funding_source) == 'Internal Funded Pilot Project' ? additional_funding_source.funding_source_other : PermissibleValue.get_value('funding_source', additional_funding_source.funding_source)
+    .d-flex.align-items-center
+      = link_to edit_additional_funding_sources_path(id: additional_funding_source.id, index: index,  additional_funding_source: params[:additional_funding_source].present? ? params[:additional_funding_source].permit! : {}), remote: true, class: 'text-warning mr-2 edit-additional-funding-source', title: t('additional_funding_sources.tooltips.edit'), data: { toggle: 'tooltip' } do
+        = icon('fas', 'edit fa-lg')
+      = link_to additional_funding_sources_path(id: additional_funding_source.id, index: index), remote: true, method: :delete, class: ['delete-additional-funding-source',  'text-danger'], title: t('additional_funding_sources.tooltips.delete'), data: { toggle: 'tooltip' } do
+        = icon('fas', 'trash-alt fa-lg')
+  .collapse{ id: "additionalFundingSource#{index}Collapse" }
+    .w-100.pt-3
+      .form-row
+        .form-group.col-4
+          %label.mb-0.font-weight-bold
+            = AdditionalFundingSource.human_attribute_name(:funding_source)
+        .form-group.col-2
+          = PermissibleValue.get_value('funding_source', additional_funding_source.funding_source) == 'Internal Funded Pilot Project' ? additional_funding_source.funding_source_other : PermissibleValue.get_value('funding_source', additional_funding_source.funding_source)
+        .form-group.col-4
+          %label.mb-0.font-weight-bold
+            = AdditionalFundingSource.human_attribute_name(:sponsor_name)
+        .form-group.col-2
+          = additional_funding_source.sponsor_name.present? ? additional_funding_source.sponsor_name : t('constants.na')
+      .form-row
+        .form-group.col-4
+          %label.mb-0.font-weight-bold
+            = AdditionalFundingSource.human_attribute_name(:comments)
+        .form-group.col-8
+          = additional_funding_source.comments.present? ? additional_funding_source.comments : t('constants.na')
+
+      - if additional_funding_source.funding_source == 'federal'
+        .form-row
+          .form-group.col-4
+            %label.mb-0.font-weight-bold
+              = AdditionalFundingSource.human_attribute_name(:federal_grant_serial_number)
+          .form-group.col-2
+            = additional_funding_source.federal_grant_serial_number.present? ? additional_funding_source.federal_grant_serial_number : t('constants.na')
+          .form-group.col-4
+            %label.mb-0.font-weight-bold
+              = AdditionalFundingSource.human_attribute_name(:federal_grant_title)
+          .form-group.col-2
+            = additional_funding_source.federal_grant_title.present? ? additional_funding_source.federal_grant_title : t('constants.na')
+        .form-row
+          .form-group.col-4
+            %label.mb-0.font-weight-bold
+              = AdditionalFundingSource.human_attribute_name(:federal_grant_code)
+          .form-group.col-2
+            = additional_funding_source.federal_grant_code.present? ? additional_funding_source.federal_grant_code : t('constants.na')
+          .form-group.col-4
+            %label.mb-0.font-weight-bold
+              = AdditionalFundingSource.human_attribute_name(:phs_sponsor)
+          .form-group.col-2
+            = additional_funding_source.phs_sponsor.present? ? additional_funding_source.phs_sponsor : t('constants.na')
+        .form-row
+          .form-group.col-4
+            %label.mb-0.font-weight-bold
+              = AdditionalFundingSource.human_attribute_name(:non_phs_sponsor)
+          .form-group.col-8
+            = additional_funding_source.non_phs_sponsor.present? ? additional_funding_source.non_phs_sponsor : t('constants.na')
+
+
+

--- a/app/views/additional_funding_sources/_destroy.html.haml
+++ b/app/views/additional_funding_sources/_destroy.html.haml
@@ -1,0 +1,21 @@
+-# Copyright © 2011-2022 MUSC Foundation for Research Development~
+-# All rights reserved.~
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:~
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.~
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following~
+-# disclaimer in the documentation and/or other materials provided with the distribution.~
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products~
+-# derived from this software without specific prior written permission.~
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,~
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT~
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL~
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS~
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR~
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.~
+
+= hidden_field_tag "protocol[additional_funding_sources_attributes][#{index}][_destroy]", true

--- a/app/views/additional_funding_sources/_form.html.haml
+++ b/app/views/additional_funding_sources/_form.html.haml
@@ -31,14 +31,14 @@
       .modal-body
         .form-row
           .form-group.col-6
-            = f.label :funding_source, title: t('additional_funding_source.funding_source'), class: 'required'
+            = f.label :funding_source, title: t('additional_funding_source.funding_source')
             = f.select :funding_source, options_for_select(PermissibleValue.get_inverted_hash('funding_source'), f.object.funding_source), { include_blank: true }, class: 'selectpicker'
           .form-group.col-6#additionalFundingSourceOtherContainer{ class: f.object.funding_source == 'internal' ? '' : 'd-none' }
-            = f.label :funding_source_other, t('constants.prompts.please_specify'), class: 'required'
+            = f.label :funding_source_other, t('constants.prompts.please_specify')
             = f.text_field :funding_source_other, class: 'form-control'
         .form-row
           .form-group.col-6#sponsorName
-            = f.label :sponsor_name, t('additional_funding_source.sponsor_name'), class: 'required'
+            = f.label :sponsor_name, t('additional_funding_source.sponsor_name')
             = f.text_field :sponsor_name, class: 'form-control'
 
         %section.mt-12#federalGrantFields{ class: f.object.funding_source == 'federal' ? '' : 'd-none' }

--- a/app/views/additional_funding_sources/_form.html.haml
+++ b/app/views/additional_funding_sources/_form.html.haml
@@ -1,0 +1,75 @@
+-# Copyright © 2011-2022 MUSC Foundation for Research Development
+-# All rights reserved.
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+-# disclaimer in the documentation and/or other materials provided with the distribution.
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+-# derived from this software without specific prior written permission.
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+.modal-dialog{ role: 'document' }
+  .modal-content
+    = form_for additional_funding_source, url: additional_funding_sources_path, method: action_name == 'new' ? :post : :put, remote: true do |f|
+      = hidden_field_tag :protocol_id, params[:protocol_id]
+      = hidden_field_tag :index, params[:index]
+      .modal-header
+        %h3.modal-title
+          = AdditionalFundingSource.model_name.human.humanize
+        %button.close{ type: 'button', data: { dismiss: 'modal' }, aria: { label: t('actions.close') } }
+          %span{ aria: { hidden: 'true' } } &times;
+      .modal-body
+        .form-row
+          .form-group.col-6
+            = f.label :funding_source, title: t('additional_funding_source.funding_source'), class: 'required'
+            = f.select :funding_source, options_for_select(PermissibleValue.get_inverted_hash('funding_source'), f.object.funding_source), { include_blank: true }, class: 'selectpicker'
+          .form-group.col-6#additionalFundingSourceOtherContainer{ class: f.object.funding_source == 'internal' ? '' : 'd-none' }
+            = f.label :funding_source_other, t('constants.prompts.please_specify'), class: 'required'
+            = f.text_field :funding_source_other, class: 'form-control'
+        .form-row
+          .form-group.col-6#sponsorName
+            = f.label :sponsor_name, t('additional_funding_source.sponsor_name'), class: 'required'
+            = f.text_field :sponsor_name, class: 'form-control'
+
+        %section.mt-12#federalGrantFields{ class: f.object.funding_source == 'federal' ? '' : 'd-none' }
+          .form-row
+            .form-group.col-6
+              = f.label :federal_grant_code
+              = f.select :federal_grant_code, options_for_select(PermissibleValue.get_inverted_hash('federal_grant_code'), f.object.federal_grant_code), { include_blank: true }, class: 'selectpicker form-control wrap-text', data: { live_search: true }
+            .form-group.col-6
+              = f.label :federal_grant_serial_number
+              = f.text_field :federal_grant_serial_number, class: 'form-control'
+          .form-row
+            .form-group.col-6
+              = f.label :federal_grant_title
+              = f.text_field :federal_grant_title, class: 'form-control'
+          .form-row
+            .form-group.col-4
+              = f.label :phs_sponsor
+              = f.select :phs_sponsor, options_for_select(PermissibleValue.get_inverted_hash('federal_grant_phs_sponsor'), additional_funding_source.phs_sponsor), { include_blank: true }, class: 'selectpicker form-control', data: { live_search: 'true' }
+            .form-group.col-2.d-flex.align-items-end.justify-content-center
+              %label
+                %strong
+                  = t('protocols.form.grant_information.sponsor_separator')
+            .form-group.col-4
+              = f.label :non_phs_sponsor
+              = f.select :non_phs_sponsor, options_for_select(PermissibleValue.get_inverted_hash('federal_grant_non_phs_sponsor'), additional_funding_source.non_phs_sponsor), { include_blank: true }, class: 'selectpicker form-control', data: { live_search: 'true' }
+        .form-row
+          .form-group.col-6
+            = f.label :comments, t('additional_funding_source.comments')
+            = f.text_area :comments, class: 'form-control'
+
+      .modal-footer
+        %button.btn.btn-secondary{ type: 'button', data: { dismiss: 'modal' } }
+          = t('actions.close')
+        = f.submit t('actions.submit'), class: 'btn btn-primary'

--- a/app/views/additional_funding_sources/_new_additional_funding_source.html.haml
+++ b/app/views/additional_funding_sources/_new_additional_funding_source.html.haml
@@ -1,0 +1,23 @@
+-# Copyright © 2011-2023 MUSC Foundation for Research Development
+-# All rights reserved.
+
+-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+-# disclaimer in the documentation and/or other materials provided with the distribution.
+
+-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+-# derived from this software without specific prior written permission.
+
+-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+-# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+-# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+-# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+= link_to new_additional_funding_sources_path(protocol_id: protocol.id, index: index), remote: true, class: 'btn btn-success', id: 'newAdditionalFundingSource' do
+  = icon('fas', 'plus')
+  = t('additional_funding_sources.add')

--- a/app/views/additional_funding_sources/create.js.coffee
+++ b/app/views/additional_funding_sources/create.js.coffee
@@ -1,0 +1,36 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+<% if @errors %>
+$("[name^='additional_funding_source']:not([type='hidden'])").parents('.form-group').removeClass('is-invalid').addClass('is-valid')
+$('.form-error').remove()
+
+<% @errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='additional_funding_source[<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
+<% else %>
+$('#additionalFundingSources').append("<%= j render 'additional_funding_sources/additional_funding_source', protocol: @protocol, additional_funding_source: @additional_funding_source, index: params[:index] %>")
+$('#newAdditionalFundingSource').replaceWith("<%= j render 'additional_funding_sources/new_additional_funding_source', protocol: @protocol, index: params[:index].to_i + 1 %>")
+
+if $('#modalContainer').hasClass('show')
+  $("#modalContainer").modal('hide')
+<% end %>

--- a/app/views/additional_funding_sources/destroy.js.coffee
+++ b/app/views/additional_funding_sources/destroy.js.coffee
@@ -1,0 +1,21 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+$("#additionalFundingSource<%= params[:index] %>").removeClass('d-flex').addClass('d-none').append("<%= j render 'additional_funding_sources/destroy', index: params[:index] %>")

--- a/app/views/additional_funding_sources/edit.js.coffee
+++ b/app/views/additional_funding_sources/edit.js.coffee
@@ -1,0 +1,22 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+$("#modalContainer").html("<%= j render 'additional_funding_sources/form', additional_funding_source: @additional_funding_source %>")
+$("#modalContainer").modal('show')

--- a/app/views/additional_funding_sources/new.js.coffee
+++ b/app/views/additional_funding_sources/new.js.coffee
@@ -1,0 +1,22 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+$("#modalContainer").html("<%= j render 'additional_funding_sources/form', additional_funding_source: @additional_funding_source %>" )
+$("#modalContainer").modal('show')

--- a/app/views/additional_funding_sources/update.js.coffee
+++ b/app/views/additional_funding_sources/update.js.coffee
@@ -1,0 +1,40 @@
+# Copyright © 2011-2022 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+<% if @errors %>
+$("[name^='additional_funding_source']:not([type='hidden'])").parents('.form-group').removeClass('is-invalid').addClass('is-valid')
+$('.form-error').remove()
+
+<% @errors.messages.each do |attr, messages| %>
+<% messages.each do |message| %>
+$("[name='additional_funding_source[<%= attr.to_s %>]']").parents('.form-group').removeClass('is-valid').addClass('is-invalid').append("<small class='form-text form-error'><%= message.capitalize.html_safe %></small>")
+<% end %>
+<% end %>
+<% else %>
+$("#additionalFundingSource<%= params[:index] %>").replaceWith("<%= j render 'additional_funding_sources/additional_funding_source', protocol: @protocol, additional_funding_source: @additional_funding_source, index: params[:index] %>")
+
+if $('.additional-funding-source:not(.d-none)').length > 1
+  $('.primary-additional-funding-source .delete-external-organization').addClass('text-muted').removeClass('text-danger').
+    attr('disabled', true).
+    attr('data-original-title', I18n.t('additional_funding_sources.tooltips.cant_delete_primary'))
+
+if $('#modalContainer').hasClass('show')
+  $("#modalContainer").modal('hide')
+<% end %>

--- a/app/views/protocols/form/_financial_information.html.haml
+++ b/app/views/protocols/form/_financial_information.html.haml
@@ -18,6 +18,8 @@
 -# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 -# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+- use_additional_funding_sources = Setting.get_value("use_additional_funding_sources")
+
 %section.pt-3#financialInformation
   .card
     .card-body.p-5
@@ -100,3 +102,15 @@
 
       - if protocol.is_a?(Study)
         = render 'protocols/form/federal_grant_information', f: f, protocol: protocol
+
+      - if use_additional_funding_sources
+        %section.mt-3#additionalFundingsourcesContainer
+        .form-group
+          %h4.pb-2.border-bottom
+            = t('protocols.form.financial_information.additional_funding_sources')
+        .w-100#additionalFundingSources
+          - @afs_count = f.object.additional_funding_sources.length
+          = f.fields_for :additional_funding_sources do |ff_afs|
+            = render 'additional_funding_sources/additional_funding_source', protocol: protocol, f: f, additional_funding_source: ff_afs.object, index: ff_afs.index
+        = render 'additional_funding_sources/new_additional_funding_source', protocol: protocol, index: @afs_count
+

--- a/app/views/protocols/form/_financial_information.html.haml
+++ b/app/views/protocols/form/_financial_information.html.haml
@@ -104,13 +104,23 @@
         = render 'protocols/form/federal_grant_information', f: f, protocol: protocol
 
       - if use_additional_funding_sources
-        %section.mt-3#additionalFundingsourcesContainer
-        .form-group
-          %h4.pb-2.border-bottom
-            = t('protocols.form.financial_information.additional_funding_sources')
-        .w-100#additionalFundingSources
-          - @afs_count = f.object.additional_funding_sources.length
-          = f.fields_for :additional_funding_sources do |ff_afs|
-            = render 'additional_funding_sources/additional_funding_source', protocol: protocol, f: f, additional_funding_source: ff_afs.object, index: ff_afs.index
-        = render 'additional_funding_sources/new_additional_funding_source', protocol: protocol, index: @afs_count
+        %section
+          .form-row
+            .form-group.col-12
+              .custom-control.custom-checkbox.custom-control-lg.custom-control-inline
+                - if f.object.additional_funding_sources.present?
+                  = f.check_box :additional_funding_sources, class: 'custom-control-input', data: { target: '#additionalFundingSourcesContainer' }, checked: true
+                - else
+                  = f.check_box :additional_funding_sources, class: 'custom-control-input', data: { target: '#additionalFundingSourcesContainer' }
+                = f.label :additional_funding_sources, t('protocols.form.financial_information.additional_funding_sources'), class: 'custom-control-label', data: { toggle: 'tooltip', placement: 'right' }, title: t('protocols.tooltips.additional_funding_sources')
+
+        %section.mt-3#additionalFundingSourcesContainer{ class: f.object.additional_funding_sources.present? ? '' : 'd-none'}
+          .form-group
+            %h5.pb-2.border-bottom
+              = t('protocols.form.financial_information.additional_funding')
+          .w-100#additionalFundingSources
+            - @afs_count = f.object.additional_funding_sources.length
+            = f.fields_for :additional_funding_sources do |ff_afs|
+              = render 'additional_funding_sources/additional_funding_source', protocol: protocol, f: f, additional_funding_source: ff_afs.object, index: ff_afs.index
+          = render 'additional_funding_sources/new_additional_funding_source', protocol: protocol, index: @afs_count
 

--- a/app/views/protocols/view_details/_additional_funding_sources.html.haml
+++ b/app/views/protocols/view_details/_additional_funding_sources.html.haml
@@ -1,0 +1,58 @@
+%tr.bg-light
+  %td{ colspan: 2 }
+    %h6.mb-0
+      = t('protocols.form.financial_information.additional_funding_sources')
+- protocol.additional_funding_sources.each_with_index do |additional_funding_source, index|
+  %tr
+    %td.w-25.alert-success
+      %label.mb-0
+        = "Additional Funding Source #{index + 1}"
+    %td.w-75.alert-success
+      = additional_funding_source.funding_source == 'internal' ? additional_funding_source.funding_source_other : additional_funding_source.funding_source
+  %tr
+    %td.w-25
+      %label.mb-0
+        = AdditionalFundingSource.human_attribute_name(:sponsor_name)
+    %td.w-75
+      = additional_funding_source.sponsor_name.present? ? additional_funding_source.sponsor_name : t('constants.na')
+  %tr
+    %td.w-25
+      %label.mb-0
+        = AdditionalFundingSource.human_attribute_name(:comments)
+    %td.w-75
+      = additional_funding_source.comments.present? ? additional_funding_source.comments : t('constants.na')
+
+  - if additional_funding_source.funding_source == 'federal'
+    %tr
+      %td.w-25
+        %label.mb-0
+          = AdditionalFundingSource.human_attribute_name(:federal_grant_code)
+      %td.w-75
+        = additional_funding_source.federal_grant_code.present? ? additional_funding_source.federal_grant_code : t('constants.na')
+    %tr
+      %td.w-25
+        %label.mb-0
+          = AdditionalFundingSource.human_attribute_name(:federal_grant_serial_number)
+      %td.w-75
+        = additional_funding_source.federal_grant_serial_number.present? ? additional_funding_source.federal_grant_serial_number : t('constants.na')
+    %tr
+      %td.w-25
+        %label.mb-0
+          = AdditionalFundingSource.human_attribute_name(:federal_grant_title)
+      %td.w-75
+        = additional_funding_source.federal_grant_title.present? ? additional_funding_source.federal_grant_title : t('constants.na')
+    %tr
+      %td.w-25
+        %label.mb-0
+          = AdditionalFundingSource.human_attribute_name(:phs_sponsor)
+      %td.w-75
+        = additional_funding_source.phs_sponsor.present? ? additional_funding_source.phs_sponsor : t('constants.na')
+    %tr
+      %td.w-25
+        %label.mb-0
+          = AdditionalFundingSource.human_attribute_name(:non_phs_sponsor)
+      %td.w-75
+        = additional_funding_source.non_phs_sponsor.present? ? additional_funding_source.non_phs_sponsor : t('constants.na')
+
+
+

--- a/app/views/protocols/view_details/_financial_information.html.haml
+++ b/app/views/protocols/view_details/_financial_information.html.haml
@@ -1,4 +1,4 @@
--# Copyright © 2011-2022 MUSC Foundation for Research Development
+-# Copyright © 2011-2023 MUSC Foundation for Research Development
 -# All rights reserved.
 
 -# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -88,3 +88,5 @@
 
         - if protocol.federally_funded?
           = render 'protocols/view_details/federal_grant_information', protocol: protocol
+        - if protocol.additional_funding_sources.present?
+          = render 'protocols/view_details/additional_funding_sources', protocol: protocol

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1178,6 +1178,15 @@
     "version":        "",
     "parent_key":     "",
     "parent_value":   ""
+  },
+  {
+    "key":            "use_additional_funding_sources",
+    "value":          "true",
+    "friendly_name":  "Use Additional Funding Sources",
+    "description":    "This determines whether the application will display the Additional Funding Sources section on a Study Form.",
+    "group":          "",
+    "version":        "",
+    "parent_key":     "",
+    "parent_value":   ""
   }
-
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -700,6 +700,15 @@ en:
     none: "You don't have any forms to complete"
     srid: "SRID"
 
+  ##############################
+  # ADDITIONAL FUNDING SOURCES #
+  ##############################
+  additional_funding_sources:
+    add: "Add New"
+    tooltips:
+      edit: "Edit the Additional Funding Source"
+      delete: "Delete the Additional Funding Source"
+
   ###############
   # IRB RECORDS #
   ###############
@@ -931,6 +940,7 @@ en:
       financial_information:
         header: "Financial Information"
         guarantor_header: "Send Bills To..."
+        additional_funding_sources: "Additional Funding Sources"
       grant_information:
         header: "Federal Grant Information"
         sponsor_separator: "- OR -"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -941,6 +941,7 @@ en:
         header: "Financial Information"
         guarantor_header: "Send Bills To..."
         additional_funding_sources: "Additional Funding Sources"
+        additional_funding: "Additional Funding"
       grant_information:
         header: "Federal Grant Information"
         sponsor_separator: "- OR -"
@@ -955,10 +956,11 @@ en:
         affiliations: "Affiliations, Collaborations, & Memberships"
         subheader: "Involved External Organizations"
     tooltips:
+      additional_funding_sources: "Sources that are not the most current or largest funders"
       external_organization_name: "Collaborating Org Name"
       end_date: "Estimated end date for your %{protocol_type} (used by service providers to prioritize)"
       epic: "Defines whether record will interface to Epic EMR."
-      funding_source: "Funding source which drives research pricing for your Study/Project"
+      funding_source: "Current or largest sponsoring funding source which drives research pricing for your Study/Project"
       funding_status: "Indicates whether or not funding has been applied for or obtained. Choose 'Pending Funding' if you are applying for grant service."
       ind_number: "Investigational New Drug Number"
       nct_number: "Clinicaltrials.gov Registry Number."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ SparcRails::Application.routes.draw do
   ####################
   ### Other Routes ###
   ####################
+  resource :additional_funding_sources
 
   resource :pages, only: [] do
     get :event_details

--- a/db/migrate/20231115180501_create_additional_funding_sources.rb
+++ b/db/migrate/20231115180501_create_additional_funding_sources.rb
@@ -1,0 +1,18 @@
+class CreateAdditionalFundingSources < ActiveRecord::Migration[5.2]
+  def change
+    create_table :additional_funding_sources do |t|
+      t.string :funding_source
+      t.string :funding_source_other
+      t.string :sponsor_name
+      t.text :comments
+      t.string :federal_grant_code
+      t.string :federal_grant_serial_number
+      t.string :federal_grant_title
+      t.string :phs_sponsor
+      t.string :non_phs_sponsor
+      t.references :protocol, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_27_001331) do
+ActiveRecord::Schema.define(version: 2023_11_15_180501) do
 
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -31,6 +31,22 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "additional_funding_sources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.string "funding_source"
+    t.string "funding_source_other"
+    t.string "sponsor_name"
+    t.text "comments"
+    t.string "federal_grant_code"
+    t.string "federal_grant_serial_number"
+    t.string "federal_grant_title"
+    t.string "phs_sponsor"
+    t.string "non_phs_sponsor"
+    t.bigint "protocol_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["protocol_id"], name: "index_additional_funding_sources_on_protocol_id"
   end
 
   create_table "admin_rate_changes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
@@ -53,7 +69,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.integer "identity_id"
   end
 
-  create_table "affiliations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "affiliations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "name"
     t.datetime "created_at", null: false
@@ -62,14 +78,14 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_affiliations_on_protocol_id"
   end
 
-  create_table "alerts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "alerts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "alert_type"
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "applications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "applications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.string "domain"
@@ -80,7 +96,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["created_by"], name: "index_applications_on_created_by"
   end
 
-  create_table "approvals", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "approvals", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.datetime "approval_date"
     t.datetime "created_at", null: false
@@ -92,7 +108,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_approvals_on_sub_service_request_id"
   end
 
-  create_table "arms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "arms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.integer "visit_count", default: 1
     t.datetime "created_at", null: false
@@ -105,7 +121,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_arms_on_protocol_id"
   end
 
-  create_table "associated_surveys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "associated_surveys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "associable_id"
     t.string "associable_type"
     t.bigint "survey_id"
@@ -115,7 +131,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["survey_id"], name: "index_associated_surveys_on_survey_id"
   end
 
-  create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "auditable_id"
     t.string "auditable_type"
     t.bigint "associated_id"
@@ -137,7 +153,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table "available_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "available_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "organization_id"
     t.string "status"
     t.datetime "created_at", null: false
@@ -146,7 +162,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_available_statuses_on_organization_id"
   end
 
-  create_table "catalog_managers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "catalog_managers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.bigint "organization_id"
     t.datetime "created_at", null: false
@@ -157,7 +173,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_catalog_managers_on_organization_id"
   end
 
-  create_table "charges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "charges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "service_request_id"
     t.bigint "service_id"
     t.decimal "charge_amount", precision: 12, scale: 4
@@ -168,7 +184,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["service_request_id"], name: "index_charges_on_service_request_id"
   end
 
-  create_table "clinical_providers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "clinical_providers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.bigint "organization_id"
     t.datetime "created_at", null: false
@@ -177,7 +193,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_clinical_providers_on_organization_id"
   end
 
-  create_table "cover_letters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "cover_letters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "content"
     t.bigint "sub_service_request_id"
     t.datetime "created_at", null: false
@@ -185,7 +201,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_cover_letters_on_sub_service_request_id"
   end
 
-  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", limit: 4294967295, null: false
@@ -200,7 +216,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "documents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "documents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "deleted_at"
     t.string "doc_type"
     t.datetime "created_at", null: false
@@ -212,12 +228,12 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_documents_on_protocol_id"
   end
 
-  create_table "documents_sub_service_requests", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "documents_sub_service_requests", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "document_id"
     t.bigint "sub_service_request_id"
   end
 
-  create_table "editable_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "editable_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "organization_id"
     t.string "status", null: false
     t.datetime "created_at", null: false
@@ -226,7 +242,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_editable_statuses_on_organization_id"
   end
 
-  create_table "epic_queue_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "epic_queue_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "status"
     t.datetime "created_at", null: false
@@ -235,7 +251,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.bigint "identity_id"
   end
 
-  create_table "epic_queues", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "epic_queues", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -244,14 +260,14 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.boolean "user_change", default: false
   end
 
-  create_table "epic_rights", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "epic_rights", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "project_role_id"
     t.string "right"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "excluded_funding_sources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "excluded_funding_sources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "subsidy_map_id"
     t.string "funding_source"
     t.datetime "created_at", null: false
@@ -260,7 +276,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["subsidy_map_id"], name: "index_excluded_funding_sources_on_subsidy_map_id"
   end
 
-  create_table "external_organizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "external_organizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.string "collaborating_org_name"
     t.string "collaborating_org_type"
     t.text "comments"
@@ -272,7 +288,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_external_organizations_on_protocol_id"
   end
 
-  create_table "feedbacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "feedbacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "message"
     t.string "name"
     t.string "email"
@@ -280,7 +296,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "fulfillment_synchronizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "fulfillment_synchronizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "sub_service_request_id"
     t.integer "line_item_id"
     t.string "action"
@@ -288,7 +304,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_fulfillment_synchronizations_on_sub_service_request_id"
   end
 
-  create_table "fulfillments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "fulfillments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "line_item_id"
     t.string "timeframe"
     t.string "time"
@@ -303,7 +319,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["line_item_id"], name: "index_fulfillments_on_line_item_id"
   end
 
-  create_table "human_subjects_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "human_subjects_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -312,7 +328,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_human_subjects_info_on_protocol_id"
   end
 
-  create_table "identities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "identities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "ldap_uid"
     t.string "email"
     t.string "last_name"
@@ -356,7 +372,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["reset_password_token"], name: "index_identities_on_reset_password_token", unique: true
   end
 
-  create_table "impact_areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "impact_areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "name"
     t.datetime "created_at", null: false
@@ -366,7 +382,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_impact_areas_on_protocol_id"
   end
 
-  create_table "investigational_products_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "investigational_products_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "ind_number"
     t.boolean "ind_on_hold"
@@ -378,7 +394,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_investigational_products_info_on_protocol_id"
   end
 
-  create_table "ip_patents_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ip_patents_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "patent_number"
     t.text "inventors"
@@ -388,7 +404,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_ip_patents_info_on_protocol_id"
   end
 
-  create_table "irb_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "irb_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "human_subjects_info_id"
     t.string "pro_number"
     t.string "irb_of_record"
@@ -402,14 +418,14 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["human_subjects_info_id"], name: "index_irb_records_on_human_subjects_info_id"
   end
 
-  create_table "irb_records_study_phases", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "irb_records_study_phases", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "irb_record_id"
     t.bigint "study_phase_id"
     t.index ["irb_record_id"], name: "index_irb_records_study_phases_on_irb_record_id"
     t.index ["study_phase_id"], name: "index_irb_records_study_phases_on_study_phase_id"
   end
 
-  create_table "line_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "line_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "service_request_id"
     t.bigint "sub_service_request_id"
     t.bigint "service_id"
@@ -426,17 +442,18 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_line_items_on_sub_service_request_id"
   end
 
-  create_table "line_items_visits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "line_items_visits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "arm_id"
     t.bigint "line_item_id"
     t.integer "subject_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "visit_r_quantity", default: 0
     t.index ["arm_id"], name: "index_line_items_visits_on_arm_id"
     t.index ["line_item_id"], name: "index_line_items_visits_on_line_item_id"
   end
 
-  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "notification_id"
     t.bigint "to"
     t.bigint "from"
@@ -449,7 +466,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["to"], name: "index_messages_on_to"
   end
 
-  create_table "notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.text "body"
     t.datetime "created_at", null: false
@@ -461,7 +478,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["notable_id", "notable_type"], name: "index_notes_on_notable_id_and_notable_type"
   end
 
-  create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "sub_service_request_id"
     t.bigint "originator_id"
     t.datetime "created_at", null: false
@@ -475,7 +492,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_notifications_on_sub_service_request_id"
   end
 
-  create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "resource_owner_id", null: false
     t.bigint "application_id", null: false
     t.string "token", null: false
@@ -489,7 +506,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "oauth_access_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "application_id"
     t.bigint "access_token_id"
     t.string "ip_address", null: false
@@ -501,7 +518,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["application_id"], name: "index_oauth_access_requests_on_application_id"
   end
 
-  create_table "oauth_access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "oauth_access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "resource_owner_id"
     t.bigint "application_id", null: false
     t.string "token", null: false
@@ -517,7 +534,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table "oauth_applications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "oauth_applications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.string "uid", null: false
@@ -530,7 +547,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "oncore_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "oncore_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "protocol_id"
     t.integer "calendar_version"
     t.string "status"
@@ -539,7 +556,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_oncore_records_on_protocol_id"
   end
 
-  create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "question_id"
     t.text "content", null: false
     t.datetime "created_at", null: false
@@ -547,7 +564,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["question_id"], name: "index_options_on_question_id"
   end
 
-  create_table "organizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "organizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type"
     t.string "name"
     t.integer "order"
@@ -567,7 +584,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["parent_id"], name: "index_organizations_on_parent_id"
   end
 
-  create_table "past_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "past_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "sub_service_request_id"
     t.string "status"
     t.datetime "date"
@@ -580,7 +597,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_past_statuses_on_sub_service_request_id"
   end
 
-  create_table "past_subsidies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "past_subsidies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "sub_service_request_id"
     t.integer "total_at_approval"
     t.bigint "approved_by"
@@ -592,7 +609,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_past_subsidies_on_sub_service_request_id"
   end
 
-  create_table "patient_registrars", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "patient_registrars", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.bigint "organization_id"
     t.datetime "created_at", null: false
@@ -601,14 +618,14 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_patient_registrars_on_organization_id"
   end
 
-  create_table "payment_uploads", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "payment_uploads", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "payment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["payment_id"], name: "index_payment_uploads_on_payment_id"
   end
 
-  create_table "payments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "payments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "sub_service_request_id"
     t.date "date_submitted"
     t.decimal "amount_invoiced", precision: 12, scale: 4
@@ -622,7 +639,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_payments_on_sub_service_request_id"
   end
 
-  create_table "permissible_values", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "permissible_values", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "value"
     t.string "concept_code"
@@ -636,7 +653,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.boolean "is_available"
   end
 
-  create_table "pricing_maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pricing_maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "service_id"
     t.string "unit_type"
     t.decimal "unit_factor", precision: 5, scale: 2
@@ -660,7 +677,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["service_id"], name: "index_pricing_maps_on_service_id"
   end
 
-  create_table "pricing_setups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pricing_setups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "organization_id"
     t.date "display_date"
     t.date "effective_date"
@@ -680,13 +697,13 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_pricing_setups_on_organization_id"
   end
 
-  create_table "professional_organizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "professional_organizations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "name"
     t.string "org_type"
     t.bigint "parent_id"
   end
 
-  create_table "project_roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "project_roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.bigint "identity_id"
     t.string "project_rights"
@@ -700,7 +717,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_project_roles_on_protocol_id"
   end
 
-  create_table "protocol_filters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "protocol_filters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.string "search_name"
     t.boolean "show_archived"
@@ -713,7 +730,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.string "with_owner"
   end
 
-  create_table "protocol_merges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "protocol_merges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "master_protocol_id"
     t.integer "merged_protocol_id"
     t.integer "identity_id"
@@ -721,7 +738,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "protocols", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "protocols", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type"
     t.bigint "next_ssr_id"
     t.string "short_title"
@@ -771,7 +788,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["next_ssr_id"], name: "index_protocols_on_next_ssr_id"
   end
 
-  create_table "question_responses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "question_responses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "question_id"
     t.bigint "response_id"
     t.text "content"
@@ -782,7 +799,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["response_id"], name: "index_question_responses_on_response_id"
   end
 
-  create_table "questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "section_id"
     t.boolean "is_dependent", null: false
     t.text "content", null: false
@@ -796,7 +813,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["section_id"], name: "index_questions_on_section_id"
   end
 
-  create_table "quick_questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "quick_questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "to"
     t.string "from"
     t.text "body"
@@ -804,7 +821,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "races", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_bin", force: :cascade do |t|
+  create_table "races", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin", force: :cascade do |t|
     t.bigint "identity_id"
     t.string "name", null: false
     t.string "other_text"
@@ -813,14 +830,14 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["identity_id"], name: "index_races_on_identity_id"
   end
 
-  create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "sub_service_request_id"
     t.string "report_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "research_types_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "research_types_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.boolean "human_subjects"
     t.boolean "vertebrate_animals"
@@ -832,7 +849,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_research_types_info_on_protocol_id"
   end
 
-  create_table "response_filters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "response_filters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.string "name"
     t.string "of_type"
@@ -845,7 +862,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "responses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "responses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "survey_id"
     t.bigint "identity_id"
     t.datetime "created_at", null: false
@@ -857,7 +874,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["survey_id"], name: "index_responses_on_survey_id"
   end
 
-  create_table "revenue_code_ranges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "revenue_code_ranges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "from"
     t.integer "to"
     t.float "percentage"
@@ -868,7 +885,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sections", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sections", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "survey_id"
     t.string "title"
     t.text "description"
@@ -877,7 +894,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["survey_id"], name: "index_sections_on_survey_id"
   end
 
-  create_table "service_providers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "service_providers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.bigint "organization_id"
     t.boolean "is_primary_contact"
@@ -889,7 +906,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_service_providers_on_organization_id"
   end
 
-  create_table "service_relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "service_relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "service_id"
     t.bigint "related_service_id"
     t.boolean "required"
@@ -900,7 +917,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["service_id"], name: "index_service_relations_on_service_id"
   end
 
-  create_table "service_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "service_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "status"
     t.datetime "submitted_at"
@@ -912,7 +929,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["status"], name: "index_service_requests_on_status"
   end
 
-  create_table "services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "abbreviation"
     t.integer "order"
@@ -938,7 +955,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_services_on_organization_id"
   end
 
-  create_table "sessions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sessions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
     t.datetime "created_at", null: false
@@ -947,7 +964,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "settings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.text "value"
     t.string "data_type"
@@ -962,7 +979,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["key"], name: "index_settings_on_key", unique: true
   end
 
-  create_table "short_interactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "short_interactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.string "name"
     t.string "email"
@@ -976,7 +993,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["identity_id"], name: "index_short_interactions_on_identity_id"
   end
 
-  create_table "study_phases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "study_phases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "order"
     t.string "phase"
     t.integer "version", default: 1
@@ -984,7 +1001,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "study_type_answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "study_type_answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.bigint "study_type_question_id"
     t.boolean "answer"
@@ -992,14 +1009,14 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "study_type_question_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "study_type_question_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "version"
     t.boolean "active", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "study_type_questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "study_type_questions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "order"
     t.text "question"
     t.string "friendly_id"
@@ -1008,7 +1025,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.bigint "study_type_question_group_id"
   end
 
-  create_table "study_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "study_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "name"
     t.datetime "created_at", null: false
@@ -1017,7 +1034,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_study_types_on_protocol_id"
   end
 
-  create_table "sub_service_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sub_service_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "service_request_id"
     t.bigint "organization_id"
     t.bigint "owner_id"
@@ -1047,7 +1064,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["status"], name: "index_sub_service_requests_on_status"
   end
 
-  create_table "submission_emails", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "submission_emails", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "organization_id"
     t.string "email"
     t.datetime "created_at", null: false
@@ -1056,7 +1073,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_submission_emails_on_organization_id"
   end
 
-  create_table "subsidies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "subsidies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
@@ -1070,7 +1087,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["sub_service_request_id"], name: "index_subsidies_on_sub_service_request_id"
   end
 
-  create_table "subsidy_maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "subsidy_maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "organization_id"
     t.decimal "max_dollar_cap", precision: 12, scale: 4, default: "0.0"
     t.decimal "max_percentage", precision: 5, scale: 2, default: "0.0"
@@ -1082,7 +1099,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_subsidy_maps_on_organization_id"
   end
 
-  create_table "super_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "super_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "identity_id"
     t.bigint "organization_id"
     t.datetime "created_at", null: false
@@ -1096,7 +1113,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["organization_id"], name: "index_super_users_on_organization_id"
   end
 
-  create_table "surveys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "surveys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
     t.string "access_code", null: false
@@ -1107,12 +1124,12 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type"
-    t.bigint "surveyable_id"
     t.string "surveyable_type"
+    t.bigint "surveyable_id"
     t.index ["surveyable_id", "surveyable_type"], name: "index_surveys_on_surveyable_id_and_surveyable_type"
   end
 
-  create_table "taggings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "taggings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "tag_id"
     t.bigint "taggable_id"
     t.string "taggable_type"
@@ -1125,13 +1142,13 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table "tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "service_request_id"
     t.bigint "identity_id"
     t.string "token"
@@ -1142,7 +1159,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["service_request_id"], name: "index_tokens_on_service_request_id"
   end
 
-  create_table "vertebrate_animals_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "vertebrate_animals_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "protocol_id"
     t.string "iacuc_number"
     t.string "name_of_iacuc"
@@ -1154,7 +1171,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["protocol_id"], name: "index_vertebrate_animals_info_on_protocol_id"
   end
 
-  create_table "visit_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "visit_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.bigint "arm_id"
     t.datetime "created_at", null: false
@@ -1166,7 +1183,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
     t.index ["arm_id"], name: "index_visit_groups_on_arm_id"
   end
 
-  create_table "visits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "visits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "quantity", default: 0
     t.string "billing"
     t.datetime "created_at", null: false
@@ -1183,6 +1200,7 @@ ActiveRecord::Schema.define(version: 2023_06_27_001331) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "additional_funding_sources", "protocols"
   add_foreign_key "editable_statuses", "organizations"
   add_foreign_key "external_organizations", "protocols"
   add_foreign_key "oauth_access_grants", "identities", column: "resource_owner_id"

--- a/spec/factories/additional_funding_sources.rb
+++ b/spec/factories/additional_funding_sources.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :additional_funding_source do
+    funding_source { "college" }
+    sponsor_name { "MyString" }
+    comments { "MyText" }
+    federal_grant_code { "MyString" }
+    federal_grant_serial_number { "MyString" }
+    federal_grant_title { "MyString" }
+    phs_sponsor { "MyString" }
+    non_phs_sponsor { "MyString" }
+    protocol_id { nil }
+  end
+end

--- a/spec/models/additional_funding_source_spec.rb
+++ b/spec/models/additional_funding_source_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AdditionalFundingSource, type: :model do
+  it { should belong_to(:protocol) }
+end

--- a/spec/models/external_organization_spec.rb
+++ b/spec/models/external_organization_spec.rb
@@ -14,6 +14,4 @@ RSpec.describe ExternalOrganization, type: :model do
     ExternalOrganization.create collaborating_org_name:'Other', collaborating_org_type:'Other'
     expect(ExternalOrganization.count).to eq 1
   end
-
-  it 
 end

--- a/spec/requests/additional_funding_sources_spec.rb
+++ b/spec/requests/additional_funding_sources_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "/additional_funding_sources", type: :request, js: true do
+
+  let!(:protocol) { create(:protocol_without_validations) }
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      # GET /additional_funding_sources/new?additional_funding_source[protocol_id]=64&format=js
+      get new_additional_funding_sources_url, params: { additional_funding_source: { protocol_id: protocol.id }, format: :js }, xhr: true
+      expect(response).to render_template(:new)
+    end
+  end
+end

--- a/spec/routing/additional_funding_sources_routing_spec.rb
+++ b/spec/routing/additional_funding_sources_routing_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe AdditionalFundingSourcesController, type: :routing do
+  describe "routing" do
+    it "routes to #new" do
+      expect(get: "/additional_funding_sources/new").to route_to("additional_funding_sources#new")
+    end
+
+    it "routes to #edit" do
+      expect(get: "/additional_funding_sources/edit?id=1").to route_to("additional_funding_sources#edit", id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/additional_funding_sources").to route_to("additional_funding_sources#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(put: "/additional_funding_sources?index=1").to route_to("additional_funding_sources#update", index: "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/additional_funding_sources?index=1").to route_to("additional_funding_sources#update", index: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/additional_funding_sources?index=1").to route_to("additional_funding_sources#destroy", index: "1")
+    end
+  end
+end

--- a/spec/views/additional_funding_sources/_additional_funding_source.html.haml_spec.rb
+++ b/spec/views/additional_funding_sources/_additional_funding_source.html.haml_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "additional_funding_sources/additional_funding_source", type: :view do
+  let!(:protocol) { create(:protocol_without_validations) }
+  let!(:additional_funding_source) { build(:additional_funding_source) }
+
+  it "renders hidden fields" do
+    render 'additional_funding_sources/additional_funding_source', additional_funding_source: additional_funding_source, index: 0
+
+    hidden_fields = %w[id funding_source sponsor_name comments federal_grant_code federal_grant_serial_number federal_grant_title phs_sponsor non_phs_sponsor protocol_id]
+
+    hidden_fields.each do |field|
+      expect(response).to have_selector("#protocol_additional_funding_sources_attributes_0_#{field}", visible: false)
+    end
+  end
+end


### PR DESCRIPTION
Currently projects and studies only have the ability to associate information about one funding award. For many studies there are multiple funding sources, either at one time or as the study continues and new funding is obtained. This pr adds a resource to house information about previous or additional funding associated with a project.

https://www.pivotaltracker.com/story/show/170740848