### PR TITLE
Epic study type questions not consistently displaying

### DIFF
--- a/app/assets/javascripts/protocol_form.js.coffee
+++ b/app/assets/javascripts/protocol_form.js.coffee
@@ -157,26 +157,61 @@ $(document).ready ->
 
   if $("#protocol_selected_for_epic_false").is(":checked")
     $('#studyTypeNote').hide()
-
-  $("#protocol_selected_for_epic_false").on "click", ->
-    $('#studyTypeNote').hide()
-    # Hide study_type_questions container unless human_subjects is checked
-    if !$('#protocol_research_types_info_attributes_human_subjects').prop('checked')
-      $('#studyTypeQuestionsContainer').addClass('d-none')
+    if $(humanSubjects).prop('checked')
+      $('#studyTypeQuestionsContainer').removeClass('d-none')
+      justShowSTQ($(certificateOfConfidenceNoEpic))
+      if $(certificateOfConfidenceNoEpic).val() == 'true'
+        justHideSTQ($(higherLevelOfPrivacyNoEpic))
+      else
+        justShowSTQ($(higherLevelOfPrivacyNoEpic))
+        justShowSTQ($(higherLevelOfPrivacyNoEpic))
 
   $(document).on 'change', '[name="protocol[selected_for_epic]"]', ->
     $('[for=protocol_selected_for_epic]').addClass('required')
-
     if $(this).val() == 'true'
       $('label[for=protocol_study_type_questions]').addClass('required')
       if $('#studyTypeQuestionsContainer').hasClass('d-none')
         $('#studyTypeQuestionsContainer').removeClass('d-none')
       setRequiredFields()
-      hideStudyTypeQuestion($(certificateOfConfidenceNoEpic))
-      showStudyTypeQuestion($(certificateOfConfidence))
+      for el in noEpic
+        justHideSTQ($(el))
+      justShowSTQ($(certificateOfConfidence))
+      if $(certificateOfConfidence).val() == 'true'
+        for el in epicQuestions2through5
+          justHideSTQ($(el))
+      else
+        for el in epicQuestions2through5
+          justShowSTQ($(el))
     else
-      hideStudyTypeQuestion($(certificateOfConfidence))
-      showStudyTypeQuestion($(certificateOfConfidenceNoEpic))
+      for el in epic
+        justHideSTQ($(el))
+      if $('#protocol_research_types_info_attributes_human_subjects').prop('checked')
+        if $('#studyTypeQuestionsContainer').hasClass('d-none')
+          $('#studyTypeQuestionsContainer').removeClass('d-none')
+        justShowSTQ($(certificateOfConfidenceNoEpic))
+        if $(certificateOfConfidenceNoEpic).val() == 'true'
+          justHideSTQ($(higherLevelOfPrivacyNoEpic))
+        else
+          justShowSTQ($(higherLevelOfPrivacyNoEpic))
+      else
+        $('#studyTypeQuestionsContainer').addClass('d-none')
+        $('#studyTypeNote').hide()
+
+  $(humanSubjects).on "click", ->
+    if $(this).prop('checked')
+      if $('#protocol_selected_for_epic_false').prop('checked')
+        $('#studyTypeQuestionsContainer').removeClass('d-none')
+        $('#studyTypeNote').hide()
+        justShowSTQ($(certificateOfConfidenceNoEpic))
+        justHideSTQs($(epic))
+        if $(certificateOfConfidenceNoEpic).val() == 'true'
+          justHideSTQ($(higherLevelOfPrivacyNoEpic))
+        else
+          justShowSTQ($(higherLevelOfPrivacyNoEpic))
+    else
+      if $('#protocol_selected_for_epic_false').prop('checked')
+        $('#studyTypeQuestionsContainer').addClass('d-none')
+        $('#studyTypeNote').hide()
 
   $(document).on 'change', certificateOfConfidence, (e) ->
     if $(this).val() == 'true'
@@ -340,15 +375,40 @@ researchActive                = '#study_type_answer_research_active_answer'
 restrictSending               = '#study_type_answer_restrict_sending_answer'
 
 certificateOfConfidenceNoEpic = '#study_type_answer_certificate_of_conf_no_epic_answer'
+
 higherLevelOfPrivacyNoEpic    = '#study_type_answer_higher_level_of_privacy_no_epic_answer'
 
+humanSubjects                 = "#protocol_research_types_info_attributes_human_subjects"
+
+epicQuestions2through5 = [
+  higherLevelOfPrivacy, epicInBasket, researchActive, restrictSending
+  ]
+
+noEpic = [
+  certificateOfConfidenceNoEpic,
+  higherLevelOfPrivacyNoEpic
+]
+
+epic = [
+  certificateOfConfidence,
+  higherLevelOfPrivacy,
+  epicInBasket,
+  researchActive,
+  restrictSending
+]
 hideStudyTypeQuestion = ($select) ->
   $select.selectpicker('val', '')
   $select.trigger('change')
   $select.closest('.form-row').addClass('d-none')
 
+justHideSTQ = ($select) ->
+  $select.closest('.form-row').addClass('d-none')
+
 showStudyTypeQuestion = ($select) ->
   $select.trigger('change')
+  $select.closest('.form-row').removeClass('d-none')
+
+justShowSTQ = ($select) ->
   $select.closest('.form-row').removeClass('d-none')
 
 determineStudyType = () ->

--- a/spec/features/dashboard/protocols/edit/user_edits_confidentiality_epic_questions.rb
+++ b/spec/features/dashboard/protocols/edit/user_edits_confidentiality_epic_questions.rb
@@ -1,3 +1,23 @@
+# Copyright © 2011-2023 MUSC Foundation for Research Development
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 require 'rails_helper'
 
 RSpec.describe 'User wants to edit a Protocol', js: true do

--- a/spec/features/dashboard/protocols/edit/user_edits_confidentiality_epic_questions.rb
+++ b/spec/features/dashboard/protocols/edit/user_edits_confidentiality_epic_questions.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'User wants to edit a Protocol', js: true do
+  let_there_be_lane
+  fake_login_for_each_test
+  build_study_type_question_groups
+  build_study_type_questions
+
+  before :each do
+    @protocol = create(:study_federally_funded, primary_pi: jug2)
+
+    visit dashboard_protocol_path(@protocol)
+    wait_for_javascript_to_finish
+    click_link I18n.t('protocols.edit', protocol_type: @protocol.model_name.human)
+    wait_for_javascript_to_finish
+  end
+
+  describe "When 'use epic' is no but 'human subjects' is checked" do
+    before do
+      find(:xpath, "//label[contains(text(),'Human Subjects')]").click
+      wait_for_javascript_to_finish
+    end
+
+    it "displays the 'Confidentiality and Epic Questions' container" do
+      expect(page).to have_selector('#studyTypeQuestionsContainer:not(.d-none)')
+    end
+
+    it "displays the first 'no epic' Study Type Question" do
+      expect(page).not_to have_selector('#study_type_answer_certificate_of_conf_no_epic_answer .form-row.d-none')
+    end
+
+    it "displays the second 'no epic' Study Type Question when the first question has no selected" do
+      expect(page).not_to have_selector('#study_type_answer_higher_level_of_privacy_no_epic_answer .form-row.d-none')
+    end
+  end
+
+  describe "When 'use epic' is yes" do
+    before do
+      @protocol.update_attribute(:selected_for_epic, true)
+      visit dashboard_protocol_path(@protocol)
+      wait_for_javascript_to_finish
+      click_link I18n.t('protocols.edit', protocol_type: @protocol.model_name.human)
+      wait_for_javascript_to_finish
+    end
+
+    it "displays the 'Confidentiality and Epic Questions' container" do
+      expect(page).to have_selector('#studyTypeQuestionsContainer:not(.d-none)')
+    end
+
+    it "displays the first 'epic' Study Type Question" do
+      expect(page).not_to have_selector('#study_type_answer_certificate_of_conf_answer .form-row.d-none')
+    end
+
+    it "displays the second 'epic' Study Type Question when the first question has no selected" do
+      expect(page).not_to have_selector('#study_type_answer_higher_level_of_privacy_answer .form-row.d-none')
+    end
+  end
+end


### PR DESCRIPTION
- [x] Already saved responses should be kept and displayed when returning for page edits, even after toggling between the Y/N Epic question

https://www.pivotaltracker.com/story/show/186276340