### PR TITLE
If Epic user interface is disable via validate_epic_users setting, do…

### DIFF
--- a/app/controllers/dashboard/epic_queues_controller.rb
+++ b/app/controllers/dashboard/epic_queues_controller.rb
@@ -60,13 +60,8 @@ class Dashboard::EpicQueuesController < Dashboard::BaseController
   end
 
   def ensure_epic_connection
-    @epic_connection = nil
-
-    if EpicUser.confirm_connection
-      @epic_connection = true 
-    else
-      @epic_connection = false 
-    end
+    @epic_connection = true #assume true unless we test the connection
+    @epic_connection = EpicUser.confirm_connection if Setting.get_value("validate_epic_users")
   end
 
   def get_epic_queue

--- a/app/models/epic_user.rb
+++ b/app/models/epic_user.rb
@@ -32,6 +32,7 @@ class EpicUser < ActiveResource::Base
     begin
       # test if we can query the ActiveResource, unless successful we should get a message the the interface is down
       get(:viewuser, userid: 'dummy_account')
+      return true
     rescue => e
       slack_epic_error_webhook = Setting.get_value("epic_user_api_error_slack_webhook")
       teams_epic_error_webhook = Setting.get_value("epic_user_api_error_teams_webhook")


### PR DESCRIPTION
…n't show messages and don't send Teams/Slack message