### PR TITLE
SPFUL-614 Report of Push to Fulfillment SPARC Study Errors

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -363,7 +363,7 @@ class Protocol < ApplicationRecord
     end
     if self.end_date.blank?
       self.errors.add(:end_date, :blank)
-      invalid = false
+      is_valid = false
     end
     if self.start_date && self.end_date && self.start_date > self.end_date
       self.errors.add(:start_date, :invalid)

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -80,12 +80,6 @@ class ServiceRequest < ApplicationRecord
       # Run protocol validations
       self.protocol.valid?
 
-      # Check for RMID presence for auditing
-      # self.protocol.define_singleton_method(:rmid_requires_validation?) { true }
-
-      # Validate start/end dates and recruitment dates
-      # self.protocol.validate_dates
-
       # Extract and add protocol model errors to the service_requests base errors
       extract_errors(self.protocol.errors).each do |msg|
         self.errors.add(:base, msg)

--- a/app/models/service_request.rb
+++ b/app/models/service_request.rb
@@ -49,6 +49,8 @@ class ServiceRequest < ApplicationRecord
 
   alias_attribute :service_request_id, :id
 
+  validates_associated :protocol
+
   #after_save :fix_missing_visits
 
   def catalog_valid?
@@ -56,11 +58,41 @@ class ServiceRequest < ApplicationRecord
     self.errors.none?
   end
 
-  def protocol_valid?
-    self.errors.add(:protocol, :blank) if self.protocol_id.blank?
-    self.errors.add(:protocol, :invalid) if self.protocol && !self.protocol.valid?
-    self.errors.add(:protocol, :invalid) if self.protocol && !self.protocol.validate_dates
-    self.errors.none?
+  def extract_errors(errors)
+    errors.details.flat_map do |attr, details_array|
+      details_array.map do |detail|
+        begin
+          errors.full_message(attr, detail[:error]) ||
+          "#{attr.to_s.humanize} #{detail[:error].to_s.humanize.downcase}"
+        rescue
+          "#{attr.to_s.humanize} #{detail[:error].to_s.humanize.downcase}"
+        end
+      end
+    end
+  end
+
+  def protocol_valid?(return_errors: false)
+    if self.protocol_id.blank?
+      self.errors.add(:protocol, "must be present")
+    end
+
+    if self.protocol
+      # Run protocol validations
+      self.protocol.valid?
+
+      # Check for RMID presence for auditing
+      # self.protocol.define_singleton_method(:rmid_requires_validation?) { true }
+
+      # Validate start/end dates and recruitment dates
+      # self.protocol.validate_dates
+
+      # Extract and add protocol model errors to the service_requests base errors
+      extract_errors(self.protocol.errors).each do |msg|
+        self.errors.add(:base, msg)
+      end
+    end
+
+    return_errors ? self.errors.messages : self.errors.none?
   end
 
   def service_details_valid?

--- a/lib/tasks/audit_push_to_fulfillment.rake
+++ b/lib/tasks/audit_push_to_fulfillment.rake
@@ -10,7 +10,7 @@ namespace :audit do
     puts "File exists? #{File.exist?(input_file)}"
 
     headers = [
-      "Display ID", "Protocol ID", "SSR ID", "Organization", "Status", "Can Push?", "Blocking Reasons"
+      "SPARC ID", "Organization", "Requested Services", "Status", "Status Date", "Can Push to CWF?", "Blocking Reasons", "Addl Protocol Message"
     ]
 
     ssr_keys = []
@@ -33,42 +33,46 @@ namespace :audit do
         formatted_ssr_id = "%04d" % ssr_id.to_i
         display_id       = "#{protocol_id}-#{formatted_ssr_id}"
         blocking_errors  = []
+        epic_questions_answered = ""
 
         ssr = SubServiceRequest.includes(
                 :organization,
-                :line_items,
+                { :line_items => :service },
                 :line_items_visits,
+                :past_statuses,
                 service_request: [:protocol, arms: :visit_groups]
               ).find_by(ssr_id: formatted_ssr_id, protocol_id: protocol_id)
 
         unless ssr
-          csv << [display_id, protocol_id, formatted_ssr_id, nil, nil, "No", "SSR not found"]
+          csv << [display_id, nil, nil, nil, nil, "No", "SSR not found", epic_questions_answered]
           next
         end
 
         sr       = ssr.service_request
         protocol = sr.protocol
+        requested_services = ssr.line_items.map { |li| li.service.name }.uniq.join("; ")
+        status_date = ssr.past_statuses
+                      .order(date: :desc)
+                      .last
+                      &.date
+                      &.strftime("%m/%d/%Y")
 
         # Check if Protocol exists
         if protocol.nil?
           csv << [
             ssr.display_id,
-            nil,
-            ssr.ssr_id,
+            requested_services,
+            status_date,
             ssr.organization&.name,
             ssr.status,
             "No",
-            "Protocol is missing"
+            "Protocol is missing",
+            epic_questions_answered
           ]
           next
         end
 
-        # Check if Protocol is valid
-        protocol.bypass_rmid_validation = true
-        sr.protocol_valid?
-        blocking_errors += sr.errors.full_messages
-
-        # Check if RMID present when required
+        # Check if RMID is present when required
         rmid_required = !protocol.bypass_rmid_validation &&
                         Setting.get_value('research_master_enabled') &&
                         protocol.has_human_subject_info? &&
@@ -83,9 +87,30 @@ namespace :audit do
           blocking_errors << "Research Master ID is required but missing"
         end
 
-        # Check if dates are valid
+        # Check if Epic study type questions are answered (not a push blocker, but useful to track)
+        if protocol.is_a?(Study) && protocol.selected_for_epic
+          epic_questions_answered = protocol.study_type_answers.any? { |a| a.answer.nil? } ? "Epic questions not answered" : ""
+        end
+
+        # Check if dates are valid. The errors this kicked back were not very legible to read if there were multiple errors
+        # This was done to not have to touch the yml files
         protocol.validate_dates
-        date_errors = protocol.errors.full_messages
+        date_errors = protocol.errors.map(&:full_message).map do |msg|
+          case msg
+          when /recruitment_start_date|Estimate Recruitment Start Date/i
+            "Recruitment Start Date must come before Recruitment End Date"
+          when /recruitment_end_date|Estimated Recruitment End Date/i
+            "Recruitment End Date must come after Recruitment Start Date"
+          when /start_date/i
+            "Start Date can't be blank"
+          when /end_date/i
+            "End Date can't be blank"
+          else
+            msg
+          end
+        end.uniq
+
+        puts "DEBUG #{date_errors.inspect}"
 
         # Manually check end_date since the model has a typo, just in case
         if protocol.end_date.blank? && date_errors.none? { |e| e.downcase.include?("end date") }
@@ -94,9 +119,25 @@ namespace :audit do
 
         blocking_errors += date_errors
 
+        # Check if Protocol is valid
+        protocol.bypass_rmid_validation = true
+        sr.protocol_valid?
+        blocking_errors += sr.errors.map(&:full_message)
+
         # Check if service details are valid (visit groups and arms)
         sr.service_details_valid?
-        blocking_errors += sr.errors.full_messages
+        if sr.errors.any?
+          protocol.arms.each do |arm|
+            arm.visit_groups.each do |vg|
+              if vg.day.blank?
+                blocking_errors << "'#{arm.name}' - '#{vg.name}' is missing a calendar day."
+              elsif vg.invalid?
+                blocking_errors << "'#{arm.name}' - '#{vg.name}' has validation errors: #{vg.errors.map(&:full_message).join(', ')}"
+              end
+            end
+          end
+          blocking_errors += sr.errors.map(&:full_message).reject { |e| e.downcase.include?("arms")}
+        end
 
         blocking_errors = blocking_errors.uniq
 
@@ -104,12 +145,13 @@ namespace :audit do
 
         csv << [
           ssr.display_id,
-          protocol.id,
-          ssr.ssr_id,
           ssr.organization&.name,
+          requested_services,
           ssr.status,
+          status_date,
           blocking_errors.empty? ? "Yes" : "No",
-          blocking_errors.join("; ")
+          blocking_errors.join("; "),
+          epic_questions_answered
         ]
       end
     end

--- a/lib/tasks/audit_push_to_fulfillment.rake
+++ b/lib/tasks/audit_push_to_fulfillment.rake
@@ -3,20 +3,18 @@ namespace :audit do
   task check_fulfillment_blockers: :environment do
     require 'csv'
 
-    input_file = Rails.root.join('tmp', 'service_requests_input.csv')
+    input_file  = Rails.root.join('tmp', 'service_requests_input.csv')
     output_file = Rails.root.join('tmp', 'service_requests_errors.csv')
 
     puts "Looking for input file at: #{input_file}"
     puts "File exists? #{File.exist?(input_file)}"
 
     headers = [
-      "Display ID", "Protocol ID", "SSR ID", "Organization", "Status",
-      "Can Push?", "Blocking Reasons"
+      "Display ID", "Protocol ID", "SSR ID", "Organization", "Status", "Can Push?", "Blocking Reasons"
     ]
 
     ssr_keys = []
 
-    # Parse input CSV and extract protocol/SSR ID pairs from csv
     CSV.foreach(input_file, headers: true, col_sep: ',', liberal_parsing: true) do |row|
       display_id = row["Protocol ID (SRID)"]&.strip
 
@@ -28,36 +26,85 @@ namespace :audit do
       end
     end
 
-    puts "Found #{ssr_keys.size} SubService Requests"
+    puts "Found #{ssr_keys.size} SubServiceRequests to check"
 
     CSV.open(output_file, "w", write_headers: true, headers: headers) do |csv|
       ssr_keys.each do |protocol_id, ssr_id|
-        ssr = SubServiceRequest.includes(:protocol, :organization, :line_items, :line_items_visits, service_request: [:protocol, :arms])
-                               .find_by(ssr_id: "%04d" % ssr_id.to_i, protocol_id: protocol_id)
+        formatted_ssr_id = "%04d" % ssr_id.to_i
+        display_id       = "#{protocol_id}-#{formatted_ssr_id}"
+        blocking_errors  = []
+
+        ssr = SubServiceRequest.includes(
+                :organization,
+                :line_items,
+                :line_items_visits,
+                service_request: [:protocol, arms: :visit_groups]
+              ).find_by(ssr_id: formatted_ssr_id, protocol_id: protocol_id)
 
         unless ssr
-          csv << ["#{protocol_id}-#{ssr_id}", protocol_id, ssr_id, nil, nil, "No", "SSR not found"]
+          csv << [display_id, protocol_id, formatted_ssr_id, nil, nil, "No", "SSR not found"]
           next
         end
 
-        sr = ssr.service_request
+        sr       = ssr.service_request
+        protocol = sr.protocol
 
-        # Reset errors
-        sr.errors.clear
-        sr.protocol&.errors&.clear
+        # Check if Protocol exists
+        if protocol.nil?
+          csv << [
+            ssr.display_id,
+            nil,
+            ssr.ssr_id,
+            ssr.organization&.name,
+            ssr.status,
+            "No",
+            "Protocol is missing"
+          ]
+          next
+        end
 
-        # Run validations that add to sr.errors
-        sr.protocol_valid?(return_errors: true)
+        # Check if Protocol is valid
+        protocol.bypass_rmid_validation = true
+        sr.protocol_valid?
+        blocking_errors += sr.errors.full_messages
+
+        # Check if RMID present when required
+        rmid_required = !protocol.bypass_rmid_validation &&
+                        Setting.get_value('research_master_enabled') &&
+                        protocol.has_human_subject_info? &&
+                        protocol.is_a?(Study)
+
+        # Check again with RMID bypass off
+        rmid_required = Setting.get_value('research_master_enabled') &&
+                        protocol.has_human_subject_info? &&
+                        protocol.is_a?(Study)
+
+        if rmid_required && protocol.research_master_id.blank?
+          blocking_errors << "Research Master ID is required but missing"
+        end
+
+        # Check if dates are valid
+        protocol.validate_dates
+        date_errors = protocol.errors.full_messages
+
+        # Manually check end_date since the model has a typo, just in case
+        if protocol.end_date.blank? && date_errors.none? { |e| e.downcase.include?("end date") }
+          date_errors << "End date can't be blank"
+        end
+
+        blocking_errors += date_errors
+
+        # Check if service details are valid (visit groups and arms)
         sr.service_details_valid?
-        sr.protocol.validate_dates
+        blocking_errors += sr.errors.full_messages
 
-        # Collect unique errors
-        blocking_errors = (sr.errors.full_messages.uniq + Array(sr.errors[:base])).uniq
-        puts "DEBUG: blocking_errors = #{blocking_errors.inspect}"
+        blocking_errors = blocking_errors.uniq
+
+        puts "DEBUG #{ssr.display_id}: blocking_errors = #{blocking_errors.inspect}"
 
         csv << [
           ssr.display_id,
-          sr.protocol&.id,
+          protocol.id,
           ssr.ssr_id,
           ssr.organization&.name,
           ssr.status,
@@ -67,6 +114,6 @@ namespace :audit do
       end
     end
 
-    puts "Done! Results written to #{output_file}"
+    puts "Rake task completed. Results written to #{output_file}"
   end
 end

--- a/lib/tasks/audit_push_to_fulfillment.rake
+++ b/lib/tasks/audit_push_to_fulfillment.rake
@@ -1,0 +1,72 @@
+namespace :audit do
+  desc "Check selected SSRs from CSV for Fulfillment push blockers"
+  task check_fulfillment_blockers: :environment do
+    require 'csv'
+
+    input_file = Rails.root.join('tmp', 'service_requests_input.csv')
+    output_file = Rails.root.join('tmp', 'service_requests_errors.csv')
+
+    puts "Looking for input file at: #{input_file}"
+    puts "File exists? #{File.exist?(input_file)}"
+
+    headers = [
+      "Display ID", "Protocol ID", "SSR ID", "Organization", "Status",
+      "Can Push?", "Blocking Reasons"
+    ]
+
+    ssr_keys = []
+
+    # Parse input CSV and extract protocol/SSR ID pairs from csv
+    CSV.foreach(input_file, headers: true, col_sep: ',', liberal_parsing: true) do |row|
+      display_id = row["Protocol ID (SRID)"]&.strip
+
+      if display_id.present? && display_id.match?(/^\d+-\d+$/)
+        protocol_id, ssr_id = display_id.split("-")
+        ssr_keys << [protocol_id.to_i, ssr_id]
+      else
+        puts "Cannot read SSR ID on row: #{row.inspect}."
+      end
+    end
+
+    puts "Found #{ssr_keys.size} SubService Requests"
+
+    CSV.open(output_file, "w", write_headers: true, headers: headers) do |csv|
+      ssr_keys.each do |protocol_id, ssr_id|
+        ssr = SubServiceRequest.includes(:protocol, :organization, :line_items, :line_items_visits, service_request: [:protocol, :arms])
+                               .find_by(ssr_id: "%04d" % ssr_id.to_i, protocol_id: protocol_id)
+
+        unless ssr
+          csv << ["#{protocol_id}-#{ssr_id}", protocol_id, ssr_id, nil, nil, "No", "SSR not found"]
+          next
+        end
+
+        sr = ssr.service_request
+
+        # Reset errors
+        sr.errors.clear
+        sr.protocol&.errors&.clear
+
+        # Run validations that add to sr.errors
+        sr.protocol_valid?(return_errors: true)
+        sr.service_details_valid?
+        sr.protocol.validate_dates
+
+        # Collect unique errors
+        blocking_errors = (sr.errors.full_messages.uniq + Array(sr.errors[:base])).uniq
+        puts "DEBUG: blocking_errors = #{blocking_errors.inspect}"
+
+        csv << [
+          ssr.display_id,
+          sr.protocol&.id,
+          ssr.ssr_id,
+          ssr.organization&.name,
+          ssr.status,
+          blocking_errors.empty? ? "Yes" : "No",
+          blocking_errors.join("; ")
+        ]
+      end
+    end
+
+    puts "Done! Results written to #{output_file}"
+  end
+end


### PR DESCRIPTION
Adds a rake task, audit:check_fulfillment_blockers, that reads a csv list of SubServiceRequest IDs, checks each one for push to fulfillment blockers, and writes the results to an output csv. Input file expects a Protocol ID column in xxxx+-xxxx format. Output file writes to tmp/service_requests_errors.csv.

Checks for the following on each SSR:

SSR exists in the database
Associated Protocol exists and is valid
Research Master ID is present when required
Protocol dates are valid, including start and end dates and that end_dates !< start_dates, and vice versa.
Arms and Visit groups are valid