### PR TITLE
JV - Removing .msg file extension from source code syntax (SPOSDEV-1178)

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -23,7 +23,7 @@ class Document < ApplicationRecord
   audited
 
   SUPPORTED_FILE_TYPES = [
-    /\.pdf$/i, /\.docx?$/i, /\.xlsx?$/i, /\.pptx?$/i, /\.txt$/i, /\.csv$/i, /\.msg$/i, /\.eml$/i, /\.jpg$/i, /\.jpeg$/i, /\.gif$/i, /\.png$/i, /\.tiff$/i 
+    /\.pdf$/i, /\.docx?$/i, /\.xlsx?$/i, /\.pptx?$/i, /\.txt$/i, /\.csv$/i, /\.eml$/i, /\.jpg$/i, /\.jpeg$/i, /\.gif$/i, /\.png$/i, /\.tiff$/i 
   ]
 
   belongs_to :protocol
@@ -63,7 +63,7 @@ class Document < ApplicationRecord
   def supported_file_types
     return unless document.attached?
 
-    supported_types = %w(application/pdf application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.openxmlformats-officedocument.presentationml.presentation text/plain text/csv application/vnd.ms-outlook message/rfc822 image/jpeg image/gif image/png image/tiff)
+    supported_types = %w(application/pdf application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.openxmlformats-officedocument.presentationml.presentation text/plain text/csv message/rfc822 image/jpeg image/gif image/png image/tiff)
     unless supported_types.include?(document.content_type)
       errors.add(:document, 'file type is not supported.')
     end


### PR DESCRIPTION
Removed uncooperative .msg file extension (not being parsed correctly by browsers), as .eml is default for MacOS users and allowed by New Outlook for Windows.