### PR TITLE
fix remove service bug

### DIFF
--- a/app/lib/remove_service.rb
+++ b/app/lib/remove_service.rb
@@ -52,8 +52,10 @@ class RemoveService
 
       @ssr.update_attribute(:status, 'draft') unless ['first_draft', 'draft'].include?(@ssr.status)
       if @ssr.line_items.empty?
-        @ssr.current_user_id = @current_user.id
-        NotifierLogic.new(@service_request, @current_user).ssr_deletion_emails(deleted_ssr: @ssr, ssr_destroyed: true, request_amendment: false, admin_delete_ssr: false)
+        if @current_user
+          @ssr.current_user_id = @current_user.id
+          NotifierLogic.new(@service_request, @current_user).ssr_deletion_emails(deleted_ssr: @ssr, ssr_destroyed: true, request_amendment: false, admin_delete_ssr: false)
+        end
         @ssr.destroy
       end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1918597/stories/188932141

The following exception occurs when a non-logged in user add a service then remove it from the shopping cart. 

Exception service_requests#remove_service (NoMethodError) "undefined method `id' for nil"

A NoMethodError occurred in service_requests#remove_service: 
undefined method id' for nil app/lib/remove_service.rb:55:inremove_service'

 