### PR TITLE
JV - Ability to Edit User Login in SPARC Admin and Toggle Off/On

### DIFF
--- a/app/controllers/admin/identities_controller.rb
+++ b/app/controllers/admin/identities_controller.rb
@@ -69,6 +69,7 @@ class Admin::IdentitiesController < Admin::ApplicationController
       :orcid,
       :credentials,
       :credentials_other,
+      :ldap_uid,
       :email,
       :era_commons_name,
       :professional_organization_id,

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -126,7 +126,7 @@ class Identity < ApplicationRecord
     return if term.blank?
 
     identity_arel = Identity.arel_table
-    attrs = [:last_name, :first_name, :email, :institution]
+    attrs = [:last_name, :first_name, :ldap_uid, :email, :institution]
 
     where (attrs
       .map { |attr| identity_arel[attr].matches("%#{term}%")}

--- a/app/views/admin/identities/_form.html.haml
+++ b/app/views/admin/identities/_form.html.haml
@@ -21,6 +21,7 @@
 
 - first_name_disabled = Setting.get_value("noneditable_identity_fields").include?("first_name")
 - last_name_disabled = Setting.get_value("noneditable_identity_fields").include?("last_name")
+- ldap_uid_disabled = Setting.get_value("noneditable_identity_fields").include?("ldap_uid")
 - email_disabled = Setting.get_value("noneditable_identity_fields").include?("email")
 - display_age = Setting.get_value("displayed_demographics_fields").include?("age_group")
 - display_gender = Setting.get_value("displayed_demographics_fields").include?("gender")
@@ -49,11 +50,18 @@
             = f.text_field :last_name, class: 'form-control', disabled: last_name_disabled
         .form-row
           .form-group.col-12.col-xl-6
+            = f.label :ldap_uid, class: 'required'
+            .input-group
+              .input-group-prepend
+                = f.label :ldap_uid, icon('fas', 'user'), class: 'input-group-text'
+              = f.email_field :ldap_uid, class: 'form-control', disabled: ldap_uid_disabled
+          .form-group.col-12.col-xl-6
             = f.label :email, class: 'required'
             .input-group
               .input-group-prepend
                 = f.label :email, icon('far', 'envelope'), class: 'input-group-text'
               = f.email_field :email, class: 'form-control', disabled: email_disabled
+        .form-row
           .form-group.col-12.col-xl-6
             = f.label :phone
             .input-group

--- a/app/views/admin/identities/_table.html.haml
+++ b/app/views/admin/identities/_table.html.haml
@@ -30,6 +30,8 @@
           = Identity.human_attribute_name(:name)
         %th{ data: { field: 'institution', sortable: 'true' } }
           = Identity.human_attribute_name(:institution)
+        %th{ data: { field: 'ldap_uid' } }
+          = Identity.human_attribute_name(:ldap_uid)
         %th{ data: { field: 'email' } }
           = Identity.human_attribute_name(:email)
         %th.w-10{ data: { field: 'created_at', align: 'center', sortable: 'true', sorter: 'dateSorter' } }

--- a/app/views/admin/identities/index.json.jbuilder
+++ b/app/views/admin/identities/index.json.jbuilder
@@ -2,6 +2,7 @@ json.total @total
 json.rows(@identities) do |identity|
   json.name            display_name(identity)
   json.institution     identity.institution
+  json.ldap_uid        identity.ldap_uid
   json.email           identity.email
   json.created_at      format_date(identity.created_at)
   json.last_sign_in_at format_date(identity.current_sign_in_at)

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -621,7 +621,7 @@
   },
   {
     "key":            "noneditable_identity_fields",
-    "value":          "[\"last_name\", \"first_name\", \"email\"]",
+    "value":          "[\"last_name\", \"first_name\", \"ldap_uid\", \"email\"]",
     "friendly_name":  "noneditable user profile fields",
     "description":    "Determines which identity fields are read-only on the edit profile page, currently only email, first_name, and last_name are configurable.",
     "group":          "",


### PR DESCRIPTION
Admin users are now able to edit user logins directly from the Users table within SPARC Admin, but only if they remove "ldap_uid" from the "noneditable_identity_fields" setting array in SPARC Admin. Default behavior is to include "ldap_uid" in that array to prevent any unintentional login edits.

https://www.pivotaltracker.com/story/show/185386654

[#185386654]